### PR TITLE
Support HANDLER - #9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ coverage:
 docs:
 	rm -f docs/django-mysql.rst
 	rm -f docs/modules.rst
-	sphinx-apidoc -o docs/ django-mysql
+	# DJANGO_SETTINGS_MODULE=django.conf.global_settings sphinx-apidoc -o docs/ django_mysql
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 	open docs/_build/html/index.html

--- a/django_mysql/models/base.py
+++ b/django_mysql/models/base.py
@@ -1,20 +1,11 @@
 # -*- coding:utf-8 -*-
 from django.db import models
 
-from django_mysql.models.handler import Handler
 from django_mysql.models.query import QuerySet
-
-
-_BaseManager = models.Manager.from_queryset(QuerySet)
-
-
-class Manager(_BaseManager):
-    def handler(self):
-        return Handler(self)
 
 
 class Model(models.Model):
     class Meta(object):
         abstract = True
 
-    objects = Manager()
+    objects = QuerySet.as_manager()

--- a/django_mysql/models/base.py
+++ b/django_mysql/models/base.py
@@ -1,11 +1,20 @@
 # -*- coding:utf-8 -*-
 from django.db import models
 
+from django_mysql.models.handler import Handler
 from django_mysql.models.query import QuerySet
+
+
+_BaseManager = models.Manager.from_queryset(QuerySet)
+
+
+class Manager(_BaseManager):
+    def handler(self):
+        return Handler(self)
 
 
 class Model(models.Model):
     class Meta(object):
         abstract = True
 
-    objects = QuerySet.as_manager()
+    objects = Manager()

--- a/django_mysql/models/handler.py
+++ b/django_mysql/models/handler.py
@@ -160,11 +160,11 @@ class Handler(object):
         'gt': '>',
     }
 
-    def iter(self, index='PRIMARY', where=None, chunk_size=100, forwards=True):
-        if forwards:
-            mode = 'first'
-        else:
+    def iter(self, index='PRIMARY', where=None, chunk_size=100, reverse=False):
+        if reverse:
             mode = 'last'
+        else:
+            mode = 'first'
 
         if where is not None:
             # Pre-convert so each iteration doesn't have to repeatedly parse
@@ -181,10 +181,10 @@ class Handler(object):
             if count < chunk_size:
                 return
 
-            if forwards:
-                mode = 'next'
-            else:
+            if reverse:
                 mode = 'prev'
+            else:
+                mode = 'next'
 
     # Internal methods
 

--- a/django_mysql/models/handler.py
+++ b/django_mysql/models/handler.py
@@ -1,33 +1,54 @@
 from random import randint
+import re
 
 from django.db import connections
 
 
 class Handler(object):
-    def __init__(self, manager):
-        self.manager = manager
+    absolute_col_re = re.compile("`[^`]+`.(`[^`]+`)")
+
+    def __init__(self, queryset):
+        self._queryset = queryset
+        self._model = queryset.model
+        self._table_name = self._model._meta.db_table
+        self._handler_name = '{}_{}'.format(self._table_name, randint(1, 2e10))
+
+        sql, params = queryset.query.sql_with_params()
+        where_pos = sql.find('WHERE ')
+        if where_pos != -1:
+            where_clause = sql[where_pos:]
+            # replace absolute table-column refs with relative ones
+            where_clause, _ = self.absolute_col_re.subn(r"\1", where_clause)
+            self._where_clause = where_clause
+            self._params = params
+        else:
+            self._where_clause = ""
+            self._params = ()
 
     def __enter__(self):
-        self._handler_name = '{}_{}'.format(
-            self._table_name,
-            randint(1, 9999999)
-        )
-        self.cursor = connections[self.manager.db].cursor()
+        self.cursor = connections[self._queryset.db].cursor()
         self.cursor.__enter__()
         self.cursor.execute("HANDLER `{}` OPEN AS {}"
                             .format(self._table_name, self._handler_name))
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.cursor.execute("HANDLER {} CLOSE".format(self._handler_name))
+        self.cursor.execute("HANDLER `{}` CLOSE".format(self._handler_name))
         self.cursor.__exit__(exc_type, exc_value, traceback)
 
-    def read(self, limit):
-        return self.manager.raw(
-            "HANDLER {} READ `PRIMARY` FIRST LIMIT {:d}"
-            .format(self._handler_name, limit)
-        )
+    def read(self, mode='first', limit=None):
+        sql = ["HANDLER {} READ `PRIMARY`".format(self._handler_name)]
+        params = ()
 
-    @property
-    def _table_name(self):
-        return self.manager.model._meta.db_table
+        if mode == 'first':
+            sql.append("FIRST")
+
+        if self._where_clause:
+            sql.append(self._where_clause)
+            params += self._params
+
+        if limit is not None:
+            sql.append("LIMIT %s")
+            params += (limit,)
+
+        return self._model.objects.raw(" ".join(sql), params)

--- a/django_mysql/models/handler.py
+++ b/django_mysql/models/handler.py
@@ -74,16 +74,14 @@ class Handler(object):
                 sql.append("(%s)")
                 params += (index_value,)
 
-        if mode == 'first':
-            sql.append("FIRST")
-        elif mode == 'last':
-            sql.append("LAST")
-        elif mode == 'next':
-            sql.append("NEXT")
-        elif mode == 'prev':
-            sql.append("PREV")
-        elif index_op is None:
-            raise ValueError("'mode' must be one of: first, last, next, prev")
+        if index_op is None:
+            try:
+                sql.append(self._read_modes[mode])
+            except KeyError:
+                raise ValueError(
+                    "'mode' must be one of: {}"
+                    .format(",".join(self._read_modes.keys()))
+                )
 
         if where is None:
             # Use default
@@ -101,6 +99,13 @@ class Handler(object):
             params += (limit,)
 
         return self._model.objects.raw(" ".join(sql), params)
+
+    _read_modes = {
+        'first': 'FIRST',
+        'last': 'LAST',
+        'next': 'NEXT',
+        'prev': 'PREV'
+    }
 
     def _parse_index_value(self, kwargs):
         """

--- a/django_mysql/models/handler.py
+++ b/django_mysql/models/handler.py
@@ -1,3 +1,6 @@
+# -*- coding:utf-8 -*-
+from __future__ import unicode_literals
+
 from random import randint
 import re
 
@@ -12,9 +15,16 @@ class Handler(object):
         self.db = queryset.db
         self._model = queryset.model
         self._table_name = self._model._meta.db_table
-        self._handler_name = '{}_{}'.format(self._table_name, randint(1, 2e10))
 
+        self._handler_name = self._construct_name(self._table_name)
         self._where, self._params = self._extract_where(queryset)
+
+    def _construct_name(self, table_name):
+        # Undocumented max of 64 chars (get error on HANDLER CLOSE only!)
+        return '{}_{}'.format(
+            table_name[31:],
+            randint(1, 2e10)
+        )
 
     # Context manager
 

--- a/django_mysql/models/handler.py
+++ b/django_mysql/models/handler.py
@@ -33,17 +33,15 @@ class Handler(object):
 
     # Public methods
 
-    def read(self, index='pk', mode='first', where=None, limit=None):
+    def read(self, index='PRIMARY', mode='first', where=None, limit=None):
         if not self.open:
             raise RuntimeError("This handler isn't open yet")
 
         sql = ["HANDLER {} READ".format(self._handler_name)]
         params = ()
 
-        if index == 'pk':
-            sql.append("`PRIMARY`")
-        else:
-            sql.append(index)
+        # Caller's responsibility to ensure the index name is correct
+        sql.append("`{}`".format(index))
 
         if mode == 'first':
             sql.append("FIRST")

--- a/django_mysql/models/handler.py
+++ b/django_mysql/models/handler.py
@@ -1,0 +1,33 @@
+from random import randint
+
+from django.db import connections
+
+
+class Handler(object):
+    def __init__(self, manager):
+        self.manager = manager
+
+    def __enter__(self):
+        self._handler_name = '{}_{}'.format(
+            self._table_name,
+            randint(1, 9999999)
+        )
+        self.cursor = connections[self.manager.db].cursor()
+        self.cursor.__enter__()
+        self.cursor.execute("HANDLER `{}` OPEN AS {}"
+                            .format(self._table_name, self._handler_name))
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.cursor.execute("HANDLER {} CLOSE".format(self._handler_name))
+        self.cursor.__exit__(exc_type, exc_value, traceback)
+
+    def read(self, limit):
+        return self.manager.raw(
+            "HANDLER {} READ `PRIMARY` FIRST LIMIT {:d}"
+            .format(self._handler_name, limit)
+        )
+
+    @property
+    def _table_name(self):
+        return self.manager.model._meta.db_table

--- a/django_mysql/models/handler.py
+++ b/django_mysql/models/handler.py
@@ -5,19 +5,36 @@ from django.db import connections
 
 
 class Handler(object):
-    absolute_col_re = re.compile("`[^`]+`.(`[^`]+`)")
 
     def __init__(self, queryset):
-        self._queryset = queryset
+        self.open = False
+
+        self.db = queryset.db
         self._model = queryset.model
         self._table_name = self._model._meta.db_table
         self._handler_name = '{}_{}'.format(self._table_name, randint(1, 2e10))
 
+        self._set_where(queryset)
+
+    def _set_where(self, queryset):
+        """
+        Was this a queryset with filters/excludes/expressions set? If so,
+        extract the WHERE clause from the ORM output so we can use it in the
+        handler queries
+        """
+        if not self._is_simple_query(queryset.query):
+            raise ValueError("This QuerySet's WHERE clause is too complex to "
+                             "be used in a HANDLER")
+
         sql, params = queryset.query.sql_with_params()
         where_pos = sql.find('WHERE ')
         if where_pos != -1:
+            # Cut the query to extract just its WHERE clause
             where_clause = sql[where_pos:]
-            # replace absolute table-column refs with relative ones
+            # Replace absolute table.column references with relative ones
+            # since that is all HANDLER can work with
+            # This is a bit flakey - if you inserted extra SQL with extra() or
+            # an expression or something it might break.
             where_clause, _ = self.absolute_col_re.subn(r"\1", where_clause)
             self._where_clause = where_clause
             self._params = params
@@ -25,23 +42,61 @@ class Handler(object):
             self._where_clause = ""
             self._params = ()
 
+    # For modifying the queryset SQL. Attempts to match the TABLE.COLUMN
+    # pattern that Django compiles. Clearly not perfect.
+    absolute_col_re = re.compile("`[^`]+`.(`[^`]+`)")
+
+    @classmethod
+    def _is_simple_query(cls, query):
+        """
+        Inspect the internals of the Query and say if we think its WHERE clause
+        can be used in a HANDLER statement
+        """
+        return (
+            not query.low_mark and
+            not query.high_mark and
+            not query.select and
+            not query.group_by and
+            not query.having and
+            not query.distinct and
+            query.default_ordering and
+            len(query.tables) <= 1
+        )
+
+    # Context manager
+
     def __enter__(self):
-        self.cursor = connections[self._queryset.db].cursor()
+        self.cursor = connections[self.db].cursor()
         self.cursor.__enter__()
         self.cursor.execute("HANDLER `{}` OPEN AS {}"
                             .format(self._table_name, self._handler_name))
+        self.open = True
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.cursor.execute("HANDLER `{}` CLOSE".format(self._handler_name))
         self.cursor.__exit__(exc_type, exc_value, traceback)
+        self.open = False
+
+    # Public methods
 
     def read(self, mode='first', limit=None):
+        if not self.open:
+            raise RuntimeError("This handler isn't open yet")
+
         sql = ["HANDLER {} READ `PRIMARY`".format(self._handler_name)]
         params = ()
 
         if mode == 'first':
             sql.append("FIRST")
+        elif mode == 'last':
+            sql.append("LAST")
+        elif mode == 'next':
+            sql.append("NEXT")
+        elif mode == 'prev':
+            sql.append("PREV")
+        else:
+            raise ValueError("'mode' must be one of: first, last, next, prev")
 
         if self._where_clause:
             sql.append(self._where_clause)
@@ -52,3 +107,23 @@ class Handler(object):
             params += (limit,)
 
         return self._model.objects.raw(" ".join(sql), params)
+
+    def iter(self, chunk_size=100, forwards=True):
+        if forwards:
+            mode = 'first'
+        else:
+            mode = 'last'
+
+        while True:
+            count = 0
+            for obj in self.read(mode=mode, limit=chunk_size):
+                count += 1
+                yield obj
+
+            if count < chunk_size:
+                return
+
+            if forwards:
+                mode = 'next'
+            else:
+                mode = 'prev'

--- a/django_mysql/models/handler.py
+++ b/django_mysql/models/handler.py
@@ -107,7 +107,7 @@ class Handler(object):
             sql.append("LIMIT %s")
             params += (limit,)
 
-        return self._model.objects.raw(" ".join(sql), params)
+        return self._model.objects.using(self.db).raw(" ".join(sql), params)
 
     _read_modes = {
         'first': 'FIRST',

--- a/django_mysql/models/handler.py
+++ b/django_mysql/models/handler.py
@@ -29,6 +29,8 @@ class Handler(object):
     # Context manager
 
     def __enter__(self):
+        if self.open:
+            raise ValueError("You cannot open the same handler twice!")
         self.cursor = connections[self.db].cursor()
         self.cursor.__enter__()
         self.cursor.execute("HANDLER `{}` OPEN AS {}"
@@ -37,6 +39,8 @@ class Handler(object):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
+        if not self.open:
+            raise ValueError("You cannot close an unopened handler!")
         self.cursor.execute("HANDLER `{}` CLOSE".format(self._handler_name))
         self.cursor.__exit__(exc_type, exc_value, traceback)
         self.open = False

--- a/django_mysql/models/handler.py
+++ b/django_mysql/models/handler.py
@@ -22,7 +22,7 @@ class Handler(object):
     def _construct_name(self, table_name):
         # Undocumented max of 64 chars (get error on HANDLER CLOSE only!)
         return '{}_{}'.format(
-            table_name[31:],
+            table_name[-31:],
             randint(1, 2e10)
         )
 

--- a/django_mysql/models/handler.py
+++ b/django_mysql/models/handler.py
@@ -80,12 +80,17 @@ class Handler(object):
 
     # Public methods
 
-    def read(self, mode='first', limit=None):
+    def read(self, index='pk', mode='first', limit=None):
         if not self.open:
             raise RuntimeError("This handler isn't open yet")
 
-        sql = ["HANDLER {} READ `PRIMARY`".format(self._handler_name)]
+        sql = ["HANDLER {} READ".format(self._handler_name)]
         params = ()
+
+        if index == 'pk':
+            sql.append("`PRIMARY`")
+        else:
+            sql.append(index)
 
         if mode == 'first':
             sql.append("FIRST")

--- a/django_mysql/models/handler.py
+++ b/django_mysql/models/handler.py
@@ -59,7 +59,7 @@ class Handler(object):
             not query.group_by and
             not query.having and
             not query.distinct and
-            query.default_ordering and
+            not query.order_by and
             len(query.tables) <= 1
         )
 

--- a/django_mysql/models/query.py
+++ b/django_mysql/models/query.py
@@ -12,6 +12,7 @@ from django.utils import six
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext as _
 
+from django_mysql.models.handler import Handler
 from django_mysql.status import GlobalStatus
 from django_mysql.utils import (
     have_program, noop_context, settings_to_cmd_args, StopWatch,
@@ -99,6 +100,9 @@ class QuerySetMixin(object):
 
     def pt_visual_explain(self, display=True):
         return pt_visual_explain(self, display)
+
+    def handler(self):
+        return Handler(self)
 
 
 class QuerySet(QuerySetMixin, models.QuerySet):

--- a/docs/exposition.rst
+++ b/docs/exposition.rst
@@ -69,6 +69,19 @@ its ``EXPLAIN`` to ``pt-visual-explain`` to see what the query plan is::
 :ref:`Read more <pt-visual-explain>`
 
 
+MySQL ``HANDLER`` API
+---------------------
+
+MySQL's ``HANDLER`` commands give simple NoSQL-style read access to rows faster
+than normal SQL queries, with the ability to perform index lookups or
+page-by-page scans. This extension adds an ORM-based API for handlers::
+
+    with Author.objects.handler() as handler:
+        for author in handler.iter(chunk_size=1000):
+            author.send_apology_email()
+
+:ref:`Read more <handler>`
+
 -------------
 Field Lookups
 -------------

--- a/docs/queryset_extensions.rst
+++ b/docs/queryset_extensions.rst
@@ -485,7 +485,7 @@ easily as well::
             The name of the index to iterate over. As detailed above, this must
             be the index name on MySQL.
 
-        .. attribute:: where
+        .. attribute:: where=None
 
             A ``QuerySet`` for filter conditions, the same as ``read``'s
             ``where`` argument, as detailed above.

--- a/docs/queryset_extensions.rst
+++ b/docs/queryset_extensions.rst
@@ -315,3 +315,17 @@ easy to gain an understanding of what your queries do.
         rows           1
         +- Table
            table          auth_user
+
+
+.. _handler:
+
+Handler
+-------
+
+MySQL's ``HANDLER`` commands give simple NoSQL-style read access to rows faster
+than normal SQL queries, with the ability to perform index lookups or
+page-by-page scans (docs:
+`MySQL<http://dev.mysql.com/doc/refman/5.6/en/handler.html>`_ /
+`MariaDB <https://mariadb.com/kb/en/mariadb/handler-commands/>`_).
+
+This extension adds an ORM-based API for handlers::

--- a/docs/queryset_extensions.rst
+++ b/docs/queryset_extensions.rst
@@ -472,7 +472,7 @@ easily as well::
             rows.
 
     .. attribute:: iter(index='PRIMARY', where=None, chunk_size=100, \
-                        forwards=True)
+                        reverse=False)
 
         Iterate over a table via the named index, one chunk at a time, yielding
         the individual objects. Acts as a wrapper around repeated calls to
@@ -492,7 +492,7 @@ easily as well::
 
             The size of the chunks to read during iteration.
 
-        .. attribute:: forwards=True
+        .. attribute:: reverse=False
 
             The direction of iteration over the index. By default set to
             ``True``, the index will be iterated in ascending order; set to

--- a/docs/queryset_extensions.rst
+++ b/docs/queryset_extensions.rst
@@ -372,8 +372,8 @@ easily as well::
     manager. You may have multiple handlers open at once, even on the same
     table, but you cannot open the same one twice.
 
-    .. attribute:: read(index='PRIMARY', mode=None, where=None, limit=None, \
-                        value__LOOKUP=None)
+    .. attribute:: read(index='PRIMARY', value__LOOKUP=None, mode=None, \
+                        where=None, limit=None)
 
         Returns the result of a ``HANDLER .. READ`` statement as a
         :class:`~django.db.models.RawQuerySet` for the given ``queryset``'s
@@ -400,12 +400,13 @@ easily as well::
 
             Both single and multi-column indexes are supported.
 
-        .. attribute:: value__LOOKUP
+        .. attribute:: value__LOOKUP=None
 
-            ``value__LOOKUP`` allows you to specify an index lookup using the
-            same style as Django's ORM. You may only have one index lookup on a
-            ``read`` - other conditions must be filtered with ``where``. For
-            example::
+            The 'first form' of ``HANDLER .. READ`` supports index lookups.
+            ``value__LOOKUP`` allows you to specify a lookup on ``index`` using
+            the same style as Django's ORM, and is mutually exclusive with
+            ``mode``. You may only have one index lookup on a ``read`` - other
+            conditions must be filtered with ``where``. For example::
 
                 # Read objects with primary key <= 100
                 handler.read(value__lte=100, limit=100)
@@ -430,15 +431,22 @@ easily as well::
             The 'second form' of ``HANDLER .. READ`` supports paging over a
             table, fetching one batch of results at a time whilst the handler
             object on MySQL's end retains state, somewhat like a 'cursor'. This
-            is mututally exclusive with specifying an index lookup via
-            ``value__LOOKUP``.
+            is mututally exclusive with ``value__LOOKUP``, and if neither is
+            specified, this is the default.
 
-            You can specify ``'first'`` and then repeatedly ``'next'`` to
-            iterate forwards over the index, or ``'last'`` and then repeatedly
-            ``'prev'`` to iterate backwards over the index. The page size is
-            set with ``limit``.
+            There are four modes::
 
-            N.B. the below ``iter`` method below is recommended for iteration.
+                * ``first`` - commence iteration at the start
+                * ``next`` - continue ascending/go forward one page
+                * ``last`` - commence iteration at the end (in reverse)
+                * ``prev`` - continue descending/go backward one page
+
+            To iterate forwards, use ``'first'`` and then
+            repeatedly ``'next'``. To iterate backwards, use ``'last'`` and
+            then repeatedly ``'prev'``. The page size is set with ``limit``.
+
+            N.B. the below ``iter`` method below is recommended for most
+            iteration.
 
         .. attribute:: where=None
 

--- a/docs/queryset_extensions.rst
+++ b/docs/queryset_extensions.rst
@@ -281,7 +281,7 @@ Integration with pt-visual-explain
 ----------------------------------
 
 How does MySQL *really* execute a query? The ``EXPLAIN`` statement
-(docs: `MySQL<http://dev.mysql.com/doc/refman/5.6/en/explain.html>`_ /
+(docs: `MySQL <http://dev.mysql.com/doc/refman/5.6/en/explain.html>`_ /
 `MariaDB <https://mariadb.com/kb/en/mariadb/explain/>`_),
 gives a description of the execution plan, and the ``pt-visual-explain``
 `tool <http://www.percona.com/doc/percona-toolkit/2.2/pt-visual-explain.html>`_
@@ -322,10 +322,180 @@ easy to gain an understanding of what your queries do.
 Handler
 -------
 
+.. currentmodule:: django_mysql.models.handler
+
 MySQL's ``HANDLER`` commands give simple NoSQL-style read access to rows faster
 than normal SQL queries, with the ability to perform index lookups or
 page-by-page scans (docs:
-`MySQL<http://dev.mysql.com/doc/refman/5.6/en/handler.html>`_ /
+`MySQL <http://dev.mysql.com/doc/refman/5.6/en/handler.html>`_ /
 `MariaDB <https://mariadb.com/kb/en/mariadb/handler-commands/>`_).
 
-This extension adds an ORM-based API for handlers::
+This extension adds an ORM-based API for handlers. You can instantiate them
+from a ``QuerySet`` (and thus from `.objects`), and open close them as context
+managers::
+
+    with Author.objects.handler() as handler:
+
+        first_ten_authors_by_pk = handler.read(limit=10)
+
+        for author in handler.iter(chunk_size=1000):
+            author.send_apology_email()
+
+
+The ``.handler()`` method simply returns a ``Handler`` instance; the class can
+be imported and applied to ``QuerySet``\s from models without the extensions
+easily as well::
+
+    from django_mysql.models.handler import Handler
+
+    with Handler(User.objects.all()) as handler:
+
+        for user in handler.iter(chunk_size=1000):
+            user.send_notification_email()
+
+.. warning::
+
+    ``HANDLER`` is lower level than ``SELECT``, and has some optimizations
+    that mean it permits **dirty reads**. Check the database documentation and
+    understand the consequences of this before you replace any SQL queries!
+
+
+.. class:: Handler(queryset)
+
+    Implements a handler for the given queryset's model. The ``WHERE`` clause
+    and query parameters, if they exist, will be extracted from the queryset's
+    SQL. Since ``HANDLER`` statements can only operate on one table at a time,
+    only relatively simple querysets can be used - others will result in a
+    ``ValueError`` being raised.
+
+    A ``Handler`` is only opened and available for reads when used as a context
+    manager. You may have multiple handlers open at once, even on the same
+    table, but you cannot open the same one twice.
+
+    .. attribute:: read(index='PRIMARY', mode=None, where=None, limit=None, \
+                        value__LOOKUP=None)
+
+        Returns the result of a ``HANDLER .. READ`` statement as a
+        :class:`~django.db.models.RawQuerySet` for the given ``queryset``'s
+        model (which, like all ``QuerySet``\s is lazy).
+
+        .. note::
+            The ``HANDLER`` statements must select whole rows, therefore there
+            is no way of optimizing by returning only certain columns (like
+            ``QuerySet``'s :meth:`~django.db.models.query.QuerySet.only()`).
+
+        MySQL supports three forms of ``HANDLER .. READ`` statements, but only
+        **first two forms** of ``HANDLER .. READ`` statements are supported -
+        you can specify index lookups, or pagination, and thus the arguments
+        ``mode`` and ``value__LOOKUP`` are mutually exclusive.
+
+        .. attribute:: index='PRIMARY'
+
+            The name of the index of the table to read, defaulting to the
+            primary key. You must provide the index name as known by MySQL, not
+            the names of the indexed column[s] as Django's ``db_index`` and
+            ``index_together`` let you specify. This will only be checked by
+            MySQL so an ``OperationalError`` will be raised if you specify a
+            wrong name.
+
+            Both single and multi-column indexes are supported.
+
+        .. attribute:: value__LOOKUP
+
+            ``value__LOOKUP`` allows you to specify an index lookup using the
+            same style as Django's ORM. You may only have one index lookup on a
+            ``read`` - other conditions must be filtered with ``where``. For
+            example::
+
+                # Read objects with primary key <= 100
+                handler.read(value__lte=100, limit=100)
+
+            The valid lookups are:
+
+                * ``value__lt=x`` - index value ``<`` x
+                * ``value__lte=x`` - index value ``<=`` x
+                * ``value=x``, ``value__exact=x`` - index value ``=`` x
+                * ``value__gte=x`` - index value ``>=`` x
+                * ``value__gt=x`` - index value ``>`` x
+
+            For single-column indexes, specify the value; for multi-column
+            indexes, specify the tuple of values, for example::
+
+                # Index is on on first and last name columns
+                grisham = handler.read(index='full_name_idx',
+                                       value=('John', 'Grisham'))
+
+        .. attribute:: mode
+
+            The 'second form' of ``HANDLER .. READ`` supports paging over a
+            table, fetching one batch of results at a time whilst the handler
+            object on MySQL's end retains state, somewhat like a 'cursor'. This
+            is mututally exclusive with specifying an index lookup via
+            ``value__LOOKUP``.
+
+            You can specify ``'first'`` and then repeatedly ``'next'`` to
+            iterate forwards over the index, or ``'last'`` and then repeatedly
+            ``'prev'`` to iterate backwards over the index. The page size is
+            set with ``limit``.
+
+            N.B. the below ``iter`` method below is recommended for iteration.
+
+        .. attribute:: where=None
+
+            ``HANDLER .. READ`` statements support ``WHERE`` clauses for
+            columns on the same table, which apply after the index filtering.
+            By default the ``WHERE`` clause from the ``queryset`` used to
+            construct the ``Handler`` will be applied. Passing a different
+            ``QuerySet`` as ``where`` allows you to read with different
+            filters. For example::
+
+                with Author.objects.handler() as handler:
+
+                    old = Author.objects.filter(age__gte=50) first_old_author =
+                    handler.read(where=old)[0]
+
+                    young = Author.objects.filter(age__lte=50)
+                    first_young_author = handler.read(where=young)[0]
+
+        .. attribute:: limit=None
+
+            By default every ``HANDLER .. READ`` statement returns *only* the
+            first row. Specify ``limit`` to retrieve a different number of
+            rows.
+
+    .. attribute:: iter(index='PRIMARY', where=None, chunk_size=100, \
+                        forwards=True)
+
+        Iterate over a table via the named index, one chunk at a time, yielding
+        the individual objects. Acts as a wrapper around repeated calls to
+        ``read``.
+
+        .. attribute:: index='PRIMARY'
+
+            The name of the index to iterate over. As detailed above, this must
+            be the index name on MySQL.
+
+        .. attribute:: where
+
+            A ``QuerySet`` for filter conditions, the same as ``read``'s
+            ``where`` argument, as detailed above.
+
+        .. attribute:: chunk_size=100
+
+            The size of the chunks to read during iteration.
+
+        .. attribute:: forwards=True
+
+            The direction of iteration over the index. By default set to
+            ``True``, the index will be iterated in ascending order; set to
+            ``False``, the index will be iterated in descending order.
+
+            Sets ``mode`` on ``read`` to either ``FIRST`` then repeatedly
+            ``NEXT`` or ``LAST`` then repeatedly ``PREV`` respectively.
+
+            .. warning::
+
+                You can only have one iteration happening at a time per
+                ``Handler``, otherwise on the MySQL side it loses its position.
+                There is no checking for this in ``Handler`` class.
+

--- a/tests/django_mysql_tests/models.py
+++ b/tests/django_mysql_tests/models.py
@@ -12,18 +12,30 @@ class Settee(Model):
         max_length=32,
     )
 
+    def __unicode__(self):
+        return "{} {}".format(self.id, ",".join(self.features))
+
 
 class Author(Model):
     name = CharField(max_length=32, db_index=True)
     tutor = ForeignKey('self', null=True)
 
+    def __unicode__(self):
+        return "{} {}".format(self.id, self.name)
+
 
 class VanillaAuthor(VanillaModel):
     name = CharField(max_length=32)
 
+    def __unicode__(self):
+        return "{} {}".format(self.id, self.name)
+
 
 class NameAuthor(Model):
     name = CharField(max_length=32, primary_key=True)
+
+    def __unicode__(self):
+        return "{} {}".format(self.id, self.name)
 
 
 class AuthorMultiIndex(Model):
@@ -32,3 +44,6 @@ class AuthorMultiIndex(Model):
 
     name = CharField(max_length=32)
     country = CharField(max_length=32)
+
+    def __unicode__(self):
+        return "{} {} in {}".format(self.id, self.name, self.country)

--- a/tests/django_mysql_tests/models.py
+++ b/tests/django_mysql_tests/models.py
@@ -1,5 +1,5 @@
 # -*- coding:utf-8 -*-
-from django.db.models import CharField, Model as VanillaModel
+from django.db.models import CharField, ForeignKey, Model as VanillaModel
 
 from django_mysql.fields import SetCharField
 from django_mysql.models import Model
@@ -15,6 +15,7 @@ class Settee(Model):
 
 class Author(Model):
     name = CharField(max_length=32)
+    tutor = ForeignKey('self', null=True)
 
 
 class VanillaAuthor(VanillaModel):

--- a/tests/django_mysql_tests/models.py
+++ b/tests/django_mysql_tests/models.py
@@ -47,3 +47,11 @@ class AuthorMultiIndex(Model):
 
     def __unicode__(self):
         return "{} {} in {}".format(self.id, self.name, self.country)
+
+
+class AuthorHugeName(Model):
+    class Meta(object):
+        db_table = 'this_is_an_author_with_an_incredibly_long_table_name_' \
+                   'you_know_it'
+
+    name = CharField(max_length=32)

--- a/tests/django_mysql_tests/models.py
+++ b/tests/django_mysql_tests/models.py
@@ -24,3 +24,11 @@ class VanillaAuthor(VanillaModel):
 
 class NameAuthor(Model):
     name = CharField(max_length=32, primary_key=True)
+
+
+class AuthorMultiIndex(Model):
+    class Meta(object):
+        index_together = ('name', 'country')
+
+    name = CharField(max_length=32)
+    country = CharField(max_length=32)

--- a/tests/django_mysql_tests/models.py
+++ b/tests/django_mysql_tests/models.py
@@ -14,7 +14,7 @@ class Settee(Model):
 
 
 class Author(Model):
-    name = CharField(max_length=32)
+    name = CharField(max_length=32, db_index=True)
     tutor = ForeignKey('self', null=True)
 
 

--- a/tests/django_mysql_tests/test_handler.py
+++ b/tests/django_mysql_tests/test_handler.py
@@ -223,34 +223,35 @@ class HandlerReadTests(BaseAuthorTestCase):
     def test_read_bad_argument_underscores(self):
         with Author.objects.handler() as handler:
             with self.assertRaises(ValueError):
-                handler.read(value___exact=1)
+                handler.read(value_exact=1)
 
 
 class HandlerIterTests(BaseAuthorTestCase):
 
     def test_iter_all(self):
-        all_ids = list(Author.objects.values_list('id', flat=True))
-
         with Author.objects.handler() as handler:
             seen_ids = [author.id for author in handler.iter()]
 
-        self.assertEqual(seen_ids, list(sorted(all_ids)))
+        self.assertEqual(seen_ids, [self.jk.id, self.grisham.id])
 
     def test_iter_chunk_size_1(self):
-        all_ids = list(Author.objects.values_list('id', flat=True))
-
         with Author.objects.handler() as handler:
-            seen_ids = [author.id for author in handler.iter()]
+            seen_ids = [author.id for author in handler.iter(chunk_size=1)]
 
-        self.assertEqual(seen_ids, list(sorted(all_ids)))
+        self.assertEqual(seen_ids, [self.jk.id, self.grisham.id])
 
     def test_iter_reverse(self):
-        all_ids = list(Author.objects.values_list('id', flat=True))
-
         with Author.objects.handler() as handler:
             seen_ids = [author.id for author in handler.iter(forwards=False)]
 
-        self.assertEqual(seen_ids, list(sorted(all_ids, reverse=True)))
+        self.assertEqual(seen_ids, [self.grisham.id, self.jk.id])
+
+    def test_iter_reverse_chunk_size_1(self):
+        with Author.objects.handler() as handler:
+            seen_ids = [author.id for author in
+                        handler.iter(chunk_size=1, forwards=False)]
+
+        self.assertEqual(seen_ids, [self.grisham.id, self.jk.id])
 
     def test_bad_iter_unopened(self):
         handler = Author.objects.all().handler()

--- a/tests/django_mysql_tests/test_handler.py
+++ b/tests/django_mysql_tests/test_handler.py
@@ -144,12 +144,57 @@ class HandlerTests(TestCase):
     def test_read_index_value_and_mode_invalid(self):
         with Author.objects.handler() as handler:
             with self.assertRaises(ValueError):
-                handler.read(index_value=1, mode='first')
+                handler.read(value=1, mode='first')
 
-    def test_read_index_pk(self):
+    def test_read_index_equal(self):
         with Author.objects.handler() as handler:
-            handler_result = handler.read(index_value=self.jk.id)[0]
+            handler_result = handler.read(value=self.jk.id)[0]
         self.assertEqual(handler_result, self.jk)
+
+    def test_read_index_equal_exact(self):
+        with Author.objects.handler() as handler:
+            handler_result = handler.read(value__exact=self.jk.id)[0]
+        self.assertEqual(handler_result, self.jk)
+
+    def test_read_index_less_than(self):
+        with Author.objects.handler() as handler:
+            handler_result = handler.read(value__lt=self.jk.id + 1)[0]
+        self.assertEqual(handler_result, self.jk)
+
+    def test_read_index_less_than_equal(self):
+        with Author.objects.handler() as handler:
+            handler_result = handler.read(value__lte=self.jk.id)[0]
+        self.assertEqual(handler_result, self.jk)
+
+    def test_read_index_greater_than_equal(self):
+        with Author.objects.handler() as handler:
+            handler_result = handler.read(value__gte=self.jk.id)[0]
+        self.assertEqual(handler_result, self.jk)
+
+    def test_read_index_greater_than(self):
+        with Author.objects.handler() as handler:
+            handler_result = handler.read(value__gt=self.jk.id)[0]
+        self.assertEqual(handler_result, self.grisham)
+
+    def test_read_index_too_many_filters(self):
+        with Author.objects.handler() as handler:
+            with self.assertRaises(ValueError):
+                handler.read(value__lte=1, value__gte=1)
+
+    def test_read_index_bad_operator(self):
+        with Author.objects.handler() as handler:
+            with self.assertRaises(ValueError):
+                handler.read(value__flange=1)
+
+    def test_read_bad_argument(self):
+        with Author.objects.handler() as handler:
+            with self.assertRaises(ValueError):
+                handler.read(pk=1)
+
+    def test_read_bad_argument_underscores(self):
+        with Author.objects.handler() as handler:
+            with self.assertRaises(ValueError):
+                handler.read(value___exact=1)
 
     def test_read_index_multipart(self):
         AuthorMultiIndex.objects.create(name='John Smith', country='Scotland')
@@ -161,7 +206,7 @@ class HandlerTests(TestCase):
 
         with AuthorMultiIndex.objects.handler() as handler:
             value = ('John Smith', 'England')
-            handler_result = handler.read(index=idx_name, index_value=value)[0]
+            handler_result = handler.read(index=idx_name, value=value)[0]
 
         self.assertEqual(handler_result, smith2)
 

--- a/tests/django_mysql_tests/test_handler.py
+++ b/tests/django_mysql_tests/test_handler.py
@@ -64,7 +64,14 @@ class HandlerTests(TestCase):
 
         self.assertEqual(handler_all, qs_all)
 
-    def test_read_index(self):
+    def test_read_index_primary(self):
+        with Author.objects.handler() as handler:
+            handler_all = list(handler.read(index='PRIMARY', limit=2))
+        qs_all = list(Author.objects.order_by('id'))
+
+        self.assertEqual(handler_all, qs_all)
+
+    def test_read_index_different(self):
         # There's no easy way of getting index names in django so get the name
         # of the index on Author.name from INFORMATION_SCHEMA
         with connection.cursor() as cursor:

--- a/tests/django_mysql_tests/test_handler.py
+++ b/tests/django_mysql_tests/test_handler.py
@@ -1,0 +1,26 @@
+# -*- coding:utf-8 -*-
+from django.test import TestCase
+
+from django_mysql_tests.models import Author
+
+
+class HandlerTests(TestCase):
+    def setUp(self):
+        Author.objects.create(name='JK Rowling')
+        Author.objects.create(name='John Grisham')
+
+    def test_simple(self):
+        qs_all = list(Author.objects.order_by('id'))
+
+        with Author.objects.handler() as handler:
+            handler_all = list(handler.read(limit=10000))
+
+        self.assertEqual(handler_all, qs_all)
+
+    def test_limit(self):
+        qs_first = Author.objects.earliest('id')
+
+        with Author.objects.handler() as handler:
+            handler_first = handler.read(limit=1)[0]
+
+        self.assertEqual(handler_first, qs_first)

--- a/tests/django_mysql_tests/test_handler.py
+++ b/tests/django_mysql_tests/test_handler.py
@@ -377,3 +377,17 @@ class HandlerStandaloneTests(TestCase):
             first = handler.read()[0]
 
         self.assertEqual(first, self.grisham)
+
+
+class HandlerMultiDBTests(TestCase):
+
+    def setUp(self):
+        self.jk = Author.objects.using('secondary').create(name='JK Rowling')
+        self.grisham = Author.objects.create(name='John Grisham')
+
+    def test_queryset_db_is_used(self):
+        handler = Author.objects.using('secondary').handler()
+        with handler:
+            handler_result = handler.read()[0]
+
+        self.assertEqual(handler_result, self.jk)

--- a/tests/django_mysql_tests/test_handler.py
+++ b/tests/django_mysql_tests/test_handler.py
@@ -274,6 +274,23 @@ class HandlerIterTests(BaseAuthorTestCase):
 
         self.assertEqual(seen_ids, [self.grisham.id])
 
+    def test_iter_loses_its_place(self):
+        portis = Author.objects.create(name='Charles Portis')
+
+        with Author.objects.handler() as handler:
+            iterator = handler.iter(chunk_size=1)
+            self.assertEqual(next(iterator), self.jk)
+            self.assertEqual(next(iterator), self.grisham)
+
+            iterator2 = handler.iter(chunk_size=1, forwards=False)
+            self.assertEqual(next(iterator2), portis)
+
+            # This SHOULD be portis, but it thinks it's exhausted already
+            # because iterator2 reset the iteration in reverse, and now for the
+            # NEXT page after the LAST
+            with self.assertRaises(StopIteration):
+                self.assertEqual(next(iterator), portis)
+
 
 class HandlerMultipartIndexTests(TestCase):
 

--- a/tests/django_mysql_tests/test_handler.py
+++ b/tests/django_mysql_tests/test_handler.py
@@ -257,6 +257,22 @@ class HandlerIterTests(BaseAuthorTestCase):
         with self.assertRaises(RuntimeError):
             sum(1 for x in handler.iter())
 
+    def test_iter_where_preset(self):
+        where_qs = Author.objects.filter(name__startswith='John')
+
+        with where_qs.handler() as handler:
+            seen_ids = [author.id for author in handler.iter()]
+
+        self.assertEqual(seen_ids, [self.grisham.id])
+
+    def test_iter_where_passed_in(self):
+        where_qs = Author.objects.filter(name__startswith='John')
+
+        with Author.objects.handler() as handler:
+            seen_ids = [author.id for author in handler.iter(where=where_qs)]
+
+        self.assertEqual(seen_ids, [self.grisham.id])
+
 
 class HandlerMultipartIndexTests(TestCase):
 

--- a/tests/django_mysql_tests/test_handler.py
+++ b/tests/django_mysql_tests/test_handler.py
@@ -1,4 +1,5 @@
 # -*- coding:utf-8 -*-
+from django.db import connection
 from django.db.models import F
 from django.test import TestCase
 
@@ -60,6 +61,28 @@ class HandlerTests(TestCase):
         with Author.objects.handler() as handler:
             handler_all = list(handler.read(limit=2))
         qs_all = list(Author.objects.all())
+
+        self.assertEqual(handler_all, qs_all)
+
+    def test_read_index(self):
+        # There's no easy way of getting index names in django so get the name
+        # of the index on Author.name from INFORMATION_SCHEMA
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """SELECT DISTINCT INDEX_NAME
+                FROM INFORMATION_SCHEMA.STATISTICS
+                WHERE TABLE_SCHEMA = %s AND
+                      TABLE_NAME = %s
+                      AND INDEX_NAME != 'PRIMARY'
+                LIMIT 1""",
+                (connection.settings_dict['NAME'], Author._meta.db_table)
+            )
+
+            index_name = [x[0] for x in cursor.fetchall()][0]
+
+        with Author.objects.handler() as handler:
+            handler_all = list(handler.read(index=index_name, limit=2))
+        qs_all = list(Author.objects.order_by('name').all())
 
         self.assertEqual(handler_all, qs_all)
 

--- a/tests/django_mysql_tests/test_handler.py
+++ b/tests/django_mysql_tests/test_handler.py
@@ -254,14 +254,14 @@ class HandlerIterTests(BaseAuthorTestCase):
 
     def test_iter_reverse(self):
         with Author.objects.handler() as handler:
-            seen_ids = [author.id for author in handler.iter(forwards=False)]
+            seen_ids = [author.id for author in handler.iter(reverse=True)]
 
         self.assertEqual(seen_ids, [self.grisham.id, self.jk.id])
 
     def test_iter_reverse_chunk_size_1(self):
         with Author.objects.handler() as handler:
             seen_ids = [author.id for author in
-                        handler.iter(chunk_size=1, forwards=False)]
+                        handler.iter(chunk_size=1, reverse=True)]
 
         self.assertEqual(seen_ids, [self.grisham.id, self.jk.id])
 
@@ -294,7 +294,7 @@ class HandlerIterTests(BaseAuthorTestCase):
             self.assertEqual(next(iterator), self.jk)
             self.assertEqual(next(iterator), self.grisham)
 
-            iterator2 = handler.iter(chunk_size=1, forwards=False)
+            iterator2 = handler.iter(chunk_size=1, reverse=True)
             self.assertEqual(next(iterator2), portis)
 
             # This SHOULD be portis, but it thinks it's exhausted already

--- a/tests/django_mysql_tests/test_handler.py
+++ b/tests/django_mysql_tests/test_handler.py
@@ -1,4 +1,5 @@
 # -*- coding:utf-8 -*-
+from django.db.models import F
 from django.test import TestCase
 
 from django_mysql_tests.models import Author
@@ -27,10 +28,10 @@ class HandlerTests(TestCase):
 
     def test_filter(self):
         qs = Author.objects.filter(name__startswith='John')
-        qs_all = list(qs._clone())
 
         with qs._clone().handler() as handler:
             handler_all = list(handler.read())
+        qs_all = list(qs._clone())
 
         self.assertEqual(handler_all, qs_all)
 
@@ -42,3 +43,64 @@ class HandlerTests(TestCase):
             handler_all = list(handler.read())
 
         self.assertEqual(handler_all, qs_all)
+
+    def test_filter_sql_name(self):
+        # Check that params are kept as params and no SQL injection occurs
+        table_col = "`something`.`something`"
+        author = Author.objects.create(name=table_col)
+        qs = Author.objects.filter(name=table_col)
+
+        with qs.handler() as handler:
+            handler_all = list(handler.read(limit=100))
+
+        self.assertEqual(handler_all, [author])
+
+    def test_bad_read_unopened(self):
+        handler = Author.objects.all().handler()
+        with self.assertRaises(RuntimeError):
+            handler.read()
+
+    def test_bad_read_mode(self):
+        with Author.objects.all().handler() as handler:
+            with self.assertRaises(ValueError):
+                handler.read(mode='non-existent')
+
+    def test_iter(self):
+        qs = Author.objects.all()
+
+        with qs.handler() as handler:
+            seen_pks = []
+            for author in handler.iter(chunk_size=1):
+                seen_pks.append(author.pk)
+
+        all_pks = qs.values_list('id', flat=True)
+        self.assertEqual(seen_pks, list(sorted(all_pks)))
+
+    def test_iter_reverse(self):
+        qs = Author.objects.all()
+
+        with qs.handler() as handler:
+            seen_pks = []
+            for author in handler.iter(chunk_size=1, forwards=False):
+                seen_pks.append(author.pk)
+
+        all_pks = qs.values_list('id', flat=True)
+        self.assertEqual(seen_pks, list(sorted(all_pks, reverse=True)))
+
+    def test_filter_f_expression(self):
+        qs = Author.objects.filter(name=F('name'))
+
+        with qs.handler() as handler:
+            handler_all = list(handler.read(limit=100))
+
+        self.assertEqual(len(handler_all), 2)
+
+    def test_bad_filter_joins_not_allowed(self):
+        qs = Author.objects.filter(tutor__name='A')
+        with self.assertRaises(ValueError):
+            qs.handler()
+
+    def test_bad_filter_limit_not_allowed(self):
+        qs = Author.objects.all()[:100]
+        with self.assertRaises(ValueError):
+            qs.handler()

--- a/tests/django_mysql_tests/test_handler.py
+++ b/tests/django_mysql_tests/test_handler.py
@@ -122,6 +122,25 @@ class HandlerTests(TestCase):
 
         self.assertEqual(handler_first, author)
 
+    def test_read_where_passed_in(self):
+        qs = Author.objects.filter(name__startswith='John')
+
+        with Author.objects.handler() as handler:
+            handler_author = handler.read(where=qs)[0]
+
+        self.assertEqual(handler_author, qs[0])
+
+    def test_read_where_passed_in_overrides_completely(self):
+        qs = Author.objects.filter(name='JK Rowling')
+        qs2 = Author.objects.filter(name='John Grisham')
+
+        with qs.handler() as handler:
+            handler_default = handler.read()[0]
+            handler_where = handler.read(where=qs2)[0]
+
+        self.assertEqual(handler_default, qs[0])
+        self.assertEqual(handler_where, qs2[0])
+
     def test_iter_all(self):
         all_ids = list(Author.objects.values_list('id', flat=True))
 

--- a/tests/django_mysql_tests/test_handler.py
+++ b/tests/django_mysql_tests/test_handler.py
@@ -47,6 +47,18 @@ class HandlerCreationTests(TestCase):
         with AuthorHugeName.objects.handler():
             pass
 
+    def test_cannot_open_twice(self):
+        handler = Author.objects.handler()
+        with handler:
+            with self.assertRaises(ValueError):
+                with handler:
+                    pass
+
+    def test_cannot_close_unopened(self):
+        handler = Author.objects.handler()
+        with self.assertRaises(ValueError):
+            handler.__exit__(None, None, None)
+
 
 class BaseAuthorTestCase(TestCase):
 

--- a/tests/django_mysql_tests/test_handler.py
+++ b/tests/django_mysql_tests/test_handler.py
@@ -24,3 +24,21 @@ class HandlerTests(TestCase):
             handler_first = handler.read(limit=1)[0]
 
         self.assertEqual(handler_first, qs_first)
+
+    def test_filter(self):
+        qs = Author.objects.filter(name__startswith='John')
+        qs_all = list(qs._clone())
+
+        with qs._clone().handler() as handler:
+            handler_all = list(handler.read())
+
+        self.assertEqual(handler_all, qs_all)
+
+    def test_exclude(self):
+        qs = Author.objects.filter(name__contains='JK')
+        qs_all = list(qs._clone())
+
+        with qs._clone().handler() as handler:
+            handler_all = list(handler.read())
+
+        self.assertEqual(handler_all, qs_all)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -19,6 +19,14 @@ DATABASES = {
         'HOST': '',
         'PORT': ''
     },
+    'secondary': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'django_mysql2',
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': '',
+        'PORT': ''
+    },
 }
 
 ALLOWED_HOSTS = []


### PR DESCRIPTION
Relatively simple API that supports the HANDLER statements of forms 1 and 2 only. Form 3, 'natural row' order, didn't seem worth supporting at this time since it's not a thing in InnoDB. (N.B. it may be *even faster* though for those non-transactional storage engines).