### PR TITLE
Fix race condition possibility in SmartChunkedIterator.get_min_and_max

### DIFF
--- a/django_mysql/models/query.py
+++ b/django_mysql/models/query.py
@@ -212,7 +212,13 @@ class SmartChunkedIterator(object):
             # We're working on an empty QuerySet, yield no chunks
             max_pk = min_pk = 0
         else:
-            max_pk = max_qs[0]
+            try:
+                max_pk = max_qs[0]
+            except IndexError:
+                # Fix possible race condition - max_qs could find nothing if
+                # all rows (including that with id min_pk) were processed
+                # between finding min_pk and the above [0]
+                max_pk = min_pk
 
         return (min_pk, max_pk)
 


### PR DESCRIPTION
Race condition spotted in the wild - if all the matching objects are deleted between finding the min and max PKs to iterate over when starting a SmartChunkedIterator, IndexError is raised. Fix that by catching it and re-using min_pk as max_pk.