### PR TITLE
Add CRC64 function

### DIFF
--- a/django_mysql/models/functions.py
+++ b/django_mysql/models/functions.py
@@ -47,6 +47,12 @@ class CRC32(SingleArgFunc):
     output_field_class = IntegerField
 
 
+class CRC64(SingleArgFunc):
+    # Nabbed from common_schema
+    template = 'CONV(LEFT(MD5(%(expressions)s), 16), 16, 10)'
+    output_field_class = IntegerField
+
+
 class Floor(SingleArgFunc):
     function = 'FLOOR'
     output_field_class = IntegerField
@@ -92,7 +98,6 @@ class ConcatWS(Func):
 
 
 # Encryption Functions
-
 
 class MD5(SingleArgFunc):
     function = 'MD5'

--- a/tests/django_mysql_tests/test_functions.py
+++ b/tests/django_mysql_tests/test_functions.py
@@ -7,15 +7,19 @@ from django.db.models import F
 from django.test import TestCase
 
 from django_mysql.models.functions import (
-    Abs, ConcatWS, Ceiling, CRC32, Floor, Greatest, Least, MD5, Round, SHA1,
-    SHA2, Sign
+    Abs, ConcatWS, Ceiling, CRC32, CRC64, Floor, Greatest, Least, MD5, Round,
+    SHA1, SHA2, Sign
 )
 
 from django_mysql_tests.models import Alphabet
 
+requiresDatabaseFunctions = skipIf(
+    django.VERSION <= (1, 8),
+    "Requires Database Functions from Django 1.8+"
+)
 
-@skipIf(django.VERSION <= (1, 8),
-        "Requires Database Functions from Django 1.8+")
+
+@requiresDatabaseFunctions
 class ComparisonFunctionTests(TestCase):
 
     def test_greatest(self):
@@ -33,8 +37,7 @@ class ComparisonFunctionTests(TestCase):
         self.assertEqual(ab.worst, -1)
 
 
-@skipIf(django.VERSION <= (1, 8),
-        "Requires Database Functions from Django 1.8+")
+@requiresDatabaseFunctions
 class NumericFunctionTests(TestCase):
 
     def test_abs(self):
@@ -60,6 +63,11 @@ class NumericFunctionTests(TestCase):
 
         with self.assertRaises(TypeError):
             CRC32('d', something='wrong')
+
+    def test_crc64(self):
+        Alphabet.objects.create(d='AAAAAA')
+        ab = Alphabet.objects.annotate(crc=CRC64('d')).first()
+        self.assertEqual(ab.crc, 3949738913324149874)
 
     def test_floor(self):
         Alphabet.objects.create(g=1.5)
@@ -93,8 +101,7 @@ class NumericFunctionTests(TestCase):
         self.assertEqual(ab.csign, -1)
 
 
-@skipIf(django.VERSION <= (1, 8),
-        "Requires Database Functions from Django 1.8+")
+@requiresDatabaseFunctions
 class StringFunctionTests(TestCase):
 
     def test_concat_ws(self):
@@ -155,8 +162,7 @@ class StringFunctionTests(TestCase):
         self.assertEqual(ab.de, 'AAA:BBB')
 
 
-@skipIf(django.VERSION <= (1, 8),
-        "Requires Database Functions from Django 1.8+")
+@requiresDatabaseFunctions
 class EncryptionFunctionTests(TestCase):
 
     def test_md5_string(self):


### PR DESCRIPTION
From #52 - copied the definition out from common schema. Can be more useful than CRC32 for group-by hashing etc. so keeping it!