### PR TITLE
Add functions for Django 1.8+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ install:
   - pip install -r requirements/requirements-testing.txt
   - pip install coveralls tox
 
-script: tox
+script:
+  - coverage erase
+  - tox
 
-after_success: coveralls
+after_success:
+  - coverage combine
+  - coveralls

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,9 @@ test-all:
 	tox
 
 coverage:
-	coverage run --source django_mysql ./runtests.py
+	coverage erase
+	tox
+	coverage combine
 	coverage report -m
 	coverage html
 	open htmlcov/index.html

--- a/django_mysql/models/functions.py
+++ b/django_mysql/models/functions.py
@@ -1,0 +1,119 @@
+import django
+from django.db.models import CharField, IntegerField, TextField
+
+if django.VERSION >= (1, 8):
+    from django.db.models.functions import Func, Value
+else:
+    class Func(object):
+        def __init__(self, *args, **kwargs):
+            raise ValueError("Database Functions only exist in Django 1.8+")
+
+    Value = object
+
+
+class SingleArgFunc(Func):
+
+    output_field_class = None
+
+    def __init__(self, expression):
+        super(SingleArgFunc, self).__init__(expression)
+        if self.output_field_class is not None:
+            self.output_field = self.output_field_class()
+
+
+class MultiArgFunc(Func):
+    def __init__(self, *expressions):
+        super(MultiArgFunc, self).__init__(*expressions)
+
+
+# Numeric Functions
+
+
+class Abs(SingleArgFunc):
+    function = 'ABS'
+    output_field_class = IntegerField
+
+
+class Ceiling(SingleArgFunc):
+    function = 'CEILING'
+    output_field_class = IntegerField
+
+
+class CRC32(SingleArgFunc):
+    function = 'CRC32'
+    output_field_class = IntegerField
+
+
+class Floor(SingleArgFunc):
+    function = 'FLOOR'
+    output_field_class = IntegerField
+
+
+class Greatest(MultiArgFunc):
+    function = 'GREATEST'
+
+
+class Least(MultiArgFunc):
+    function = 'LEAST'
+
+
+class Round(Func):
+    function = 'ROUND'
+    output_field_class = IntegerField
+
+    def __init__(self, expression, places=0):
+        super(Round, self).__init__(expression, places)
+
+
+class Sign(SingleArgFunc):
+    function = 'SIGN'
+    output_field_class = IntegerField
+
+
+# String Functions
+
+class ConcatWS(Func):
+    """
+    Stands for CONCAT_With-Separator
+    """
+    function = 'CONCAT_WS'
+
+    def __init__(self, *expressions, **kwargs):
+        separator = kwargs.pop('separator', ',')
+        if len(kwargs) > 0:
+            raise ValueError("Invalid keyword arguments for ConcatWS: {}"
+                             .format(",".join(kwargs.keys())))
+
+        if len(expressions) < 2:
+            raise ValueError('ConcatWS must take at least two expressions')
+
+        if not hasattr(separator, 'resolve_expression'):
+            separator = Value(separator)
+
+        # N.B. if separator is "," we could potentially use list field
+        output_field = TextField()
+        super(ConcatWS, self).__init__(separator, *expressions,
+                                       output_field=output_field)
+
+
+class MD5(SingleArgFunc):
+    function = 'MD5'
+    output_field_class = CharField
+
+
+class SHA1(SingleArgFunc):
+    function = 'SHA1'
+    output_field_class = CharField
+
+
+class SHA2(Func):
+    function = 'SHA2'
+    bitlengths = (224, 256, 384, 512)
+
+    def __init__(self, expression, bitlength):
+        if bitlength not in self.bitlengths:
+            raise ValueError(
+                "bitlength must be one of {}"
+                .format(",".join(str(x) for x in self.bitlengths))
+            )
+        super(SHA2, self).__init__(expression, Value(bitlength))

--- a/django_mysql/models/functions.py
+++ b/django_mysql/models/functions.py
@@ -8,7 +8,7 @@ else:
         def __init__(self, *args, **kwargs):
             raise ValueError("Database Functions only exist in Django 1.8+")
 
-    Value = object
+    Value = tuple
 
 
 class SingleArgFunc(Func):

--- a/django_mysql/models/functions.py
+++ b/django_mysql/models/functions.py
@@ -26,6 +26,17 @@ class MultiArgFunc(Func):
         super(MultiArgFunc, self).__init__(*expressions)
 
 
+# Comparison Functions
+
+
+class Greatest(MultiArgFunc):
+    function = 'GREATEST'
+
+
+class Least(MultiArgFunc):
+    function = 'LEAST'
+
+
 # Numeric Functions
 
 
@@ -47,14 +58,6 @@ class CRC32(SingleArgFunc):
 class Floor(SingleArgFunc):
     function = 'FLOOR'
     output_field_class = IntegerField
-
-
-class Greatest(MultiArgFunc):
-    function = 'GREATEST'
-
-
-class Least(MultiArgFunc):
-    function = 'LEAST'
 
 
 class Round(Func):
@@ -96,6 +99,9 @@ class ConcatWS(Func):
                                        output_field=output_field)
 
 
+# Encryption Functions
+
+
 class MD5(SingleArgFunc):
     function = 'MD5'
     output_field_class = CharField
@@ -108,12 +114,12 @@ class SHA1(SingleArgFunc):
 
 class SHA2(Func):
     function = 'SHA2'
-    bitlengths = (224, 256, 384, 512)
+    hash_lens = (224, 256, 384, 512)
 
-    def __init__(self, expression, bitlength):
-        if bitlength not in self.bitlengths:
+    def __init__(self, expression, hash_len=512):
+        if hash_len not in self.hash_lens:
             raise ValueError(
-                "bitlength must be one of {}"
-                .format(",".join(str(x) for x in self.bitlengths))
+                "hash_len must be one of {}"
+                .format(",".join(str(x) for x in self.hash_lens))
             )
-        super(SHA2, self).__init__(expression, Value(bitlength))
+        super(SHA2, self).__init__(expression, Value(hash_len))

--- a/docs/database_functions.rst
+++ b/docs/database_functions.rst
@@ -1,0 +1,212 @@
+.. _database_functions:
+
+==================
+Database Functions
+==================
+
+.. currentmodule:: django_mysql.models.functions
+
+MySQL-specific `database functions
+<https://docs.djangoproject.com/en/1.8/ref/models/database-functions/>`_
+for the ORM.
+
+The following can be imported from ``django_mysql.models.functions``.
+
+.. note::
+
+    Functions were only added to Django in version 1.8.
+
+
+Comparison Functions
+--------------------
+
+
+.. class:: Greatest(*expressions)
+
+    With two or more arguments, returns the largest (maximum-valued) argument.
+
+    Docs:
+    `MySQL <https://dev.mysql.com/doc/refman/5.5/en/comparison-operators.html#function_greatest>`_ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/greatest/>`_.
+
+    Usage example::
+
+        >>> Author.objects.filter(sales_eu=Greatest('sales_eu', 'sales_us'))
+
+
+.. class:: Least(*expressions)
+
+    With two or more arguments, returns the smallest (minimum-valued) argument.
+
+    Docs:
+    `MySQL <https://dev.mysql.com/doc/refman/5.5/en/comparison-operators.html#function_least>`_ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/least/>`_.
+
+    Usage example::
+
+        >>> Author.objects.filter(sales_eu=Least('sales_eu', 'sales_us'))
+
+
+Numeric Functions
+-----------------
+
+
+.. class:: Abs(expression)
+
+    Returns the absolute (non-negative) value of ``expression```. If
+    ``expression`` is not a number, it is converted to a numeric type.
+
+    Docs:
+    `MySQL <https://dev.mysql.com/doc/refman/5.5/en/mathematical-functions.html#function_abs>`_ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/abs/>`_.
+
+    Usage example::
+
+        >>> Author.objects.annotate(abs_wealth=Abs('dollars'))
+
+
+.. class:: Ceiling(expression)
+
+    Returns the smallest integer value not less than `expression`.
+
+    Docs:
+    `MySQL <https://dev.mysql.com/doc/refman/5.5/en/mathematical-functions.html#function_ceiling>`_ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/ceiling/>`_.
+
+    Usage example::
+
+        >>> Author.objects.annotate(years_ceiling=Ceiling('age'))
+
+
+.. class:: CRC32(expression)
+
+    Computes a cyclic redundancy check value and returns a 32-bit unsigned
+    value. The result is ``NULL`` if the argument is ``NULL``. The argument is
+    expected to be a string and (if possible) is treated as one if it is not.
+
+    Docs:
+    `MySQL <https://dev.mysql.com/doc/refman/5.5/en/mathematical-functions.html#function_crc32>`_ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/crc32/>`_.
+
+    Usage example::
+
+        >>> Author.objects.annotate(description_crc=CRC32('description'))
+
+
+.. class:: Floor(expression)
+
+    Returns the largest integer value not greater than ``expression``.
+
+    Docs:
+    `MySQL <https://dev.mysql.com/doc/refman/5.5/en/mathematical-functions.html#function_floor>`_ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/floor/>`_.
+
+    Usage example::
+
+        >> Author.objects.annotate(age_years=Floor('age'))
+
+
+.. class:: Round(expression, places=0)
+
+    Rounds the argument ``expression`` to ``places`` decimal places. The
+    rounding algorithm depends on the data type of ``expression``. ``places``
+    defaults to 0 if not specified. ``places`` can be negative to cause
+    ``places`` digits left of the decimal point of the value ``expression`` to
+    become zero.
+
+    Docs:
+    `MySQL <https://dev.mysql.com/doc/refman/5.5/en/mathematical-functions.html#function_round>`_ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/round/>`_.
+
+    Usage example::
+
+        >>> Author.objects.annotate(kilo_sales=Round('sales', -3))
+
+
+.. class:: Sign(expression)
+
+    Returns the sign of the argument as -1, 0, or 1, depending on whether
+    ``expression`` is negative, zero, or positive.
+
+    Docs:
+    `MySQL <https://dev.mysql.com/doc/refman/5.5/en/mathematical-functions.html#function_sign>`_ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/sign/>`_.
+
+    Usage example::
+
+        >>> Author.objects.annotate(wealth_sign=Sign('wealth'))
+
+
+String Functions
+----------------
+
+
+.. class:: ConcatWS(*expressions, separator=',')
+
+    ``ConcatWS`` stands for Concatenate With Separator and is a special form of
+    :class:`~django.db.models.functions.Concat` (included in Django). It
+    concatenates all of its argument expressions as strings with the given
+    ``separator``. Since ``NULL`` values are skipped, unlike in ``Concat``, you
+    can use the empty string as a separator and it acts as a ``NULL``-safe
+    version of ``Concat``.
+
+    If ``separator`` is a string, it will be turned into a
+    :class:`~django.db.models.Value`. If you wish to join with the value of a
+    field, you can pass in an :class:`~django.db.models.F` object for that
+    field.
+
+    Docs:
+    `MySQL <https://dev.mysql.com/doc/refman/5.5/en/string-functions.html#function_concat-ws>`_ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/concat_ws/>`_.
+
+    Usage example::
+
+        >>> Author.objects.annotate(sales_list=ConcatWS('sales_eu', 'sales_us'))
+
+
+Encryption Functions
+--------------------
+
+
+.. class:: MD5(expression)
+
+    Calculates an MD5 128-bit checksum for the string ``expression``.
+
+    Docs:
+    `MySQL <https://dev.mysql.com/doc/refman/5.5/en/encryption-functions.html#function_md5>`_ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/md5/>`_.
+
+    Usage example::
+
+        >>> Author.objects.annotate(description_md5=MD5('description'))
+
+
+.. class:: SHA1(expression)
+
+    Calculates an SHA-1 160-bit checksum for the string ``expression``, as
+    described in RFC 3174 (Secure Hash Algorithm).
+
+    Docs:
+    `MySQL <https://dev.mysql.com/doc/refman/5.5/en/encryption-functions.html#function_sha1>`_ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/sha1/>`_.
+
+    Usage example::
+
+        >>> Author.objects.annotate(description_sha=SHA1('description'))
+
+
+.. class:: SHA2(expression, hash_len=512)
+
+    Given a string ``expression``, calculates a SHA-2 checksum, which is
+    considered more cryptographically secure than its SHA-1 equivalent. The
+    SHA-2 family includes SHA-224, SHA-256, SHA-384, and SHA-512, and the
+    ``hash_len`` must correspond to one of these, i.e. 224, 256, 384 or 512.
+    The default for ``hash_len`` is 512.
+
+    Docs:
+    `MySQL <https://dev.mysql.com/doc/refman/5.5/en/encryption-functions.html#function_sha2>`_ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/sha2/>`_.
+
+    Usage example::
+
+        >>> Author.objects.annotate(description_sha256=SHA2('description', 256))

--- a/docs/exposition.rst
+++ b/docs/exposition.rst
@@ -82,6 +82,7 @@ page-by-page scans. This extension adds an ORM-based API for handlers::
 
 :ref:`Read more <handler>`
 
+
 -------------
 Field Lookups
 -------------
@@ -92,6 +93,19 @@ ORM extensions to built-in fields:
     [<Author: Robert>, <Author: Rupert>]
 
 :ref:`Read more <field-lookups>`
+
+
+------------------
+Database Functions
+------------------
+
+MySQL-specific database functions for the ORM:
+
+    >>> Author.objects.annotate(full_name=ConcatWS('first_name', 'last_name', separator=' ')) \
+    ...               .first().full_name
+    "Charles Dickens"
+
+:ref:`Read more <database_functions>`
 
 
 -----

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ or get started with :doc:`installation`. Otherwise, here's the full contents:
    installation
    queryset_extensions
    field_lookups
+   database_functions
    locks
    status
    manage_commands

--- a/tests/django_mysql_tests/models.py
+++ b/tests/django_mysql_tests/models.py
@@ -1,5 +1,7 @@
 # -*- coding:utf-8 -*-
-from django.db.models import CharField, ForeignKey, Model as VanillaModel
+from django.db.models import (
+    CharField, DecimalField, ForeignKey, IntegerField, Model as VanillaModel
+)
 
 from django_mysql.fields import SetCharField
 from django_mysql.models import Model
@@ -55,3 +57,13 @@ class AuthorHugeName(Model):
                    'you_know_it'
 
     name = CharField(max_length=32)
+
+
+class Alphabet(Model):
+    a = IntegerField(default=1)
+    b = IntegerField(default=2)
+    c = IntegerField(default=3)
+    d = CharField(max_length=32)
+    e = CharField(max_length=32, null=True)
+    f = IntegerField(null=True)
+    g = DecimalField(default=0, decimal_places=2, max_digits=10)

--- a/tests/django_mysql_tests/test_functions.py
+++ b/tests/django_mysql_tests/test_functions.py
@@ -182,6 +182,14 @@ class StringFunctionTests(TestCase):
         "Requires old Django version without Database Functions")
 class OldDjangoFunctionTests(TestCase):
 
-    def test_they_dont_work(self):
+    def test_single_arg_doesnt_work(self):
         with self.assertRaises(ValueError):
             CRC32('name')
+
+    def test_multi_arg_doesnt_work(self):
+        with self.assertRaises(ValueError):
+            Greatest('a', 'b')
+
+    def test_concat_ws_doesnt_work(self):
+        with self.assertRaises(ValueError):
+            ConcatWS('a', 'b', separator='::')

--- a/tests/django_mysql_tests/test_functions.py
+++ b/tests/django_mysql_tests/test_functions.py
@@ -1,0 +1,187 @@
+# -*- coding:utf-8 -*-
+import hashlib
+from unittest import skipIf
+
+import django
+from django.db.models import F
+from django.test import TestCase
+
+from django_mysql.models.functions import (
+    Abs, ConcatWS, Ceiling, CRC32, Floor, Greatest, Least, MD5, Round, SHA1,
+    SHA2, Sign
+)
+
+from django_mysql_tests.models import Alphabet
+
+
+@skipIf(django.VERSION <= (1, 8),
+        "Requires Database Functions from Django 1.8+")
+class NumericFunctionTests(TestCase):
+
+    def test_abs(self):
+        Alphabet.objects.create(a=-2)
+        ab = Alphabet.objects.annotate(aaa=Abs('a')).first()
+        self.assertEqual(ab.aaa, 2)
+
+    def test_ceiling(self):
+        Alphabet.objects.create(g=0.5)
+        ab = Alphabet.objects.annotate(gceil=Ceiling('g')).first()
+        self.assertEqual(ab.gceil, 1)
+
+    def test_crc32(self):
+        Alphabet.objects.create(d='AAAAAA')
+        ab = Alphabet.objects.annotate(crc=CRC32('d')).first()
+        # Precalculated this in MySQL prompt. Python's binascii.crc32 doesn't
+        # match - maybe sign issues?
+        self.assertEqual(ab.crc, 2854018686)
+
+    def test_crc32_only_takes_one_arg_no_kwargs(self):
+        with self.assertRaises(TypeError):
+            CRC32('d', 'c')
+
+        with self.assertRaises(TypeError):
+            CRC32('d', something='wrong')
+
+    def test_floor(self):
+        Alphabet.objects.create(g=1.5)
+        ab = Alphabet.objects.annotate(gfloor=Floor('g')).first()
+        self.assertEqual(ab.gfloor, 1)
+
+    def test_greatest(self):
+        Alphabet.objects.create(d='A', e='B')
+        ab = Alphabet.objects.annotate(best=Greatest('d', 'e')).first()
+        self.assertEqual(ab.best, 'B')
+
+    def test_greatest_takes_no_kwargs(self):
+        with self.assertRaises(TypeError):
+            Greatest('a', something='wrong')
+
+    def test_least(self):
+        Alphabet.objects.create(a=1, b=2, c=-1)
+        ab = Alphabet.objects.annotate(worst=Least('a', 'b', 'c')).first()
+        self.assertEqual(ab.worst, -1)
+
+    def test_round(self):
+        Alphabet.objects.create(g=24.459)
+        ab = Alphabet.objects.annotate(ground=Round('g')).get()
+        self.assertEqual(ab.ground, 24)
+
+    def test_round_up(self):
+        Alphabet.objects.create(g=27.859)
+        ab = Alphabet.objects.annotate(ground=Round('g')).get()
+        self.assertEqual(ab.ground, 28)
+
+    def test_round_places(self):
+        Alphabet.objects.create(a=81731)
+        ab = Alphabet.objects.annotate(around=Round('a', -2)).get()
+        self.assertEqual(ab.around, 81700)
+
+    def test_sign(self):
+        Alphabet.objects.create(a=123, b=0, c=-999)
+        ab = Alphabet.objects.annotate(
+            asign=Sign('a'),
+            bsign=Sign('b'),
+            csign=Sign('c'),
+        ).first()
+        self.assertEqual(ab.asign, 1)
+        self.assertEqual(ab.bsign, 0)
+        self.assertEqual(ab.csign, -1)
+
+
+@skipIf(django.VERSION <= (1, 8),
+        "Requires Database Functions from Django 1.8+")
+class StringFunctionTests(TestCase):
+
+    def test_concat_ws(self):
+        Alphabet.objects.create(d='AAA', e='BBB')
+        ab = Alphabet.objects.annotate(de=ConcatWS('d', 'e')).first()
+        self.assertEqual(ab.de, 'AAA,BBB')
+
+    def test_concat_ws_integers(self):
+        Alphabet.objects.create(a=1, b=2)
+        ab = Alphabet.objects.annotate(ab=ConcatWS('a', 'b')).first()
+        self.assertEqual(ab.ab, '1,2')
+
+    def test_concat_ws_skips_nulls(self):
+        Alphabet.objects.create(d='AAA', e=None, f=2)
+        ab = Alphabet.objects.annotate(de=ConcatWS('d', 'e', 'f')).first()
+        self.assertEqual(ab.de, 'AAA,2')
+
+    def test_concat_ws_separator(self):
+        Alphabet.objects.create(d='AAA', e='BBB')
+        ab = (
+            Alphabet.objects.annotate(de=ConcatWS('d', 'e', separator=':'))
+                            .first()
+        )
+        self.assertEqual(ab.de, 'AAA:BBB')
+
+    def test_concat_ws_separator_null_returns_none(self):
+        Alphabet.objects.create(a=1, b=2)
+        concat = ConcatWS('a', 'b', separator=None)
+        ab = Alphabet.objects.annotate(ab=concat).first()
+        self.assertEqual(ab.ab, None)
+
+    def test_concat_ws_separator_field(self):
+        Alphabet.objects.create(a=1, d='AAA', e='BBB')
+        concat = ConcatWS('d', 'e', separator=F('a'))
+        ab = Alphabet.objects.annotate(de=concat).first()
+        self.assertEqual(ab.de, 'AAA1BBB')
+
+    def test_concat_ws_bad_arg(self):
+        with self.assertRaises(ValueError) as cm:
+            ConcatWS('a', 'b', separataaa=',')
+        self.assertIn('Invalid keyword arguments for ConcatWS: separataaa',
+                      str(cm.exception))
+
+    def test_concat_ws_too_few_fields(self):
+        with self.assertRaises(ValueError) as cm:
+            ConcatWS('a')
+        self.assertIn('ConcatWS must take at least two expressions',
+                      str(cm.exception))
+
+    def test_concat_ws_then_lookups_from_textfield(self):
+        Alphabet.objects.create(d='AAA', e='BBB')
+        Alphabet.objects.create(d='AAA', e='CCC')
+        ab = (
+            Alphabet.objects.annotate(de=ConcatWS('d', 'e', separator=':'))
+                            .filter(de__endswith=':BBB')
+                            .first()
+        )
+        self.assertEqual(ab.de, 'AAA:BBB')
+
+    def test_md5_string(self):
+        string = 'A string'
+        Alphabet.objects.create(d=string)
+        pymd5 = hashlib.md5(string.encode('ascii')).hexdigest()
+        ab = Alphabet.objects.annotate(md5=MD5('d')).first()
+        self.assertEqual(ab.md5, pymd5)
+
+    def test_sha1_string(self):
+        string = 'A string'
+        Alphabet.objects.create(d=string)
+        pysha1 = hashlib.sha1(string.encode('ascii')).hexdigest()
+        ab = Alphabet.objects.annotate(sha=SHA1('d')).first()
+        self.assertEqual(ab.sha, pysha1)
+
+    def test_sha2_string(self):
+        string = 'A string'
+        Alphabet.objects.create(d=string)
+
+        for bitlength in (224, 256, 384, 512):
+            sha_func = getattr(hashlib, 'sha{}'.format(bitlength))
+            pysha = sha_func(string.encode('ascii')).hexdigest()
+            ab = Alphabet.objects.annotate(sha=SHA2('d', bitlength)).first()
+            self.assertEqual(ab.sha, pysha)
+
+    def test_sha2_bad_bitlength(self):
+        with self.assertRaises(ValueError):
+            SHA2('a', 123)
+
+
+@skipIf(django.VERSION >= (1, 8),
+        "Requires old Django version without Database Functions")
+class OldDjangoFunctionTests(TestCase):
+
+    def test_they_dont_work(self):
+        with self.assertRaises(ValueError):
+            CRC32('name')

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     django18beta: Django==1.8c1
     -rrequirements/requirements-testing.txt
     coverage
-commands = coverage run --source=django_mysql ./runtests.py --nolint
+commands = coverage run -p --source=django_mysql ./runtests.py --nolint
 
 
 [testenv:py27-flake8]


### PR DESCRIPTION
Resolves #12 .

To do:

* MD5 / SHA1 / SHA2 - https://mariadb.com/kb/en/mariadb/encryption-functions/
* LAST_VALUE - https://mariadb.com/kb/en/mariadb/last_value/ - which then suggests doing mysql-side vars
* SLEEP - https://mariadb.com/kb/en/mariadb/sleep/
* CEILING/FLOOR - https://mariadb.com/kb/en/mariadb/ceiling/ / https://mariadb.com/kb/en/mariadb/floor/
* HEX - https://mariadb.com/kb/en/mariadb/hex/

Maybe better as 'lookups' or custom field types:

* FROM/TO_BASE64 -  https://mariadb.com/kb/en/mariadb/to_base64/ / https://mariadb.com/kb/en/from_base64/
* Some MariaDB specific regex functions  https://mariadb.com/kb/en/mariadb/regular-expressions-functions/