### PR TITLE
Public test utils

### DIFF
--- a/django_mysql/test/utils.py
+++ b/django_mysql/test/utils.py
@@ -1,0 +1,83 @@
+import uuid
+from functools import wraps
+
+from django.db import connections
+from django.db.utils import DEFAULT_DB_ALIAS
+from django.utils import six
+
+
+class override_mysql_variables(object):
+    """
+    Based on Django's override_settings, but for connection settings. Give a
+    connection alias in using and variable=value pairs to save on that
+    connection. Keeps the old values MySQL-side using session variables of the
+    form @overridden_X.
+
+    Acts as either a decorator, or a context manager. If it's a decorator it
+    takes a function and returns a wrapped function. If it's a contextmanager
+    it's used with the ``with`` statement. In either event entering/exiting
+    are called before and after, respectively, the function/block is executed.
+    """
+    def __init__(self, using=DEFAULT_DB_ALIAS, **kwargs):
+        self.db = using
+        self.options = kwargs
+        self.prefix = uuid.uuid1().hex.replace('-', '')
+
+    def __enter__(self):
+        self.enable()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.disable()
+
+    def __call__(self, test_func):
+        from unittest import TestCase
+        if isinstance(test_func, six.class_types):
+            if not issubclass(test_func, TestCase):
+                raise Exception(
+                    "{} only works with TestCase classes."
+                    .format(self.__class__.__name__)
+                )
+
+            self.wrap_class(test_func)
+
+            return test_func
+        else:
+            @wraps(test_func)
+            def inner(*args, **kwargs):
+                with self:
+                    return test_func(*args, **kwargs)
+            return inner
+
+    def wrap_class(self, klass):
+        kwargs = {'using': self.db}
+        kwargs.update(**self.options)
+
+        for name in dir(klass):
+            if not name.startswith('test_'):
+                continue
+
+            method = getattr(klass, name)
+            # Reconstruct self over and over on each method
+            wrapped = self.__class__(**kwargs)(method)
+            setattr(klass, name, wrapped)
+
+    def enable(self):
+        with connections[self.db].cursor() as cursor:
+
+            for key, value in six.iteritems(self.options):
+                cursor.execute(
+                    """SET @overridden_{prefix}_{name} = @@{name},
+                           @@{name} = %s
+                    """.format(prefix=self.prefix, name=key),
+                    (value,)
+                )
+
+    def disable(self):
+        with connections[self.db].cursor() as cursor:
+
+            for key in self.options:
+                cursor.execute(
+                    """SET @@{name} = @overridden_{prefix}_{name},
+                           @overridden_{prefix}_{name} = NULL
+                    """.format(name=key, prefix=self.prefix)
+                )

--- a/docs/exposition.rst
+++ b/docs/exposition.rst
@@ -222,3 +222,19 @@ Fingerprint queries quickly with the ``pt-fingerprint`` wrapper::
     "select * from myapp_author where id = 5"
 
 :ref:`Read more <utilities>`
+
+
+--------------
+Test Utilities
+--------------
+
+Set some MySQL server variables on a test case for every method or just a
+specific one::
+
+    class MyTests(TestCase):
+
+        @override_mysql_variables(SQL_MODE="ANSI")
+        def test_it_works_in_ansi_mode(self):
+            self.run_it()
+
+:ref:`Read more <test_utilities>`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ or get started with :doc:`installation`. Otherwise, here's the full contents:
    status
    manage_commands
    utilities
+   test_utilities
    exceptions
    contributing
    authors

--- a/docs/test_utilities.rst
+++ b/docs/test_utilities.rst
@@ -1,0 +1,42 @@
+.. _test_utilities:
+
+==============
+Test Utilities
+==============
+
+.. currentmodule:: django_mysql.test.utils
+
+The following can be imported from ``django_mysql.test.utils``.
+
+
+.. function:: override_mysql_variables(using='default', **options)
+
+    Overrides MySQL system variables for a test method or for every test method
+    in a class, similar to Django's :class:`~django.test.override_settings`.
+    This can be useful when you're testing code that must run under multiple
+    MySQL environments (like most of `django-mysql`). For example::
+
+        @override_mysql_variables(SQL_MODE="MSSQL")
+        class MyTests(TestCase):
+
+            def test_it_works_in_mssql(self):
+                run_it()
+
+            @override_mysql_variables(SQL_MODE="ANSI")
+            def test_it_works_in_ansi_mode(self):
+                run_it()
+
+    During the first test, the ``SQL_MODE`` will be ``MSSQL``, and during the
+    second, it will be ``ANSI``; each slightly changes the allowed SQL syntax,
+    meaning they are useful to test.
+
+    .. note::
+
+        This only sets the system variables for the session, so if the tested
+        code closes and re-opens the database connection the change will be
+        reset.
+
+    .. attribute:: using
+
+    The connection alias to set the system variables for, defaults to
+    'default'.

--- a/tests/django_mysql_tests/test_setcharfield.py
+++ b/tests/django_mysql_tests/test_setcharfield.py
@@ -16,11 +16,11 @@ import ddt
 
 from django_mysql.models import SetCharField, SetF
 from django_mysql.forms import SimpleSetField
+from django_mysql.test.utils import override_mysql_variables
 
 from django_mysql_tests.models import (
     CharSetModel, CharSetDefaultModel, IntSetModel
 )
-from django_mysql_tests.utils import override_mysql_variables
 
 
 @ddt.ddt

--- a/tests/django_mysql_tests/test_test_utils.py
+++ b/tests/django_mysql_tests/test_test_utils.py
@@ -1,0 +1,31 @@
+from django.db import connections
+from django.test import TestCase
+
+from django_mysql.test.utils import override_mysql_variables
+
+
+class OverrideVarsMethodTest(TestCase):
+
+    @override_mysql_variables(SQL_MODE="MSSQL")
+    def test_method_sets_mssql(self):
+        self.check_sql_mode("MSSQL")
+
+    def check_sql_mode(self, expected, using='default'):
+        with connections[using].cursor() as cursor:
+            cursor.execute("SELECT @@SQL_MODE")
+            mode = cursor.fetchone()[0]
+
+        mode = mode.split(',')
+        self.assertIn(expected, mode)
+
+
+@override_mysql_variables(SQL_MODE="ANSI")
+class OverrideVarsClassTest(OverrideVarsMethodTest):
+
+    def test_class_sets_ansi(self):
+        self.check_sql_mode("ANSI")
+
+    @override_mysql_variables(using='secondary', SQL_MODE='MSSQL')
+    def test_other_connection(self):
+        self.check_sql_mode("ANSI")
+        self.check_sql_mode("MSSQL", using='secondary')

--- a/tests/django_mysql_tests/test_test_utils.py
+++ b/tests/django_mysql_tests/test_test_utils.py
@@ -29,3 +29,9 @@ class OverrideVarsClassTest(OverrideVarsMethodTest):
     def test_other_connection(self):
         self.check_sql_mode("ANSI")
         self.check_sql_mode("MSSQL", using='secondary')
+
+    def test_it_fails_on_non_test_classes(self):
+        with self.assertRaises(Exception):
+            @override_mysql_variables(SQL_MODE="ANSI")
+            class MyClass(object):
+                pass

--- a/tests/django_mysql_tests/utils.py
+++ b/tests/django_mysql_tests/utils.py
@@ -1,12 +1,10 @@
 from contextlib import contextmanager
-from functools import wraps
 import sys
 
-from django.db import connections
-from django.db.utils import DEFAULT_DB_ALIAS
 from django.utils import six
 
 
+# Copied from Django 1.8
 @contextmanager
 def captured_output(stream_name):
     """Return a context manager used by captured_stdout/stdin/stderr
@@ -22,6 +20,7 @@ def captured_output(stream_name):
         setattr(sys, stream_name, orig_stdout)
 
 
+# Copied from Django 1.8
 def captured_stdout():
     """Capture the output of sys.stdout:
 
@@ -30,63 +29,3 @@ def captured_stdout():
        self.assertEqual(stdout.getvalue(), "hello\n")
     """
     return captured_output("stdout")
-
-
-class override_mysql_variables(object):
-    """
-    Based on Django's override_settings, but for connection settings. Give a
-    connection alias in using and variable=value pairs to save on that
-    connection. Keeps the old values MySQL-side using session variables of the
-    form @overridden_X.
-
-    Acts as either a decorator, or a context manager. If it's a decorator it
-    takes a function and returns a wrapped function. If it's a contextmanager
-    it's used with the ``with`` statement. In either event entering/exiting
-    are called before and after, respectively, the function/block is executed.
-    """
-    def __init__(self, using=DEFAULT_DB_ALIAS, **kwargs):
-        self.db = using
-        self.options = kwargs
-
-    def __enter__(self):
-        self.enable()
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.disable()
-
-    def __call__(self, test_func):
-        if isinstance(test_func, type):
-            raise Exception("This doesn't work with classes.")
-        else:
-            @wraps(test_func)
-            def inner(*args, **kwargs):
-                with self:
-                    return test_func(*args, **kwargs)
-            return inner
-
-    def save_options(self, test_func):
-        if test_func._overridden_settings is None:
-            test_func._overridden_settings = self.options
-        else:
-            # Duplicate dict to prevent subclasses from altering their parent.
-            test_func._overridden_settings = dict(
-                test_func._overridden_settings, **self.options)
-
-    def enable(self):
-        with connections[self.db].cursor() as cursor:
-
-            for key, value in self.options.iteritems():
-                cursor.execute(
-                    """SET @overridden_{} = @@{},
-                           @@{} = %s""".format(key, key, key),
-                    (value,)
-                )
-
-    def disable(self):
-        with connections[self.db].cursor() as cursor:
-
-            for key in self.options:
-                cursor.execute(
-                    """SET @@{} = @overridden_{},
-                           @overridden_{} = NULL""".format(key, key, key)
-                )


### PR DESCRIPTION
Make the new @override_mysql_variables test class/method decorator better (re-entrant, work on classes, fully tested), and public and documented, so others may use it.