### PR TITLE
mysql_cache_migration outputs only one operation per table

### DIFF
--- a/django_mysql/management/commands/mysql_cache_migration.py
+++ b/django_mysql/management/commands/mysql_cache_migration.py
@@ -80,7 +80,7 @@ table_operation = '''
             """
 ''' + create_table_sql + '''
             """,
-            "DROP TABLE `{{ table }}`;"
+            "DROP TABLE `{{ table }}`"
         ),
 '''.rstrip()
 

--- a/django_mysql/management/commands/mysql_cache_migration.py
+++ b/django_mysql/management/commands/mysql_cache_migration.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
         else:
             names = settings.CACHES
 
-        tables = []
+        tables = set()
         for alias in names:
             try:
                 cache = caches[alias]
@@ -32,7 +32,7 @@ class Command(BaseCommand):
             if not isinstance(cache, MySQLCache):  # pragma: no cover
                 continue
 
-            tables.append({'name': cache._table})
+            tables.add(cache._table)
 
         if not tables:
             self.stderr.write("No MySQLCache instances in CACHES")
@@ -48,7 +48,7 @@ class Command(BaseCommand):
         out = [header]
         for table in tables:
             out.append(
-                table_operation.replace('{{ table.name }}', table['name'])
+                table_operation.replace('{{ table }}', table)
             )
         out.append(footer)
         return ''.join(out)
@@ -72,7 +72,7 @@ class Migration(migrations.Migration):
 create_table_sql = '\n'.join(
     '    ' * 3 + line
     for line in MySQLCache.create_table_sql.splitlines()
-).format(table_name='{{ table.name }}')
+).format(table_name='{{ table }}')
 
 
 table_operation = '''
@@ -80,7 +80,7 @@ table_operation = '''
             """
 ''' + create_table_sql + '''
             """,
-            "DROP TABLE `{{ table.name }}`;"
+            "DROP TABLE `{{ table }}`;"
         ),
 '''.rstrip()
 

--- a/requirements/requirements-testing.txt
+++ b/requirements/requirements-testing.txt
@@ -2,3 +2,4 @@ flake8==2.4.0
 mysqlclient==1.3.6
 mock==1.0.1
 ddt==1.0.0
+sqlparse==0.1.15

--- a/tests/django_mysql_tests/test_cache.py
+++ b/tests/django_mysql_tests/test_cache.py
@@ -1040,6 +1040,10 @@ class MySQLCacheTests(TransactionTestCase):
         self.assertTrue(hasattr(migration, 'dependencies'))
         self.assertTrue(hasattr(migration, 'operations'))
 
+        # Since they all have the same table name, there should only be one
+        # operation
+        self.assertEqual(len(migration.operations), 1)
+
     def test_mysql_cache_migration_alias(self):
         out = StringIO()
         call_command('mysql_cache_migration', 'default', stdout=out)

--- a/tests/django_mysql_tests/test_cache.py
+++ b/tests/django_mysql_tests/test_cache.py
@@ -1,6 +1,7 @@
 # -*- coding:utf-8 -*-
 from __future__ import unicode_literals
 
+import imp
 import os
 import time
 import warnings
@@ -15,6 +16,7 @@ from django.middleware.cache import (
 )
 from django.test import RequestFactory, TransactionTestCase
 from django.test.utils import override_settings
+from django.utils import six
 from django.utils.six.moves import StringIO
 from flake8.run import check_code
 
@@ -1029,6 +1031,14 @@ class MySQLCacheTests(TransactionTestCase):
             "migration.\nMigration:\n\n{}\n\nLint errors:\n\n{}"
             .format(errors, output, stderr.getvalue())
         )
+
+        # Dynamic import and check
+        migration_mod = imp.new_module('0001_add_cache_tables')
+        six.exec_(output, migration_mod.__dict__)
+        self.assertTrue(hasattr(migration_mod, 'Migration'))
+        migration = migration_mod.Migration
+        self.assertTrue(hasattr(migration, 'dependencies'))
+        self.assertTrue(hasattr(migration, 'operations'))
 
     def test_mysql_cache_migration_alias(self):
         out = StringIO()


### PR DESCRIPTION
... rather than per entry in `CACHES`. Also more thoroughly test the migration by importing it from the output and running it forwards and backwards.