### PR TITLE
SmartIterator - don't update chunk size if 0 objects were processed

### DIFF
--- a/django_mysql/models/query.py
+++ b/django_mysql/models/query.py
@@ -214,9 +214,12 @@ class SmartChunkedIterator(object):
         else:
             num_processed = len(chunk)
 
-        new_chunk_size = self.rate.update(num_processed, chunk_time)
+        if num_processed > 0:
+            new_chunk_size = self.rate.update(num_processed, chunk_time)
+        else:
+            new_chunk_size = self.chunk_size
 
-        if new_chunk_size < 1:
+        if new_chunk_size < 1:  # pragma: no cover
             new_chunk_size = 1
 
         if new_chunk_size > self.chunk_max:

--- a/tests/django_mysql_tests/test_models.py
+++ b/tests/django_mysql_tests/test_models.py
@@ -186,6 +186,13 @@ class SmartIteratorTests(TransactionTestCase):
         seen = [author.id for author in Author.objects.iter_smart()]
         self.assertEqual(seen, [])
 
+    def test_pk_hole(self):
+        first = Author.objects.earliest('id')
+        last = Author.objects.latest('id')
+        Author.objects.filter(id__gt=first.id, id__lt=last.id).delete()
+        seen = [author.id for author in Author.objects.iter_smart()]
+        self.assertEqual(seen, [first.id, last.id])
+
     def test_reporting(self):
         with captured_stdout() as output:
             qs = Author.objects.all()


### PR DESCRIPTION
The usage of `WeightedAverageRate` for updating the chunk size wasn't 100% duplicated when copying it - notably the covering `if` for doing an update only if rows were found, from http://bazaar.launchpad.net/~percona-toolkit-dev/percona-toolkit/2.2/view/head:/bin/pt-online-schema-change#L9210 . This helps with #111, at least partially. Tested on a large production table - in fact the same one that @lwiecek was having problems with.