### PR TITLE
pt_visual_explain doesn't execute the query to capture it

### DIFF
--- a/docs/queryset_extensions.rst
+++ b/docs/queryset_extensions.rst
@@ -294,16 +294,17 @@ gives a description of the execution plan, and the ``pt-visual-explain``
 `tool <http://www.percona.com/doc/percona-toolkit/2.2/pt-visual-explain.html>`_
 can format this in an understandable tree.
 
-Here's a shortcut to turn a ``QuerySet`` into its visual explanation, making it
-easy to gain an understanding of what your queries do.
+This function is a shortcut to turn a ``QuerySet`` into its visual explanation,
+making it easy to gain a better understanding of what your queries really end
+up doing.
 
 .. method:: pt_visual_explain(display=True)
 
-    Call on a queryset to print its visual explanation, or with
-    ``display=False`` to return it as a string. Executes the query, captures
-    the SQL, then gets the visual explanation via a subprocess pipeline with
-    `mysql` and `pt-visual-explain`. You therefore need the MySQL client and
-    Percona Toolkit installed where you run this.
+    Call on a ``QuerySet`` to print its visual explanation, or with
+    ``display=False`` to return it as a string. It prepends the SQL of the
+    query with 'EXPLAIN' and passes it through the ``mysql`` and
+    ``pt-visual-explain`` commands to get the output. You therefore need the
+    MySQL client and Percona Toolkit installed where you run this.
 
     Example::
 
@@ -313,8 +314,9 @@ easy to gain an understanding of what your queries do.
         +- Table
            table          myapp_author
 
-    Also importable as a standalone function if you can't use the
-    ``QuerySetMixin`` or you need it on a model you can't touch::
+    Can also be imported as a standalone function if you want to use it on a
+    ``QuerySet`` that does not have the ``QuerySetMixin`` added, e.g. for
+    built-in django models::
 
         >>> from django_mysql.models import pt_visual_explain
         >>> pt_visual_explain(User.objects.all())

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -51,10 +51,8 @@ else:
     ) + INSTALLED_APPS
 
 MIDDLEWARE_CLASSES = (
-    'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     django18beta: Django==1.8c1
     -rrequirements/requirements-testing.txt
     coverage
-commands = coverage run -p --source=django_mysql ./runtests.py --nolint
+commands = coverage run -p --source=django_mysql ./runtests.py --nolint {posargs}
 
 
 [testenv:py27-codestyle]


### PR DESCRIPTION
Resolves #56 . Gets the query's SQL and params, prepends 'explain', and executes it, to get the fully param-substituted form, before passing THAT to mysql + pt-visual-explain