### PR TITLE
Group concat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,6 @@ coverage:
 docs:
 	rm -f docs/django-mysql.rst
 	rm -f docs/modules.rst
-	# DJANGO_SETTINGS_MODULE=django.conf.global_settings sphinx-apidoc -o docs/ django_mysql
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 	open docs/_build/html/index.html

--- a/django_mysql/models/__init__.py
+++ b/django_mysql/models/__init__.py
@@ -1,4 +1,5 @@
 from django_mysql.models.base import Model  # NOQA
+from django_mysql.models.aggregates import *  # NOQA
 from django_mysql.models.query import (  # NOQA
     ApproximateInt, SmartChunkedIterator, SmartIterator, pt_visual_explain,
     QuerySet, QuerySetMixin

--- a/django_mysql/models/aggregates.py
+++ b/django_mysql/models/aggregates.py
@@ -1,0 +1,48 @@
+from django.db.models import CharField
+from django.db.models import Aggregate
+from django.db.models.sql.aggregates import Aggregate as SQLAggregate
+from django.utils.functional import cached_property
+
+__all__ = ('GroupConcat',)
+
+
+class GroupConcat(Aggregate):
+    def add_to_query(self, query, alias, col, source, is_summary):
+        query.aggregates[alias] = SQLGroupConcat(
+            col,
+            source=source,
+            is_summary=is_summary,
+            **self.extra
+        )
+
+
+class SQLGroupConcat(SQLAggregate):
+
+    def __init__(self, col, distinct=False, separator=None, **extra):
+        super(SQLGroupConcat, self).__init__(col, **extra)
+
+        self.distinct = distinct
+        self.separator = separator
+
+        # This can/will be improved to SetTextField or ListTextField
+        self.field = CharField()
+
+    sql_function = 'GROUP_CONCAT'
+
+    @cached_property
+    def sql_template(self):
+        # Constructing a template...
+
+        template = ["%(function)s("]
+
+        if self.distinct:
+            template.append("DISTINCT ")
+
+        template.append("%(field)s")
+
+        if self.separator is not None:
+            template.append(' SEPARATOR "{}"'.format(self.separator))
+
+        template.append(")")
+
+        return "".join(template)

--- a/docs/aggregates.rst
+++ b/docs/aggregates.rst
@@ -1,0 +1,58 @@
+.. _aggregates:
+
+==========
+Aggregates
+==========
+
+.. currentmodule:: django_mysql.models
+
+MySQL-specific `database aggregates
+<https://docs.djangoproject.com/en/dev/topics/db/aggregation/>`_
+for the ORM.
+
+The following can be imported from ``django_mysql.models``.
+
+.. class:: GroupConcat(column, distinct=False, separator=',')
+
+    An aggregate that concatenates values from a column of the grouped rows.
+    Useful mostly for bringing back lists of ids in a single query.
+
+    Docs:
+    `MySQL <https://dev.mysql.com/doc/refman/5.5/en/group-by-functions.html#function_group-concat>`_ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/group_concat/>`_.
+
+    Example usage::
+
+            >>> from django_mysql.models import GroupConcat
+            >>> author = Author.objects.annotate(
+            ...     book_ids=GroupConcat('books__id')
+            ... ).get(name="William Shakespeare")
+            >>> author.book_ids
+            "1,2,5,17,29"
+
+    .. warning::
+
+        MySQL will truncate the value at the value of ``group_concat_max_len``,
+        which by default is quite low at 1024 characters. You should probably
+        increase it if you're using this for any sizeable groups.
+
+        ``group_concat_max_len`` docs:
+        `MySQL <https://dev.mysql.com/doc/refman/5.5/en/server-system-variables.html#sysvar_group_concat_max_len>`_ /
+        `MariaDB <https://mariadb.com/kb/en/server-system-variables/#group_concat_max_len>`_.
+
+    Has two optional arguments:
+
+    .. attribute:: distinct=False
+
+        If set to ``True``, removes duplicates from the group.
+
+    .. attribute:: separator=','
+
+        By default the separator is a comma. You can use any other string as a
+        separator, including the empty string.
+
+        .. warning::
+
+            Due to limitations in the Django aggregate API, this is not
+            protected against SQL injection. Don't pass in user input for the
+            separator.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,9 @@ project_root = os.path.dirname(cwd)
 # version is used.
 sys.path.insert(0, project_root)
 
+from django.conf import settings
+settings.configure()
+
 import django_mysql
 
 # -- General configuration ---------------------------------------------

--- a/docs/exposition.rst
+++ b/docs/exposition.rst
@@ -95,6 +95,22 @@ ORM extensions to built-in fields:
 :ref:`Read more <field-lookups>`
 
 
+----------
+Aggregates
+----------
+
+``GROUP_CONCAT`` is supported, which allows you to bring back the concatenation
+of an aggregate in one query:
+
+    >>> author = Author.objects.annotate(
+    ...     book_ids=GroupConcat('books__id')
+    ... ).get(name="William Shakespeare")
+    >>> author.book_ids
+    "1,2,5,17,29"
+
+:ref:`Read more <aggregates>`
+
+
 ------------------
 Database Functions
 ------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ or get started with :doc:`installation`. Otherwise, here's the full contents:
    installation
    queryset_extensions
    field_lookups
+   aggregates
    database_functions
    locks
    status

--- a/tests/django_mysql_tests/models.py
+++ b/tests/django_mysql_tests/models.py
@@ -20,7 +20,7 @@ class Settee(Model):
 
 class Author(Model):
     name = CharField(max_length=32, db_index=True)
-    tutor = ForeignKey('self', null=True)
+    tutor = ForeignKey('self', null=True, related_name='tutees')
 
     def __unicode__(self):
         return "{} {}".format(self.id, self.name)

--- a/tests/django_mysql_tests/test_aggregates.py
+++ b/tests/django_mysql_tests/test_aggregates.py
@@ -1,0 +1,53 @@
+# -*- coding:utf-8 -*-
+from django.test import TestCase
+
+from django_mysql.models import GroupConcat
+
+from django_mysql_tests.models import Author
+
+
+class GroupConcatTests(TestCase):
+
+    def setUp(self):
+        self.shakes = Author.objects.create(name='William Shakespeare')
+        self.jk = Author.objects.create(name='JK Rowling', tutor=self.shakes)
+        self.grisham = Author.objects.create(name='Grisham', tutor=self.shakes)
+
+        self.str_tutee_ids = [str(self.jk.id), str(self.grisham.id)]
+
+    def test_basic_aggregate_ids(self):
+        out = self.shakes.tutees.aggregate(tids=GroupConcat('id'))
+        concatted_ids = ",".join(self.str_tutee_ids)
+        self.assertEqual(out, {'tids': concatted_ids})
+
+    def test_basic_annotate_ids(self):
+        concat = GroupConcat('tutees__id')
+        shakey = Author.objects.annotate(tids=concat).get(id=self.shakes.id)
+        concatted_ids = ",".join(self.str_tutee_ids)
+        self.assertEqual(shakey.tids, concatted_ids)
+
+    def test_separator(self):
+        concat = GroupConcat('id', separator=':')
+        out = self.shakes.tutees.aggregate(tids=concat)
+        concatted_ids = ":".join(self.str_tutee_ids)
+        self.assertEqual(out, {'tids': concatted_ids})
+
+    def test_separator_empty(self):
+        concat = GroupConcat('id', separator='')
+        out = self.shakes.tutees.aggregate(tids=concat)
+        concatted_ids = "".join(self.str_tutee_ids)
+        self.assertEqual(out, {'tids': concatted_ids})
+
+    def test_separator_big(self):
+        concat = GroupConcat('id', separator='BIG')
+        out = self.shakes.tutees.aggregate(tids=concat)
+        concatted_ids = "BIG".join(self.str_tutee_ids)
+        self.assertEqual(out, {'tids': concatted_ids})
+
+    def test_order(self):
+        out = (
+            Author.objects
+                  .exclude(id=self.shakes.id)
+                  .aggregate(tids=GroupConcat('tutor_id', distinct=True))
+        )
+        self.assertEqual(out, {'tids': str(self.shakes.id)})


### PR DESCRIPTION
Resolves #13 .

Still outstanding:

* docs
* deserializing via `SetTextField` from #10 or `ListTextField` from #11 would make it much nicer to use
* `ORDER BY` support