### PR TITLE
Document and test deficiency of the index-based lookup on list fields	

### DIFF
--- a/docs/model_fields.rst
+++ b/docs/model_fields.rst
@@ -135,9 +135,9 @@ A transform that converts to the number of items in the list. For example::
 Index lookups
 ~~~~~~~~~~~~~
 
-This class of lookups allows you to index into the list to check if a certain
-element is in a certain position. There are no errors if it exceeds the
-``size`` of the list. For example::
+This class of lookups allows you to index into the list to check if the first
+occurence of a given element is at a given position. There are no errors if
+it exceeds the ``size`` of the list. For example::
 
     >>> Person.objects.filter(post_nominals__0='PhD')
     [<Person: Horatio>, <Person: Severus>]
@@ -149,11 +149,24 @@ element is in a certain position. There are no errors if it exceeds the
     []
 
 
+.. warning::
+
+    The underlying function, ``FIND_IN_SET``, is designed for *sets*, i.e.
+    comma-separated lists of unique elements. It therefore only allows you to
+    query about the *first* occurence of the given item. For example, this is
+    a non-match::
+
+        >>> Person.objects.create(name='Cacistus', post_nominals=['MSc', 'MSc'])
+        >>> Person.objects.filter(post_nominals__1='MSc')
+        []  # Cacistus does not appear because his first MSc is at position 0
+
+    This may be fine for your application, but be careful!
+
 .. note::
 
     ``FIND_IN_SET`` uses 1-based indexing for searches on comma-based strings
     when writing raw SQL. However these indexes use 0-based indexing to be
-    consistent with Python
+    consistent with Python.
 
 .. note::
 

--- a/tests/django_mysql_tests/test_listcharfield.py
+++ b/tests/django_mysql_tests/test_listcharfield.py
@@ -171,6 +171,21 @@ class TestSaveLoad(TestCase):
         )
         self.assertEqual(list(red0_or_blue0), [mymodel])
 
+    def test_char_position_lookup_repeat_fails(self):
+        """
+        FIND_IN_SET returns the *first* position so repeats are not dealt with
+        """
+        CharListModel.objects.create(field=["red", "red", "blue"])
+
+        red1 = CharListModel.objects.filter(field__1="red")
+        self.assertEqual(list(red1), [])  # should be 'red'
+
+    def test_char_position_lookup_too_long(self):
+        CharListModel.objects.create(field=["red", "blue"])
+
+        red1 = CharListModel.objects.filter(field__2="blue")
+        self.assertEqual(list(red1), [])
+
     def test_int_easy(self):
         mymodel = IntListModel.objects.create(field=[1, 2])
         self.assertEqual(mymodel.field, [1, 2])


### PR DESCRIPTION
We're treating lists like sets, so if you try do `field__1="red"` it will not match `["red", "red"]`, since `FIND_IN_SET` returns that it's at the first position in the list.

Should document this or remove the positional lookup (since `contains` goes 90% of the way and does not carry any risk of misunderstanding).