### PR TITLE
Travis tests MariaDB 5.5 again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ language: python
 env:
   - "DB=mysql DB_VERSION=5.5"
   - "DB=mysql DB_VERSION=5.6"
-  # apt repo seems to be broken
-  # - "DB=mariadb DB_VERSION=5.5"
+  - "DB=mariadb DB_VERSION=5.5"
   - "DB=mariadb DB_VERSION=10.0"
   - "DB=mariadb DB_VERSION=10.1"
 


### PR DESCRIPTION
The apt repo seems to have broken. Keeping this open as a pull request and hitting rebuild on travis til it works again - otherwise more drastic changes may be required.