### PR TITLE
Add DynamicField for MariaDB Dynamic Columns

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,8 @@ History
 -----------------------
 
 * Pending release
+* Added ``DynamicField`` for using MariaDB's Named Dynamic Columns, and related
+  database functions ``ColumnAdd``, ``ColumnDelete``, and ``ColumnGet``.
 * ``SmartChunkedIterator`` with ``report_progress=True`` correctly reports
   'lowest pk so far' when iterating in reverse.
 * Fix broken import paths during ``deconstruct()`` for subclasses of all

--- a/django_mysql/models/__init__.py
+++ b/django_mysql/models/__init__.py
@@ -8,6 +8,7 @@ from django_mysql.models.query import (  # noqa
     QuerySet, QuerySetMixin
 )
 from django_mysql.models.fields import (  # noqa
-    Bit1BooleanField, ListCharField, ListTextField, NullBit1BooleanField,
-    SetCharField, SetTextField, SizedBinaryField, SizedTextField,
+    Bit1BooleanField, DynamicField, ListCharField, ListTextField,
+    NullBit1BooleanField, SetCharField, SetTextField, SizedBinaryField,
+    SizedTextField,
 )

--- a/django_mysql/models/fields/__init__.py
+++ b/django_mysql/models/fields/__init__.py
@@ -1,6 +1,7 @@
 from django_mysql.models.fields.bit import (  # noqa
     Bit1BooleanField, NullBit1BooleanField
 )
+from django_mysql.models.fields.dynamic import DynamicField  # noqa
 from django_mysql.models.fields.lists import (  # noqa
     ListCharField, ListTextField
 )

--- a/django_mysql/models/fields/dynamic.py
+++ b/django_mysql/models/fields/dynamic.py
@@ -1,0 +1,346 @@
+# -*- coding:utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+import json
+from copy import copy
+from datetime import date, datetime, time
+
+import django
+from django.core import checks
+from django.db import connections
+from django.db.models import (
+    DateField, DateTimeField, Field, FloatField, IntegerField, TextField,
+    TimeField, Transform
+)
+from django.utils import six
+from django.utils.translation import ugettext_lazy as _
+
+from django_mysql.compat import field_class
+from django_mysql.models.lookups import DynColHasKey
+
+try:
+    import mariadb_dyncol
+except ImportError:  # pragma: no cover
+    mariadb_dyncol = None
+
+
+class DynamicField(field_class(Field)):
+    empty_strings_allowed = False
+    description = _("Mapping")
+
+    def __init__(self, *args, **kwargs):
+        if 'default' not in kwargs:
+            kwargs['default'] = dict
+        if 'blank' not in kwargs:
+            kwargs['blank'] = True
+        self.spec = kwargs.pop('spec', None)
+        super(DynamicField, self).__init__(*args, **kwargs)
+
+    def check(self, **kwargs):
+        errors = super(DynamicField, self).check(**kwargs)
+        errors.extend(self._check_mariadb_dyncol())
+
+        if django.VERSION[:2] >= (1, 8):
+            # These checks connect to the DB, which only works on Django 1.8+
+            errors.extend(self._check_mariadb_version())
+            errors.extend(self._check_character_set())
+
+        if self.spec is not None:
+            errors.extend(self._check_spec_recursively(self.spec))
+        return errors
+
+    def _check_mariadb_dyncol(self):
+        errors = []
+        if mariadb_dyncol is None:
+            errors.append(
+                checks.Error(
+                    "'mariadb_dyncol' is required to use DynamicField",
+                    hint="Install the 'mariadb_dyncol' library from 'pip'",
+                    obj=self,
+                    id='django_mysql.E012'
+                )
+            )
+        return errors
+
+    def _check_mariadb_version(self):
+        errors = []
+
+        any_conn_works = False
+        conn_names = ['default'] + list(set(connections) - {'default'})
+        for db in conn_names:
+            if (
+                connections[db].is_mariadb and
+                connections[db].mysql_version >= (10, 0, 1)
+            ):
+                any_conn_works = True
+
+        if not any_conn_works:
+            errors.append(
+                checks.Error(
+                    "MariaDB 10.0.1+ is required to use DynamicField",
+                    hint=None,
+                    obj=self,
+                    id='django_mysql.E013'
+                )
+            )
+        return errors
+
+    def _check_character_set(self):
+        errors = []
+
+        conn = None
+        conn_names = ['default'] + list(set(connections) - {'default'})
+        for db in conn_names:
+            if (
+                connections[db].is_mariadb and
+                connections[db].mysql_version >= (10, 0, 1)
+            ):
+                conn = connections[db]
+                break
+
+        if conn is not None:
+            with conn.cursor() as cursor:
+                cursor.execute("SELECT @@character_set_client")
+                charset = cursor.fetchone()[0]
+
+            if charset not in ('utf8', 'utf8mb4'):
+                errors.append(
+                    checks.Error(
+                        "The MySQL charset must be 'utf8' or 'utf8mb4' to "
+                        "use DynamicField",
+                        hint="You are currently connecting with the '{}' "
+                             "character set. Add "
+                             "'OPTIONS': {{'charset': 'utf8mb4'}}, to your "
+                             "DATABASES setting to fix this"
+                             .format(charset),
+                        obj=self,
+                        id='django_mysql.E014'
+                    )
+                )
+
+        return errors
+
+    def _check_spec_recursively(self, spec, path=''):
+        errors = []
+
+        if not isinstance(spec, dict):
+            errors.append(
+                checks.Error(
+                    "'spec' must be a dict",
+                    hint="The value passed is of type {}"
+                         .format(type(spec).__name__),
+                    obj=self,
+                    id='django_mysql.E009',
+                )
+            )
+            return errors
+
+        for key, value in six.iteritems(spec):
+            if not isinstance(key, six.string_types):
+                errors.append(
+                    checks.Error(
+                        "The key '{}' in 'spec{}' is not a string"
+                        .format(key, path),
+                        hint="'spec' keys must be of type {}, "
+                             "'{}' is of type {}"
+                             .format(six.string_types[0].__name__,
+                                     key,
+                                     type(key).__name__),
+                        obj=self,
+                        id='django_mysql.E010',
+                    )
+                )
+                continue
+
+            if isinstance(value, dict):
+                subpath = '{}.{}'.format(path, key)
+                errors.extend(self._check_spec_recursively(value, subpath))
+            elif value not in KeyTransform.SPEC_MAP:
+                errors.append(
+                    checks.Error(
+                        "The value for '{}' in 'spec{}' is not an allowed type"
+                        .format(key, path),
+                        hint="'spec' values must be one of the following "
+                             "types: {}"
+                             .format(KeyTransform.SPEC_MAP_NAMES),
+                        obj=self,
+                        id='django_mysql.E011',
+                    )
+                )
+
+        return errors
+
+    def db_type(self, connection):
+        return 'mediumblob'
+
+    def get_transform(self, name):
+        transform = super(DynamicField, self).get_transform(name)
+        if transform:
+            return transform
+        if name in self.spec:
+            type_ = self.spec[name]
+            if isinstance(type_, dict):
+                # Nested dict
+                data_type = KeyTransform.SPEC_MAP[dict]
+                return KeyTransformFactory(name, data_type, subspec=type_)
+            else:
+                # Scalar type
+                return KeyTransformFactory(name, KeyTransform.SPEC_MAP[type_])
+
+        end = name.split('_')[-1]
+        if end in KeyTransform.TYPE_MAP and len(name) > len(end):
+            return KeyTransformFactory(
+                key_name=name[:-len(end) - 1],  # '_' + data_type
+                data_type=end,
+            )
+
+    def to_python(self, value):
+        if isinstance(value, six.binary_type):
+            return mariadb_dyncol.unpack(value)
+        elif isinstance(value, six.text_type):
+            return json.loads(value)  # serialization framework
+        return value
+
+    def from_db_value(self, value, expression, connection, context):
+        # Used to always convert a value from the database
+        return self.to_python(value)
+
+    def get_prep_value(self, value):
+        value = super(DynamicField, self).get_prep_value(value)
+        if isinstance(value, dict):
+            self.validate_spec(self.spec, value)
+            return mariadb_dyncol.pack(value)
+        return value
+
+    @classmethod
+    def validate_spec(cls, spec, value, prefix=''):
+        for key, subspec in six.iteritems(spec):
+            if key in value:
+
+                if isinstance(subspec, dict):
+                    expected_type = dict
+                elif subspec in six.integer_types:
+                    expected_type = six.integer_types
+                else:
+                    expected_type = subspec
+
+                if not isinstance(value[key], expected_type):
+                    if isinstance(expected_type, type):
+                        type_msg = expected_type.__name__
+                    else:
+                        type_msg = ','.join(e.__name__ for e in expected_type)
+                    raise TypeError(
+                        "Key '{}{}' should be of type {}"
+                        .format(prefix, key, type_msg)
+                    )
+
+                if isinstance(subspec, dict):
+                    cls.validate_spec(subspec, value[key], prefix + key + '.')
+
+    def get_internal_type(self):
+        return 'BinaryField'
+
+    def value_to_string(self, obj):
+        return json.dumps(self.value_from_object(obj))
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(DynamicField, self).deconstruct()
+
+        bad_paths = (
+            'django_mysql.models.fields.dynamic.' + self.__class__.__name__,
+            'django_mysql.models.fields.' + self.__class__.__name__
+        )
+        if path in bad_paths:
+            path = 'django_mysql.models.' + self.__class__.__name__
+
+        # Remove defaults
+        if 'default' in kwargs and kwargs['default'] is dict:
+            del kwargs['default']
+        if 'blank' in kwargs and kwargs['blank']:
+            del kwargs['blank']
+        return name, path, args, kwargs
+
+    def formfield(self, *args, **kwargs):
+        """
+        Disabled in forms - there is no sensible way of editing this
+        """
+        return None
+
+
+DynamicField.register_lookup(DynColHasKey)
+
+
+class KeyTransform(Transform):
+
+    SPEC_MAP = {
+        date: 'DATE',
+        datetime: 'DATETIME',
+        float: 'DOUBLE',
+        int: 'INTEGER',
+        six.text_type: 'CHAR',
+        time: 'TIME',
+        dict: 'BINARY',
+    }
+    if six.PY2:
+        from __builtin__ import long  # make source lintable on Python 3
+        SPEC_MAP[long] = 'INTEGER'
+
+    SPEC_MAP_NAMES = ', '.join(sorted(x.__name__ for x in
+                                      six.iterkeys(SPEC_MAP)))
+
+    TYPE_MAP = {
+        'BINARY': DynamicField,
+        'CHAR': TextField(),
+        'DATE': DateField(),
+        'DATETIME': DateTimeField(),
+        'DOUBLE': FloatField(),
+        'INTEGER': IntegerField(),
+        'TIME': TimeField(),
+    }
+
+    def __init__(self, key_name, data_type, *args, **kwargs):
+        subspec = kwargs.pop('subspec', None)
+        super(KeyTransform, self).__init__(*args, **kwargs)
+        self.key_name = key_name
+        self.data_type = data_type
+
+        try:
+            output_field = self.TYPE_MAP[data_type]
+        except KeyError:  # pragma: no cover
+            raise ValueError("Invalid data_type '{}'".format(data_type))
+
+        if data_type == 'BINARY':
+            self.output_field = output_field(spec=subspec)
+        else:
+            self.output_field = output_field
+
+    def as_sql(self, compiler, connection):
+        lhs, params = compiler.compile(self.lhs)
+        return (
+            "COLUMN_GET({}, %s AS {})".format(lhs, self.data_type),
+            params + [self.key_name]
+        )
+
+    if django.VERSION[:3] <= (1, 8, 2):
+        # Backport of bugfix for transforms with arguments, taken from:
+        # https://code.djangoproject.com/ticket/24744
+        def copy(self):
+            return copy(self)
+
+        def relabeled_clone(self, relabels):
+            copy = self.copy()
+            copy.lhs = self.lhs.relabeled_clone(relabels)
+            return copy
+
+
+class KeyTransformFactory(object):
+
+    def __init__(self, key_name, data_type, subspec=None):
+        self.key_name = key_name
+        self.data_type = data_type
+        self.subspec = subspec
+
+    def __call__(self, *args, **kwargs):
+        if self.subspec is not None:
+            kwargs['subspec'] = self.subspec
+        return KeyTransform(self.key_name, self.data_type, *args, **kwargs)

--- a/django_mysql/models/lookups.py
+++ b/django_mysql/models/lookups.py
@@ -45,3 +45,13 @@ class SetContains(Lookup):
 
 class SetIContains(SetContains):
     lookup_name = 'icontains'
+
+
+class DynColHasKey(Lookup):
+    lookup_name = 'has_key'
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = lhs_params + rhs_params
+        return 'COLUMN_EXISTS(%s, %s)' % (lhs, rhs), params

--- a/docs/model_fields.rst
+++ b/docs/model_fields.rst
@@ -10,6 +10,220 @@ More ways to store data! The following can be imported from
 
 .. currentmodule:: django_mysql.models
 
+.. _dynamic-columns-field:
+
+------------
+DynamicField
+------------
+
+**MariaDB** has a feature called **Dynamic Columns** that allows you to store
+different sets of columns for each row in a table. It works by storing the data
+in a blob and having a small set of functions to manipulate this blob.
+(`Docs <https://mariadb.com/kb/en/mariadb/dynamic-columns/>`_).
+
+Django-MySQL supports the *named* Dynamic Columns of MariaDB 10.0+, as opposed
+to the *numbered* format of 5.5+. It uses the
+`mariadb-dyncol <https://pypi.python.org/pypi/mariadb-dyncol>`_ python package
+to pack and unpack Dynamic Columns blobs in Python rather than in MariaDB
+(mostly due to limitations in the Django ORM).
+
+
+.. class:: DynamicField(spec=None, **kwargs)
+
+    A field for storing Dynamic Columns. The Python data type is ``dict``. Keys
+    must be ``str``\s (``unicode`` on Python 2) and values must be one of the
+    supported value types in ``mariadb-dyncol``:
+
+    * ``str`` (``unicode`` on Python 2)
+    * ``int`` (and also ``long`` on Python 2)
+    * ``float``
+    * ``datetime.date``
+    * ``datetime.datetime``
+    * ``datetime.datetime``
+    * A nested dict conforming to thsi spec too
+
+    Note that there are restrictions on the range of values supported for some
+    of these types, and that ``decimal.Decimal`` objects are not yet supported
+    though they are valid in MariaDB. For more information consult the
+    ``mariadb-dyncol`` documentation.
+
+    Values may also be ``None``, though they will then not be stored, since
+    dynamic columns do not store ``NULL``, so you should use ``.get()`` to
+    retrieve values that may be ``None``.
+
+    To use this field, you'll need to:
+
+    1. Use MariaDB 10.0.2+
+    2. Install ``mariadb-dyncol`` (``pip install mariadb-dyncol``)
+    3. Use either the ``utf8mb4`` or ``utf8`` character set for your
+       database connection.
+
+    These are all checked by the field and you will see sensible errors for
+    them when Django's checks run if you have a ``DynamicField`` on a model.
+
+    .. attribute:: spec
+
+        This is an optional type specification that checks that the named
+        columns, if present, have the given types. It is validated against on
+        ``save()`` to ensure type safety (unlike normal Django validation which
+        is only used in forms). It is also used for type information for
+        lookups (below).
+
+        ``spec`` should be a ``dict`` with string keys and values that are the
+        type classes you expect. You can also nest another such dictionary as a
+        value for validating nested dynamic columns.
+
+        For example:
+
+        .. code-block:: python
+
+            import datetime
+
+            class SpecModel(Model):
+                attrs = DynamicField(spec={
+                    'an_integer_key': int,
+                    'created_at': datetime.datetime,
+                    'nested_columns': {
+                        'lat': int,
+                        'lon': int,
+                    }
+                })
+
+        This will enforce the following rules:
+
+        * ``instance.attrs['an_integer_key']``, if present, is an ``int``
+        * ``instance.attrs['created_at']``, if present, is an ``datetime.datetime``
+        * ``instance.attrs['nested_columns']``, if present, is a ``dict``
+        * ``instance.attrs['nested_columns']['lat']``, if present, is an ``int``
+        * ``instance.attrs['nested_columns']['lon']``, if present, is an ``int``
+
+        Trying to save a ``DynamicField`` with data that does not match the
+        rules of its ``spec`` will raise ``TypeError``. There is no automatic
+        casting, e.g. between ``int`` and ``float``. Note that columns not in
+        ``spec`` will still be allowed and have no type enforced.
+
+        For example:
+
+        .. code-block:: python
+
+            >>> SpecModel.objects.create(attrs={'an_integer_key': 1})  # Fine
+            >>> SpecModel.objects.create(attrs={'an_integer_key': 2.0})
+            Traceback (most recent call last):
+            ...
+            TypeError: Key 'an_integer_key' should be of type 'int'
+            >>> SpecModel.objects.create(attrs={'non_spec_key': 'anytype'})  # Fine
+
+DynamicFields in Forms
+----------------------
+
+By default a ``DynamicField`` has no form field, because there isn't really a
+practical way to edit its contents. If required, is possible to add extra form
+fields to a ``ModelForm`` that then update specific dynamic column names on the
+instance in the form's ``save()``.
+
+Querying DynamicField
+---------------------
+
+You can query by names, including nested names. In cases where names collide
+with existing lookups (e.g. you have a column named ``'exact'``), you might
+want to use the :class:`~django_mysql.models.functions.ColumnGet` database
+function. You can also use the
+:class:`~django_mysql.models.functions.ColumnAdd` and
+:class:`~django_mysql.models.functions.ColumnDelete` functions for atomically
+modifying the contents of dynamic columns at the database layer.
+
+We'll use the following example model:
+
+.. code-block:: python
+
+    from django_mysql.models import DynamicField, Model
+
+    class ShopItem(Model):
+        name = models.CharField(max_length=200)
+        attrs = DynamicField(spec={
+            'size': str,
+        })
+
+        def __str__(self):  # __unicode__ on Python 2
+            return self.name
+
+Exact Lookups
+~~~~~~~~~~~~~
+
+To query based on an exact match, just use a dictionary.
+
+For example:
+
+.. code-block:: python
+
+    >>> ShopItem.objects.create(name='Camembert', {'smelliness': 15})
+    >>> ShopItem.objects.create(name='Cheddar', {'smelliness': 15, 'hardness': 5})
+
+    >>> ShopItem.objects.filter(attrs={'smelliness': 15})
+    [<ShopItem: Camembert>]
+    >>> ShopItem.objects.filter(attrs={'smelliness': 15, 'hardness': 5})
+    [<ShopItem: Cheddar>]
+
+
+Name Lookups
+~~~~~~~~~~~~
+
+To query based on a column name, use that name as a lookup with one of the
+below SQL types added after an underscore. If the column name is in your
+field's ``spec``, you can omit the SQL type and it will be extracted
+automatically - this includes keys in nested ``dict``\s.
+
+The list of SQL types is:
+
+* ``BINARY`` - ``dict`` (a nested ``DynamicField``)
+* ``CHAR`` - ``str`` (``unicode`` on Python 2)
+* ``DATE`` - ``datetime.date``
+* ``DATETIME`` - ``datetime.datetime``
+* ``DOUBLE`` - ``float``
+* ``INTEGER`` - ``int`` (and also ``long`` on Python 2)
+* ``TIME`` - ``datetime.time``
+
+These will also use the correct Django ORM field so chained lookups based on
+that type are possible, e.g. ``dynamicfield__age_INTEGER__gte=20``.
+
+Beware that getting a named column can always return ``NULL`` if the column is
+not defined for a row.
+
+For example:
+
+.. code-block:: python
+
+    >>> ShopItem.objects.create(name='T-Shirt', {'size': 'Large'})
+    >>> ShopItem.objects.create(name='Rocketship', {
+    ...     'speed_mph': 300,
+    ...     'dimensions': {'width_m': 10, 'height_m': 50}
+    ... })
+
+    # Basic template: DynamicField + '__' + column name + '_' + SQL type
+    >>> ShopItem.objects.filter(attrs__size_CHAR='Large')
+    [<ShopItem: T-Shirt>]
+
+    # As 'size' is in the field's spec, there is no need to give the SQL type
+    >>> ShopItem.objects.filter(attrs__size='Large')
+    [<ShopItem: T-Shirt>]
+
+    # Chained lookups are possible based on the data type
+    >>> ShopItem.objects.filter(attrs__speed_mph_INTEGER__gte=100)
+    [<ShopItem: Rocketship>]
+
+    # Nested keys can be looked up
+    >>> ShopItem.objects.filter(attrs__dimensions_BINARY__width_m_INTEGER=10)
+    [<ShopItem: Rocketship>]
+
+    # Nested DynamicFields can be queried as ``dict``s, as per the ``exact`` lookup
+    >>> ShopItem.objects.filter(attrs__dimensions_BINARY={'width_m': 10, 'height_m': 50})
+    [<ShopItem: Rocketship>]
+
+    # Missing keys are always NULL
+    >>> ShopItem.objects.filter(attrs__blablabla_INTEGER__isnull=True)
+    [<ShopItem: T-Shirt>, <ShopItem: Rocketship>]
+
+
 .. _list-fields:
 
 -----------

--- a/requirements/requirements-testing.txt
+++ b/requirements/requirements-testing.txt
@@ -2,6 +2,7 @@ ddt==1.0.0
 docutils==0.12
 flake8==2.4.1
 funcsigs==0.4
+mariadb-dyncol==1.1.0
 mock==1.3.0
 mysqlclient==1.3.6
 pbr==1.8.1

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,13 +1,15 @@
 # -*- coding:utf-8 -*-
+from datetime import date, datetime, time
+
 from django.db.models import Model as VanillaModel
 from django.db.models import (
     CharField, DateTimeField, DecimalField, ForeignKey, IntegerField,
     TextField
 )
-from django.utils import timezone
+from django.utils import six, timezone
 
 from django_mysql.models import (
-    Bit1BooleanField, ListCharField, ListTextField, Model,
+    Bit1BooleanField, DynamicField, ListCharField, ListTextField, Model,
     NullBit1BooleanField, SetCharField, SetTextField, SizedBinaryField,
     SizedTextField
 )
@@ -91,6 +93,28 @@ class BigIntSetModel(Model):
 
 class BigIntListModel(Model):
     field = ListTextField(base_field=IntegerField())
+
+
+class DynamicModel(Model):
+    attrs = DynamicField(
+        spec={
+            'datetimey': datetime,
+            'datey': date,
+            'floaty': float,
+            'inty': int,
+            'stry': six.text_type,
+            'timey': time,
+            'nesty': {
+                'level2': six.text_type
+            }
+        }
+    )
+
+    def __unicode__(self):
+        return ",".join(
+            '{}:{}'.format(key, value)
+            for key, value in six.iteritems(self.attrs)
+        )
 
 
 class Author(Model):

--- a/tests/testapp/test_dynamicfield.py
+++ b/tests/testapp/test_dynamicfield.py
@@ -1,0 +1,507 @@
+# -*- coding:utf-8 -*-
+from __future__ import unicode_literals
+
+import json
+import mock
+from datetime import date, datetime, time
+from unittest import SkipTest, skipIf
+
+import django
+import pytest
+from django.core import serializers
+from django.db import connection, connections
+from django.db.migrations.writer import MigrationWriter
+from django.db.models import CharField, Transform
+from django.test import TestCase
+from django.utils import six
+
+from django_mysql.models import DynamicField
+from testapp.models import DynamicModel, TemporaryModel
+from testapp.utils import requiresPython2
+
+
+class DynColTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        if not (
+            connection.is_mariadb and
+            connection.mysql_version >= (10, 0, 1)
+        ):
+            raise SkipTest("Dynamic Columns require MariaDB 10.0.1+")
+        super(DynColTestCase, cls).setUpClass()
+
+
+class TestSaveLoad(DynColTestCase):
+
+    def test_save_and_mutations(self):
+        s = DynamicModel.objects.create()
+        assert s.attrs == {}
+
+        s = DynamicModel.objects.get()
+        assert s.attrs == {}
+
+        s.attrs['key'] = 'value!'
+        s.attrs['2key'] = 23
+        s.save()
+        s = DynamicModel.objects.get()
+        assert s.attrs == {'key': 'value!', '2key': 23}
+
+        del s.attrs['key']
+        s.save()
+        s = DynamicModel.objects.get()
+        assert s.attrs == {'2key': 23}
+
+        del s.attrs['2key']
+        s.save()
+        s = DynamicModel.objects.get()
+        assert s.attrs == {}
+
+    def test_create(self):
+        DynamicModel.objects.create(attrs={
+            'a': 'value'
+        })
+        s = DynamicModel.objects.get()
+        assert s.attrs == {'a': 'value'}
+
+    def test_create_succeeds_specced_field(self):
+        DynamicModel.objects.create(attrs={'inty': 1})
+        s = DynamicModel.objects.get()
+        assert s.attrs == {'inty': 1}
+
+    def test_create_fails_bad_value(self):
+        with pytest.raises(TypeError):
+            DynamicModel.objects.create(attrs={'inty': 1.0})
+
+    def test_bulk_create(self):
+        DynamicModel.objects.bulk_create([
+            DynamicModel(attrs={'a': 'value'}),
+            DynamicModel(attrs={'b': 'value2'}),
+        ])
+        dm1, dm2 = DynamicModel.objects.all().order_by('id')
+        assert dm1.attrs == {'a': 'value'}
+        assert dm2.attrs == {'b': 'value2'}
+
+
+class SpecTests(DynColTestCase):
+
+    def test_spec_dict_type(self):
+        DynamicField.validate_spec(
+            {'a': dict},
+            {'a': {'this': 'that'}}
+        )  # no errors
+
+    def test_illegal_int(self):
+        m = DynamicModel(attrs={'inty': 1.0})
+        with pytest.raises(TypeError) as excinfo:
+            m.save()
+        assert "Key 'inty' should be of type int" in str(excinfo.value)
+
+    def test_illegal_nested(self):
+        m = DynamicModel(attrs={'nesty': {'level2': 1}})
+        with pytest.raises(TypeError) as excinfo:
+            m.save()
+        assert "Key 'nesty.level2' should be of type " in str(excinfo.value)
+
+    def test_illegal_nested_type(self):
+        m = DynamicModel(attrs={'nesty': []})
+        with pytest.raises(TypeError) as excinfo:
+            m.save()
+        assert "Key 'nesty' should be of type dict" in str(excinfo.value)
+
+    @requiresPython2
+    def test_long_equivalent_to_int(self):
+        from __builtin__ import long  # make source lintable on Python 3
+        DynamicField.validate_spec({'a': int}, {'a': long(9001)})  # no errors
+
+    @requiresPython2
+    def test_int_equivalent_to_long(self):
+        from __builtin__ import long  # make source lintable on Python 3
+        DynamicField.validate_spec({'a': long}, {'a': int(9001)})  # no errors
+
+
+class DumbTransform(Transform):
+    """
+    Used to test existing transform behaviour - by default in Django there are
+    no transforms on BinaryField.
+    Really dumb, returns the string 'dumb' always
+    """
+    lookup_name = 'dumb'
+    output_field = CharField()
+
+    def as_sql(self, compiler, connection):
+        lhs, params = compiler.compile(self.lhs)
+        return "%s", ['dumb']
+
+DynamicField.register_lookup(DumbTransform)
+
+
+class QueryTests(DynColTestCase):
+
+    def setUp(self):
+        super(QueryTests, self).setUp()
+        self.objs = [
+            DynamicModel(attrs={'a': 'b'}),
+            DynamicModel(attrs={'a': 'b', 'c': 'd'}),
+            DynamicModel(attrs={'c': 'd'}),
+            DynamicModel(attrs={}),
+            DynamicModel(attrs={
+                'datetimey': datetime(2001, 1, 4, 14, 15, 16),
+                'datey': date(2001, 1, 4),
+                'floaty': 128.5,
+                'inty': 9001,
+                'stry': "strvalue",
+                'str_underscorey': "strvalue2",
+                'timey': time(14, 15, 16),
+                'nesty': {
+                    'level2': 'chirp'
+                }
+            }),
+        ]
+        DynamicModel.objects.bulk_create(self.objs)
+        self.objs = list(DynamicModel.objects.all().order_by('id'))
+
+    def test_equal(self):
+        assert (
+            list(DynamicModel.objects.filter(attrs={'a': 'b'})) ==
+            self.objs[:1]
+        )
+
+    def test_exact(self):
+        assert (
+            list(DynamicModel.objects.filter(attrs__exact={'a': 'b'})) ==
+            self.objs[:1]
+        )
+
+    def test_preexisting_transforms_work_fine(self):
+        assert (
+            list(DynamicModel.objects.filter(attrs__dumb='notdumb')) ==
+            []
+        )
+
+    def test_has_key(self):
+        assert (
+            list(DynamicModel.objects.filter(attrs__has_key='c')) ==
+            self.objs[1:3]
+        )
+
+    def test_key_transform_datey(self):
+        assert (
+            list(DynamicModel.objects.filter(attrs__datey=date(2001, 1, 4))) ==
+            [self.objs[4]]
+        )
+
+    def test_key_transform_datey_DATE(self):
+        assert (
+            list(DynamicModel.objects.filter(
+                attrs__datey_DATE=date(2001, 1, 4)
+            )) ==
+            [self.objs[4]]
+        )
+
+    def test_key_transform_datetimey(self):
+        assert (
+            list(DynamicModel.objects.filter(
+                attrs__datetimey=datetime(2001, 1, 4, 14, 15, 16)
+            )) ==
+            [self.objs[4]]
+        )
+
+    def test_key_transform_datetimey__year(self):
+        assert (
+            list(DynamicModel.objects.filter(attrs__datetimey__year=2001)) ==
+            [self.objs[4]]
+        )
+
+    def test_key_transform_datetimey_DATETIME(self):
+        assert (
+            list(DynamicModel.objects.filter(
+                attrs__datetimey_DATETIME=datetime(2001, 1, 4, 14, 15, 16)
+            )) ==
+            [self.objs[4]]
+        )
+
+    def test_key_transform_floaty(self):
+        assert (
+            list(DynamicModel.objects.filter(attrs__floaty__gte=128.0)) ==
+            [self.objs[4]]
+        )
+
+    def test_key_transform_floaty_DOUBLE(self):
+        assert (
+            list(DynamicModel.objects.filter(attrs__floaty_DOUBLE=128.5)) ==
+            [self.objs[4]]
+        )
+
+    def test_key_transform_inty(self):
+        assert (
+            list(DynamicModel.objects.filter(attrs__inty=9001)) ==
+            [self.objs[4]]
+        )
+
+    def test_key_transform_inty_INTEGER(self):
+        assert (
+            list(DynamicModel.objects.filter(attrs__inty_INTEGER=9001)) ==
+            [self.objs[4]]
+        )
+
+    def test_key_transform_inty_no_results(self):
+        assert (
+            list(DynamicModel.objects.filter(attrs__inty=12991)) ==
+            []
+        )
+
+    def test_key_transform_inty_in_subquery(self):
+        assert (
+            list(DynamicModel.objects.filter(
+                id__in=DynamicModel.objects.filter(attrs__inty=9001),
+            )) ==
+            [self.objs[4]]
+        )
+
+    def test_key_transform_miss_CHAR_isnull(self):
+        assert (
+            list(DynamicModel.objects.filter(attrs__miss_CHAR__isnull=True)) ==
+            self.objs
+        )
+
+    def test_key_transform_stry(self):
+        assert (
+            list(DynamicModel.objects.filter(attrs__stry="strvalue")) ==
+            [self.objs[4]]
+        )
+
+    def test_key_transform_stry_CHAR(self):
+        assert (
+            list(DynamicModel.objects.filter(attrs__stry_CHAR="strvalue")) ==
+            [self.objs[4]]
+        )
+
+    def test_key_transform_str_underscorey_CHAR(self):
+        # Check that underscores in key names are parsed fine
+        assert (
+            list(DynamicModel.objects.filter(
+                attrs__str_underscorey_CHAR="strvalue2"
+            )) ==
+            [self.objs[4]]
+        )
+
+    def test_key_transform_timey(self):
+        assert (
+            list(DynamicModel.objects.filter(attrs__timey=time(14, 15, 16))) ==
+            [self.objs[4]]
+        )
+
+    def test_key_transform_timey_TIME(self):
+        assert (
+            list(DynamicModel.objects.filter(
+                attrs__timey_TIME=time(14, 15, 16)
+            )) ==
+            [self.objs[4]]
+        )
+
+    def test_key_transform_nesty__level2(self):
+        assert (
+            list(DynamicModel.objects.filter(
+                attrs__nesty__level2='chirp'
+            )) ==
+            [self.objs[4]]
+        )
+
+    def test_key_transform_nesty__level2__startswith(self):
+        assert (
+            list(DynamicModel.objects.filter(
+                attrs__nesty__level2__startswith='chi'
+            )) ==
+            [self.objs[4]]
+        )
+
+requiresDBChecks = skipIf(
+    django.VERSION[:2] < (1, 8),
+    "Requires ability to talk to DB in checks from Django 1.8+"
+)
+
+
+class TestCheck(DynColTestCase):
+
+    wrapper_path = 'django.db.backends.mysql.base.DatabaseWrapper'
+
+    @requiresDBChecks
+    @mock.patch(wrapper_path + '.is_mariadb', new=False)
+    def test_db_not_mariadb(self):
+        # Uncache cached_property
+        for db in connections:
+            if 'is_mariadb' in connections[db].__dict__:
+                del connections[db].__dict__['is_mariadb']
+
+        errors = DynamicModel.check()
+        assert len(errors) == 1
+        assert errors[0].id == 'django_mysql.E013'
+        assert "MariaDB 10.0.1+ is required" in errors[0].msg
+
+    @requiresDBChecks
+    @mock.patch(wrapper_path + '.mysql_version', new=(5, 5, 3))
+    def test_mariadb_old_version(self):
+        # Uncache cached_property
+        for db in connections:
+            if 'mysql_version' in connections[db].__dict__:
+                del connections[db].__dict__['mysql_version']
+
+        errors = DynamicModel.check()
+        assert len(errors) == 1
+        assert errors[0].id == 'django_mysql.E013'
+        assert "MariaDB 10.0.1+ is required" in errors[0].msg
+
+    @requiresDBChecks
+    @mock.patch(DynamicField.__module__ + '.mariadb_dyncol', new=None)
+    def test_mariadb_dyncol_missing(self):
+        errors = DynamicModel.check()
+        assert len(errors) == 1
+        assert errors[0].id == 'django_mysql.E012'
+        assert "'mariadb_dyncol' is required" in errors[0].msg
+
+    @requiresDBChecks
+    def test_character_set_not_utf8_compatible(self):
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT @@character_set_client")
+            orig_charset = cursor.fetchone()[0]
+            cursor.execute("SET NAMES 'latin1'")
+            try:
+                errors = DynamicModel.check()
+            finally:
+                cursor.execute("SET NAMES '{}'".format(orig_charset))
+
+        assert len(errors) == 1
+        assert errors[0].id == 'django_mysql.E014'
+        assert "The MySQL charset must be 'utf8'" in errors[0].msg
+
+    def test_spec_not_dict(self):
+        class InvalidDynamicModel(TemporaryModel):
+            field = DynamicField(spec=['woops', 'a', 'list'])
+
+        errors = InvalidDynamicModel.check(actually_check=True)
+        assert len(errors) == 1
+        assert errors[0].id == 'django_mysql.E009'
+        assert "'spec' must be a dict" in errors[0].msg
+        assert "The value passed is of type list" in errors[0].hint
+
+    def test_spec_key_not_valid(self):
+        class InvalidDynamicModel(TemporaryModel):
+            field = DynamicField(spec={
+                2.0: six.text_type
+            })
+
+        errors = InvalidDynamicModel.check(actually_check=True)
+        assert len(errors) == 1
+        assert errors[0].id == 'django_mysql.E010'
+        assert "The key '2.0' in 'spec' is not a string" in errors[0].msg
+        assert "'spec' keys must be of type " in errors[0].hint
+        assert "'2.0' is of type float" in errors[0].hint
+
+    def test_spec_value_not_valid(self):
+        class InvalidDynamicModel(TemporaryModel):
+            field = DynamicField(spec={'bad': list})
+
+        errors = InvalidDynamicModel.check(actually_check=True)
+        assert len(errors) == 1
+        assert errors[0].id == 'django_mysql.E011'
+        assert (
+            "The value for 'bad' in 'spec' is not an allowed type" in
+            errors[0].msg
+        )
+        assert (
+            "'spec' values must be one of the following types: "
+            "date, datetime" in
+            errors[0].hint
+        )
+
+    def test_spec_nested_value_not_valid(self):
+        class InvalidDynamicModel(TemporaryModel):
+            field = DynamicField(spec={
+                'l1': {
+                    'bad': tuple
+                }
+            })
+
+        errors = InvalidDynamicModel.check(actually_check=True)
+        assert len(errors) == 1
+        assert errors[0].id == 'django_mysql.E011'
+        assert (
+            "The value for 'bad' in 'spec.l1' is not an allowed type" in
+            errors[0].msg
+        )
+        assert (
+            "'spec' values must be one of the following types: "
+            "date, datetime" in
+            errors[0].hint
+        )
+
+
+class SubDynamicField(DynamicField):
+    """
+    Used below, has a different path for deconstruct()
+    """
+
+
+class TestDeconstruct(TestCase):
+
+    def test_deconstruct(self):
+        field = DynamicField()
+        name, path, args, kwargs = field.deconstruct()
+        DynamicField(*args, **kwargs)
+
+    def test_deconstruct_spec(self):
+        field = DynamicField(spec={'this': int, 'that': float})
+        name, path, args, kwargs = field.deconstruct()
+        assert path == 'django_mysql.models.DynamicField'
+        DynamicField(*args, **kwargs)
+
+    def test_bad_import_deconstruct(self):
+        from django_mysql.models.fields import DynamicField as DField
+        field = DField()
+        name, path, args, kwargs = field.deconstruct()
+        assert path == 'django_mysql.models.DynamicField'
+
+    def test_bad_import2_deconstruct(self):
+        from django_mysql.models.fields.dynamic import DynamicField as DField
+        field = DField()
+        name, path, args, kwargs = field.deconstruct()
+        assert path == 'django_mysql.models.DynamicField'
+
+    def test_subclass_deconstruct(self):
+        field = SubDynamicField()
+        name, path, args, kwargs = field.deconstruct()
+        assert path == 'tests.testapp.test_dynamicfield.SubDynamicField'
+
+
+class TestMigrations(DynColTestCase):
+
+    def test_makemigrations(self):
+        field = DynamicField(spec={'a': 'beta'})
+        statement, imports = MigrationWriter.serialize(field)
+        # 'spec' should not appear since that would trigger needless ALTERs
+        assert statement == "django_mysql.models.DynamicField()"
+
+
+class TestSerialization(DynColTestCase):
+    test_data = '''
+        [{"fields": {"attrs": "{\\"a\\": \\"b\\"}"},
+          "model": "testapp.dynamicmodel", "pk": null}]
+    '''
+
+    def test_dumping(self):
+        instance = DynamicModel(attrs={'a': 'b'})
+        data = serializers.serialize('json', [instance])
+        assert json.loads(data) == json.loads(self.test_data)
+
+    def test_loading(self):
+        deserialized = list(serializers.deserialize('json', self.test_data))
+        instance = deserialized[0].object
+        assert instance.attrs == {'a': 'b'}
+
+
+class TestFormfield(DynColTestCase):
+    def test_formfield(self):
+        model_field = DynamicField()
+        form_field = model_field.formfield()
+        self.assertIsNone(form_field)

--- a/tests/testapp/utils.py
+++ b/tests/testapp/utils.py
@@ -1,9 +1,12 @@
 import sys
 from contextlib import contextmanager
+from unittest import skipUnless
 
 from django.db import DEFAULT_DB_ALIAS, connection, connections
 from django.test.utils import CaptureQueriesContext
 from django.utils import six
+
+requiresPython2 = skipUnless(six.PY2, "Python 2 only")
 
 
 # Copied from Django 1.8


### PR DESCRIPTION
Todo:

- [x] create/update/delete
- [x] Dynamic column functions as `Function`s
- [x] Copied and adapted [custom lookups](https://docs.djangoproject.com/en/1.8/ref/contrib/postgres/fields/#querying-hstorefield) from `django.contrib.postgres` `HStoreField` and `JSONField`
- [x] Field Docs
- [x] Function Docs