### PR TITLE
MySQLCache case sensitivity

### DIFF
--- a/django_mysql/cache.py
+++ b/django_mysql/cache.py
@@ -68,9 +68,11 @@ class MySQLCache(BaseDatabaseCache):
 
     create_table_sql = dedent('''\
         CREATE TABLE `{table_name}` (
-            cache_key varchar(255) CHARACTER SET utf8 NOT NULL PRIMARY KEY,
+            cache_key varchar(255) CHARACTER SET utf8 COLLATE utf8_bin
+                                   NOT NULL PRIMARY KEY,
             value longblob NOT NULL,
-            value_type char(1) CHARACTER SET latin1 NOT NULL DEFAULT 'p',
+            value_type char(1) CHARACTER SET latin1 COLLATE latin1_bin
+                               NOT NULL DEFAULT 'p',
             expires BIGINT UNSIGNED NOT NULL
         );
     ''')

--- a/tests/django_mysql_tests/test_functions.py
+++ b/tests/django_mysql_tests/test_functions.py
@@ -231,10 +231,10 @@ class InformationFunctionTests(TestCase):
         lid = LastInsertId.get()
         self.assertEqual(lid, 7891)
 
-    def test_last_insert_id_secondary_connection(self):
-        Alphabet.objects.using('secondary').create(a=9191)
-        Alphabet.objects.using('secondary').update(a=LastInsertId('a') + 9)
-        lid = LastInsertId.get(using='secondary')
+    def test_last_insert_id_other_db_connection(self):
+        Alphabet.objects.using('other').create(a=9191)
+        Alphabet.objects.using('other').update(a=LastInsertId('a') + 9)
+        lid = LastInsertId.get(using='other')
         self.assertEqual(lid, 9191)
 
     def test_last_insert_id_in_query(self):

--- a/tests/django_mysql_tests/test_handler.py
+++ b/tests/django_mysql_tests/test_handler.py
@@ -381,11 +381,11 @@ class HandlerStandaloneTests(TestCase):
 class HandlerMultiDBTests(TestCase):
 
     def setUp(self):
-        self.jk = Author.objects.using('secondary').create(name='JK Rowling')
+        self.jk = Author.objects.using('other').create(name='JK Rowling')
         self.grisham = Author.objects.create(name='John Grisham')
 
     def test_queryset_db_is_used(self):
-        handler = Author.objects.using('secondary').handler()
+        handler = Author.objects.using('other').handler()
         with handler:
             handler_result = handler.read()[0]
 

--- a/tests/django_mysql_tests/test_locks.py
+++ b/tests/django_mysql_tests/test_locks.py
@@ -150,7 +150,7 @@ class LockTests(TestCase):
 
     def test_multi_connection(self):
         lock_a = Lock("a")
-        lock_b = Lock("b", using='secondary')
+        lock_b = Lock("b", using='other')
 
         with lock_a, lock_b:
             # Different connections = can hold > 1!

--- a/tests/django_mysql_tests/test_status.py
+++ b/tests/django_mysql_tests/test_status.py
@@ -94,7 +94,7 @@ class GlobalStatusTests(TestCase):
         self.assertNotIn('1000000', message)
 
     def test_other_databases(self):
-        status = GlobalStatus(using='secondary')
+        status = GlobalStatus(using='other')
 
         running = status.get('Threads_running')
         self.assertTrue(isinstance(running, int))
@@ -131,7 +131,7 @@ class SessionStatusTests(TestCase):
         self.assertGreaterEqual(status_dict['Threads_running'], 1)
 
     def test_other_databases(self):
-        status = SessionStatus(using='secondary')
+        status = SessionStatus(using='other')
         running = status.get('Threads_running')
         self.assertTrue(isinstance(running, int))
         self.assertGreaterEqual(running, 1)

--- a/tests/django_mysql_tests/test_test_utils.py
+++ b/tests/django_mysql_tests/test_test_utils.py
@@ -25,10 +25,10 @@ class OverrideVarsClassTest(OverrideVarsMethodTest):
     def test_class_sets_ansi(self):
         self.check_sql_mode("ANSI")
 
-    @override_mysql_variables(using='secondary', SQL_MODE='MSSQL')
+    @override_mysql_variables(using='other', SQL_MODE='MSSQL')
     def test_other_connection(self):
         self.check_sql_mode("ANSI")
-        self.check_sql_mode("MSSQL", using='secondary')
+        self.check_sql_mode("MSSQL", using='other')
 
     def test_it_fails_on_non_test_classes(self):
         with self.assertRaises(Exception):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -23,7 +23,7 @@ DATABASES = {
             'CHARSET': "utf8mb4"
         }
     },
-    'secondary': {
+    'other': {
         'ENGINE': 'django.db.backends.mysql',
         'NAME': 'django_mysql2',
         'USER': '',


### PR DESCRIPTION
Both cache keys and value_types were not case sensitive at the database level - not good!