### PR TITLE
Convert asserts to pytest style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,7 @@ end_of_line = lf
 [*.py]
 multi_line_output=5
 known_standard_library=mock
+known_third_party=pytest
 known_first_party=django_mysql
 
 [*.bat]

--- a/tests/django_mysql_tests/test_aggregates.py
+++ b/tests/django_mysql_tests/test_aggregates.py
@@ -10,12 +10,12 @@ class BitAndTests(TestCase):
     def test_implicit_name(self):
         Alphabet.objects.bulk_create([Alphabet(a=29), Alphabet(a=15)])
         out = Alphabet.objects.all().aggregate(BitAnd('a'))
-        self.assertEqual(out, {'a__bitand': 13})
+        assert out == {'a__bitand': 13}
 
     def test_explicit_name(self):
         Alphabet.objects.bulk_create([Alphabet(a=11), Alphabet(a=24)])
         out = Alphabet.objects.all().aggregate(aaa=BitAnd('a'))
-        self.assertEqual(out, {'aaa': 8})
+        assert out == {'aaa': 8}
 
     def test_no_rows(self):
         out = Alphabet.objects.all().aggregate(BitAnd('a'))
@@ -23,7 +23,7 @@ class BitAndTests(TestCase):
         # "This function returns 18446744073709551615 if there were no matching
         # rows. (This is the value of an unsigned BIGINT value with all bits
         # set to 1.)"
-        self.assertEqual(out, {'a__bitand': 18446744073709551615})
+        assert out == {'a__bitand': 18446744073709551615}
 
 
 class BitOrTests(TestCase):
@@ -31,18 +31,18 @@ class BitOrTests(TestCase):
     def test_implicit_name(self):
         Alphabet.objects.bulk_create([Alphabet(a=1), Alphabet(a=84)])
         out = Alphabet.objects.all().aggregate(BitOr('a'))
-        self.assertEqual(out, {'a__bitor': 85})
+        assert out == {'a__bitor': 85}
 
     def test_explicit_name(self):
         Alphabet.objects.bulk_create([Alphabet(a=29), Alphabet(a=15)])
         out = Alphabet.objects.all().aggregate(aaa=BitOr('a'))
-        self.assertEqual(out, {'aaa': 31})
+        assert out == {'aaa': 31}
 
     def test_no_rows(self):
         out = Alphabet.objects.all().aggregate(BitOr('a'))
         # Manual:
         # "This function returns 0 if there were no matching rows."
-        self.assertEqual(out, {'a__bitor': 0})
+        assert out == {'a__bitor': 0}
 
 
 class BitXorTests(TestCase):
@@ -50,18 +50,18 @@ class BitXorTests(TestCase):
     def test_implicit_name(self):
         Alphabet.objects.bulk_create([Alphabet(a=11), Alphabet(a=3)])
         out = Alphabet.objects.all().aggregate(BitXor('a'))
-        self.assertEqual(out, {'a__bitxor': 8})
+        assert out == {'a__bitxor': 8}
 
     def test_explicit_name(self):
         Alphabet.objects.bulk_create([Alphabet(a=123), Alphabet(a=456)])
         out = Alphabet.objects.all().aggregate(aaa=BitXor('a'))
-        self.assertEqual(out, {'aaa': 435})
+        assert out == {'aaa': 435}
 
     def test_no_rows(self):
         out = Alphabet.objects.all().aggregate(BitXor('a'))
         # Manual:
         # "This function returns 0 if there were no matching rows."
-        self.assertEqual(out, {'a__bitxor': 0})
+        assert out == {'a__bitxor': 0}
 
 
 class GroupConcatTests(TestCase):
@@ -76,31 +76,31 @@ class GroupConcatTests(TestCase):
     def test_basic_aggregate_ids(self):
         out = self.shakes.tutees.aggregate(tids=GroupConcat('id'))
         concatted_ids = ",".join(self.str_tutee_ids)
-        self.assertEqual(out, {'tids': concatted_ids})
+        assert out == {'tids': concatted_ids}
 
     def test_basic_annotate_ids(self):
         concat = GroupConcat('tutees__id')
         shakey = Author.objects.annotate(tids=concat).get(id=self.shakes.id)
         concatted_ids = ",".join(self.str_tutee_ids)
-        self.assertEqual(shakey.tids, concatted_ids)
+        assert shakey.tids, concatted_ids
 
     def test_separator(self):
         concat = GroupConcat('id', separator=':')
         out = self.shakes.tutees.aggregate(tids=concat)
         concatted_ids = ":".join(self.str_tutee_ids)
-        self.assertEqual(out, {'tids': concatted_ids})
+        assert out == {'tids': concatted_ids}
 
     def test_separator_empty(self):
         concat = GroupConcat('id', separator='')
         out = self.shakes.tutees.aggregate(tids=concat)
         concatted_ids = "".join(self.str_tutee_ids)
-        self.assertEqual(out, {'tids': concatted_ids})
+        assert out == {'tids': concatted_ids}
 
     def test_separator_big(self):
         concat = GroupConcat('id', separator='BIG')
         out = self.shakes.tutees.aggregate(tids=concat)
         concatted_ids = "BIG".join(self.str_tutee_ids)
-        self.assertEqual(out, {'tids': concatted_ids})
+        assert out == {'tids': concatted_ids}
 
     def test_order(self):
         out = (
@@ -108,4 +108,4 @@ class GroupConcatTests(TestCase):
                   .exclude(id=self.shakes.id)
                   .aggregate(tids=GroupConcat('tutor_id', distinct=True))
         )
-        self.assertEqual(out, {'tids': str(self.shakes.id)})
+        assert out == {'tids': str(self.shakes.id)}

--- a/tests/django_mysql_tests/test_forms.py
+++ b/tests/django_mysql_tests/test_forms.py
@@ -11,14 +11,14 @@ class TestSimpleListField(TestCase):
     def test_valid(self):
         field = SimpleListField(forms.CharField())
         value = field.clean('a,b,c')
-        self.assertEqual(value, ['a', 'b', 'c'])
+        assert value == ['a', 'b', 'c']
 
     def test_to_python_no_leading_commas(self):
         field = SimpleListField(forms.IntegerField())
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean(',1')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             'No leading, trailing, or double commas.'
         )
 
@@ -26,8 +26,8 @@ class TestSimpleListField(TestCase):
         field = SimpleListField(forms.IntegerField())
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('1,')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             'No leading, trailing, or double commas.'
         )
 
@@ -35,8 +35,8 @@ class TestSimpleListField(TestCase):
         field = SimpleListField(forms.IntegerField())
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('1,,2')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             'No leading, trailing, or double commas.'
         )
 
@@ -44,8 +44,8 @@ class TestSimpleListField(TestCase):
         field = SimpleListField(forms.IntegerField())
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('a,b,9')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             'Item 1 in the list did not validate: Enter a whole number.'
         )
 
@@ -56,8 +56,8 @@ class TestSimpleListField(TestCase):
         )
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('a,c')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             'Item 2 in the list did not validate: '
             'Select a valid choice. c is not one of the available choices.'
         )
@@ -66,8 +66,8 @@ class TestSimpleListField(TestCase):
         field = SimpleListField(forms.RegexField('[a-e]{2}'))
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('a,bc,de')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             'Item 1 in the list did not validate: Enter a valid value.'
         )
 
@@ -75,8 +75,8 @@ class TestSimpleListField(TestCase):
         field = SimpleListField(forms.CharField(max_length=5))
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('longer,yes')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             'Item 1 in the list did not validate: '
             'Ensure this value has at most 5 characters (it has 6).'
         )
@@ -86,13 +86,13 @@ class TestSimpleListField(TestCase):
         field = SimpleListField(forms.CharField(min_length=10, max_length=8))
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('undefined')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             'Item 1 in the list did not validate: '
             'Ensure this value has at least 10 characters (it has 9).'
         )
-        self.assertEqual(
-            cm.exception.messages[1],
+        assert (
+            cm.exception.messages[1] ==
             'Item 1 in the list did not validate: '
             'Ensure this value has at most 8 characters (it has 9).'
         )
@@ -100,19 +100,16 @@ class TestSimpleListField(TestCase):
     def test_prepare_value(self):
         field = SimpleListField(forms.CharField())
         value = field.prepare_value(['a', 'b', 'c'])
-        self.assertEqual(
-            value.split(','),
-            ['a', 'b', 'c']
-        )
+        assert value.split(',') == ['a', 'b', 'c']
 
-        self.assertEqual(field.prepare_value('1,a'), '1,a')
+        assert field.prepare_value('1,a') == '1,a'
 
     def test_max_length(self):
         field = SimpleListField(forms.CharField(), max_length=2)
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('a,b,c')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             'List contains 3 items, it should contain no more than 2.'
         )
 
@@ -120,8 +117,8 @@ class TestSimpleListField(TestCase):
         field = SimpleListField(forms.CharField(), min_length=4)
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('a,b,c')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             'List contains 3 items, it should contain no fewer than 4.'
         )
 
@@ -129,7 +126,7 @@ class TestSimpleListField(TestCase):
         field = SimpleListField(forms.CharField(), required=True)
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('')
-        self.assertEqual(cm.exception.messages[0], 'This field is required.')
+        assert cm.exception.messages[0] == 'This field is required.'
 
 
 class TestSimpleSetField(TestCase):
@@ -137,14 +134,14 @@ class TestSimpleSetField(TestCase):
     def test_valid(self):
         field = SimpleSetField(forms.CharField())
         value = field.clean('a,b,c')
-        self.assertEqual(value, {'a', 'b', 'c'})
+        assert value == {'a', 'b', 'c'}
 
     def test_to_python_no_leading_commas(self):
         field = SimpleSetField(forms.IntegerField())
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean(',1')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             'No leading, trailing, or double commas.'
         )
 
@@ -152,8 +149,8 @@ class TestSimpleSetField(TestCase):
         field = SimpleSetField(forms.IntegerField())
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('1,')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             'No leading, trailing, or double commas.'
         )
 
@@ -161,8 +158,8 @@ class TestSimpleSetField(TestCase):
         field = SimpleSetField(forms.IntegerField())
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('1,,2')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             'No leading, trailing, or double commas.'
         )
 
@@ -170,8 +167,8 @@ class TestSimpleSetField(TestCase):
         field = SimpleSetField(forms.IntegerField())
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('a,b,9')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             'Item 1 in the set did not validate: Enter a whole number.'
         )
 
@@ -179,8 +176,8 @@ class TestSimpleSetField(TestCase):
         field = SimpleSetField(forms.IntegerField())
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('1,1')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             "Duplicates are not supported. '1' appears twice or more."
         )
 
@@ -188,12 +185,12 @@ class TestSimpleSetField(TestCase):
         field = SimpleSetField(forms.IntegerField())
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('1,2,1,2')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             "Duplicates are not supported. '1' appears twice or more."
         )
-        self.assertEqual(
-            cm.exception.messages[1],
+        assert (
+            cm.exception.messages[1] ==
             "Duplicates are not supported. '2' appears twice or more."
         )
 
@@ -204,8 +201,8 @@ class TestSimpleSetField(TestCase):
         )
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('a,c')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             'Item "c" in the set did not validate: '
             'Select a valid choice. c is not one of the available choices.'
         )
@@ -214,8 +211,8 @@ class TestSimpleSetField(TestCase):
         field = SimpleSetField(forms.RegexField('[a-e]{2}'))
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('a,bc,de')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             'Item "a" in the set did not validate: Enter a valid value.'
         )
 
@@ -223,8 +220,8 @@ class TestSimpleSetField(TestCase):
         field = SimpleSetField(forms.CharField(max_length=5))
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('longer,yes')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             'Item "longer" in the set did not validate: '
             'Ensure this value has at most 5 characters (it has 6).'
         )
@@ -234,13 +231,13 @@ class TestSimpleSetField(TestCase):
         field = SimpleSetField(forms.CharField(min_length=10, max_length=8))
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('undefined')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             'Item "undefined" in the set did not validate: '
             'Ensure this value has at least 10 characters (it has 9).'
         )
-        self.assertEqual(
-            cm.exception.messages[1],
+        assert (
+            cm.exception.messages[1] ==
             'Item "undefined" in the set did not validate: '
             'Ensure this value has at most 8 characters (it has 9).'
         )
@@ -248,19 +245,19 @@ class TestSimpleSetField(TestCase):
     def test_prepare_value(self):
         field = SimpleSetField(forms.CharField())
         value = field.prepare_value({'a', 'b', 'c'})
-        self.assertEqual(
-            list(sorted(value.split(','))),
+        assert (
+            list(sorted(value.split(','))) ==
             ['a', 'b', 'c']
         )
 
-        self.assertEqual(field.prepare_value('1,a'), '1,a')
+        assert field.prepare_value('1,a') == '1,a'
 
     def test_max_length(self):
         field = SimpleSetField(forms.CharField(), max_length=2)
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('a,b,c')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             'Set contains 3 items, it should contain no more than 2.'
         )
 
@@ -268,8 +265,8 @@ class TestSimpleSetField(TestCase):
         field = SimpleSetField(forms.CharField(), min_length=4)
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('a,b,c')
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            cm.exception.messages[0] ==
             'Set contains 3 items, it should contain no fewer than 4.'
         )
 
@@ -277,4 +274,4 @@ class TestSimpleSetField(TestCase):
         field = SimpleSetField(forms.CharField(), required=True)
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('')
-        self.assertEqual(cm.exception.messages[0], 'This field is required.')
+        assert cm.exception.messages[0] == 'This field is required.'

--- a/tests/django_mysql_tests/test_forms.py
+++ b/tests/django_mysql_tests/test_forms.py
@@ -1,4 +1,5 @@
 # -*- coding:utf-8 -*-
+import pytest
 from django import forms
 from django.core import exceptions
 from django.test import TestCase
@@ -15,37 +16,37 @@ class TestSimpleListField(TestCase):
 
     def test_to_python_no_leading_commas(self):
         field = SimpleListField(forms.IntegerField())
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean(',1')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             'No leading, trailing, or double commas.'
         )
 
     def test_to_python_no_trailing_commas(self):
         field = SimpleListField(forms.IntegerField())
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('1,')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             'No leading, trailing, or double commas.'
         )
 
     def test_to_python_no_double_commas(self):
         field = SimpleListField(forms.IntegerField())
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('1,,2')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             'No leading, trailing, or double commas.'
         )
 
     def test_to_python_base_field_does_not_validate(self):
         field = SimpleListField(forms.IntegerField())
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('a,b,9')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             'Item 1 in the list did not validate: Enter a whole number.'
         )
 
@@ -54,29 +55,29 @@ class TestSimpleListField(TestCase):
             forms.ChoiceField(choices=(('a', 'The letter A'),
                                        ('b', 'The letter B')))
         )
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('a,c')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             'Item 2 in the list did not validate: '
             'Select a valid choice. c is not one of the available choices.'
         )
 
     def test_validators_fail(self):
         field = SimpleListField(forms.RegexField('[a-e]{2}'))
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('a,bc,de')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             'Item 1 in the list did not validate: Enter a valid value.'
         )
 
     def test_validators_fail_base_max_length(self):
         field = SimpleListField(forms.CharField(max_length=5))
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('longer,yes')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             'Item 1 in the list did not validate: '
             'Ensure this value has at most 5 characters (it has 6).'
         )
@@ -84,15 +85,15 @@ class TestSimpleListField(TestCase):
     def test_validators_fail_base_min_max_length(self):
         # there's just no satisfying some people...
         field = SimpleListField(forms.CharField(min_length=10, max_length=8))
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('undefined')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             'Item 1 in the list did not validate: '
             'Ensure this value has at least 10 characters (it has 9).'
         )
         assert (
-            cm.exception.messages[1] ==
+            excinfo.value.messages[1] ==
             'Item 1 in the list did not validate: '
             'Ensure this value has at most 8 characters (it has 9).'
         )
@@ -106,27 +107,27 @@ class TestSimpleListField(TestCase):
 
     def test_max_length(self):
         field = SimpleListField(forms.CharField(), max_length=2)
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('a,b,c')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             'List contains 3 items, it should contain no more than 2.'
         )
 
     def test_min_length(self):
         field = SimpleListField(forms.CharField(), min_length=4)
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('a,b,c')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             'List contains 3 items, it should contain no fewer than 4.'
         )
 
     def test_required(self):
         field = SimpleListField(forms.CharField(), required=True)
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('')
-        assert cm.exception.messages[0] == 'This field is required.'
+        assert excinfo.value.messages[0] == 'This field is required.'
 
 
 class TestSimpleSetField(TestCase):
@@ -138,59 +139,59 @@ class TestSimpleSetField(TestCase):
 
     def test_to_python_no_leading_commas(self):
         field = SimpleSetField(forms.IntegerField())
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean(',1')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             'No leading, trailing, or double commas.'
         )
 
     def test_to_python_no_trailing_commas(self):
         field = SimpleSetField(forms.IntegerField())
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('1,')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             'No leading, trailing, or double commas.'
         )
 
     def test_to_python_no_double_commas(self):
         field = SimpleSetField(forms.IntegerField())
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('1,,2')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             'No leading, trailing, or double commas.'
         )
 
     def test_to_python_base_field_does_not_validate(self):
         field = SimpleSetField(forms.IntegerField())
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('a,b,9')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             'Item 1 in the set did not validate: Enter a whole number.'
         )
 
     def test_to_python_duplicates_not_allowed(self):
         field = SimpleSetField(forms.IntegerField())
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('1,1')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             "Duplicates are not supported. '1' appears twice or more."
         )
 
     def test_to_python_two_duplicates_not_allowed(self):
         field = SimpleSetField(forms.IntegerField())
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('1,2,1,2')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             "Duplicates are not supported. '1' appears twice or more."
         )
         assert (
-            cm.exception.messages[1] ==
+            excinfo.value.messages[1] ==
             "Duplicates are not supported. '2' appears twice or more."
         )
 
@@ -199,29 +200,29 @@ class TestSimpleSetField(TestCase):
             forms.ChoiceField(choices=(('a', 'The letter A'),
                                        ('b', 'The letter B')))
         )
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('a,c')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             'Item "c" in the set did not validate: '
             'Select a valid choice. c is not one of the available choices.'
         )
 
     def test_validators_fail(self):
         field = SimpleSetField(forms.RegexField('[a-e]{2}'))
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('a,bc,de')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             'Item "a" in the set did not validate: Enter a valid value.'
         )
 
     def test_validators_fail_base_max_length(self):
         field = SimpleSetField(forms.CharField(max_length=5))
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('longer,yes')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             'Item "longer" in the set did not validate: '
             'Ensure this value has at most 5 characters (it has 6).'
         )
@@ -229,15 +230,15 @@ class TestSimpleSetField(TestCase):
     def test_validators_fail_base_min_max_length(self):
         # there's just no satisfying some people...
         field = SimpleSetField(forms.CharField(min_length=10, max_length=8))
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('undefined')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             'Item "undefined" in the set did not validate: '
             'Ensure this value has at least 10 characters (it has 9).'
         )
         assert (
-            cm.exception.messages[1] ==
+            excinfo.value.messages[1] ==
             'Item "undefined" in the set did not validate: '
             'Ensure this value has at most 8 characters (it has 9).'
         )
@@ -254,24 +255,24 @@ class TestSimpleSetField(TestCase):
 
     def test_max_length(self):
         field = SimpleSetField(forms.CharField(), max_length=2)
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('a,b,c')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             'Set contains 3 items, it should contain no more than 2.'
         )
 
     def test_min_length(self):
         field = SimpleSetField(forms.CharField(), min_length=4)
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('a,b,c')
         assert (
-            cm.exception.messages[0] ==
+            excinfo.value.messages[0] ==
             'Set contains 3 items, it should contain no fewer than 4.'
         )
 
     def test_required(self):
         field = SimpleSetField(forms.CharField(), required=True)
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean('')
-        assert cm.exception.messages[0] == 'This field is required.'
+        assert excinfo.value.messages[0] == 'This field is required.'

--- a/tests/django_mysql_tests/test_functions.py
+++ b/tests/django_mysql_tests/test_functions.py
@@ -3,6 +3,7 @@ import hashlib
 from unittest import skipIf
 
 import django
+import pytest
 from django.db.models import F
 from django.test import TestCase
 
@@ -24,16 +25,16 @@ class ComparisonFunctionTests(TestCase):
     def test_greatest(self):
         Alphabet.objects.create(d='A', e='B')
         ab = Alphabet.objects.annotate(best=Greatest('d', 'e')).first()
-        self.assertEqual(ab.best, 'B')
+        assert ab.best == 'B'
 
     def test_greatest_takes_no_kwargs(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             Greatest('a', something='wrong')
 
     def test_least(self):
         Alphabet.objects.create(a=1, b=2, c=-1)
         ab = Alphabet.objects.annotate(worst=Least('a', 'b', 'c')).first()
-        self.assertEqual(ab.worst, -1)
+        assert ab.worst == -1
 
 
 @requiresDatabaseFunctions
@@ -42,46 +43,46 @@ class NumericFunctionTests(TestCase):
     def test_abs(self):
         Alphabet.objects.create(a=-2)
         ab = Alphabet.objects.annotate(aaa=Abs('a')).first()
-        self.assertEqual(ab.aaa, 2)
+        assert ab.aaa == 2
 
     def test_ceiling(self):
         Alphabet.objects.create(g=0.5)
         ab = Alphabet.objects.annotate(gceil=Ceiling('g')).first()
-        self.assertEqual(ab.gceil, 1)
+        assert ab.gceil == 1
 
     def test_crc32(self):
         Alphabet.objects.create(d='AAAAAA')
         ab = Alphabet.objects.annotate(crc=CRC32('d')).first()
         # Precalculated this in MySQL prompt. Python's binascii.crc32 doesn't
         # match - maybe sign issues?
-        self.assertEqual(ab.crc, 2854018686)
+        assert ab.crc == 2854018686
 
     def test_crc32_only_takes_one_arg_no_kwargs(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             CRC32('d', 'c')
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             CRC32('d', something='wrong')
 
     def test_floor(self):
         Alphabet.objects.create(g=1.5)
         ab = Alphabet.objects.annotate(gfloor=Floor('g')).first()
-        self.assertEqual(ab.gfloor, 1)
+        assert ab.gfloor == 1
 
     def test_round(self):
         Alphabet.objects.create(g=24.459)
         ab = Alphabet.objects.annotate(ground=Round('g')).get()
-        self.assertEqual(ab.ground, 24)
+        assert ab.ground == 24
 
     def test_round_up(self):
         Alphabet.objects.create(g=27.859)
         ab = Alphabet.objects.annotate(ground=Round('g')).get()
-        self.assertEqual(ab.ground, 28)
+        assert ab.ground == 28
 
     def test_round_places(self):
         Alphabet.objects.create(a=81731)
         ab = Alphabet.objects.annotate(around=Round('a', -2)).get()
-        self.assertEqual(ab.around, 81700)
+        assert ab.around == 81700
 
     def test_sign(self):
         Alphabet.objects.create(a=123, b=0, c=-999)
@@ -90,9 +91,9 @@ class NumericFunctionTests(TestCase):
             bsign=Sign('b'),
             csign=Sign('c'),
         ).first()
-        self.assertEqual(ab.asign, 1)
-        self.assertEqual(ab.bsign, 0)
-        self.assertEqual(ab.csign, -1)
+        assert ab.asign == 1
+        assert ab.bsign == 0
+        assert ab.csign == -1
 
 
 @requiresDatabaseFunctions
@@ -101,17 +102,17 @@ class StringFunctionTests(TestCase):
     def test_concat_ws(self):
         Alphabet.objects.create(d='AAA', e='BBB')
         ab = Alphabet.objects.annotate(de=ConcatWS('d', 'e')).first()
-        self.assertEqual(ab.de, 'AAA,BBB')
+        assert ab.de == 'AAA,BBB'
 
     def test_concat_ws_integers(self):
         Alphabet.objects.create(a=1, b=2)
         ab = Alphabet.objects.annotate(ab=ConcatWS('a', 'b')).first()
-        self.assertEqual(ab.ab, '1,2')
+        assert ab.ab == '1,2'
 
     def test_concat_ws_skips_nulls(self):
         Alphabet.objects.create(d='AAA', e=None, f=2)
         ab = Alphabet.objects.annotate(de=ConcatWS('d', 'e', 'f')).first()
-        self.assertEqual(ab.de, 'AAA,2')
+        assert ab.de == 'AAA,2'
 
     def test_concat_ws_separator(self):
         Alphabet.objects.create(d='AAA', e='BBB')
@@ -119,31 +120,31 @@ class StringFunctionTests(TestCase):
             Alphabet.objects.annotate(de=ConcatWS('d', 'e', separator=':'))
                             .first()
         )
-        self.assertEqual(ab.de, 'AAA:BBB')
+        assert ab.de == 'AAA:BBB'
 
     def test_concat_ws_separator_null_returns_none(self):
         Alphabet.objects.create(a=1, b=2)
         concat = ConcatWS('a', 'b', separator=None)
         ab = Alphabet.objects.annotate(ab=concat).first()
-        self.assertEqual(ab.ab, None)
+        assert ab.ab is None
 
     def test_concat_ws_separator_field(self):
         Alphabet.objects.create(a=1, d='AAA', e='BBB')
         concat = ConcatWS('d', 'e', separator=F('a'))
         ab = Alphabet.objects.annotate(de=concat).first()
-        self.assertEqual(ab.de, 'AAA1BBB')
+        assert ab.de == 'AAA1BBB'
 
     def test_concat_ws_bad_arg(self):
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as excinfo:
             ConcatWS('a', 'b', separataaa=',')
-        self.assertIn('Invalid keyword arguments for ConcatWS: separataaa',
-                      str(cm.exception))
+        assert ('Invalid keyword arguments for ConcatWS: separataaa' in
+                str(excinfo.value))
 
     def test_concat_ws_too_few_fields(self):
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as excinfo:
             ConcatWS('a')
-        self.assertIn('ConcatWS must take at least two expressions',
-                      str(cm.exception))
+        assert ('ConcatWS must take at least two expressions' in
+                str(excinfo.value))
 
     def test_concat_ws_then_lookups_from_textfield(self):
         Alphabet.objects.create(d='AAA', e='BBB')
@@ -153,23 +154,23 @@ class StringFunctionTests(TestCase):
                             .filter(de__endswith=':BBB')
                             .first()
         )
-        self.assertEqual(ab.de, 'AAA:BBB')
+        assert ab.de == 'AAA:BBB'
 
     def test_elt_simple(self):
         Alphabet.objects.create(a=2)
         ab = Alphabet.objects.annotate(elt=ELT('a', ['apple', 'orange'])).get()
-        self.assertEqual(ab.elt, 'orange')
+        assert ab.elt == 'orange'
         ab = Alphabet.objects.annotate(elt=ELT('a', ['apple'])).get()
-        self.assertEqual(ab.elt, None)
+        assert ab.elt is None
 
     def test_field_simple(self):
         Alphabet.objects.create(d='a')
         ab = Alphabet.objects.annotate(dp=Field('d', ['a', 'b'])).first()
-        self.assertEqual(ab.dp, 1)
+        assert ab.dp == 1
         ab = Alphabet.objects.annotate(dp=Field('d', ['b', 'a'])).first()
-        self.assertEqual(ab.dp, 2)
+        assert ab.dp == 2
         ab = Alphabet.objects.annotate(dp=Field('d', ['c', 'd'])).first()
-        self.assertEqual(ab.dp, 0)
+        assert ab.dp == 0
 
     def test_order_by(self):
         Alphabet.objects.create(a=1, d='AAA')
@@ -180,7 +181,7 @@ class StringFunctionTests(TestCase):
             Alphabet.objects.order_by(Field('d', ['AAA', 'BBB']), 'a')
                             .values_list('a', flat=True)
         )
-        self.assertEqual(avalues, [2, 1, 3, 4])
+        assert avalues == [2, 1, 3, 4]
 
 
 @requiresDatabaseFunctions
@@ -191,14 +192,14 @@ class EncryptionFunctionTests(TestCase):
         Alphabet.objects.create(d=string)
         pymd5 = hashlib.md5(string.encode('ascii')).hexdigest()
         ab = Alphabet.objects.annotate(md5=MD5('d')).first()
-        self.assertEqual(ab.md5, pymd5)
+        assert ab.md5 == pymd5
 
     def test_sha1_string(self):
         string = 'A string'
         Alphabet.objects.create(d=string)
         pysha1 = hashlib.sha1(string.encode('ascii')).hexdigest()
         ab = Alphabet.objects.annotate(sha=SHA1('d')).first()
-        self.assertEqual(ab.sha, pysha1)
+        assert ab.sha == pysha1
 
     def test_sha2_string(self):
         string = 'A string'
@@ -208,17 +209,17 @@ class EncryptionFunctionTests(TestCase):
             sha_func = getattr(hashlib, 'sha{}'.format(hash_len))
             pysha = sha_func(string.encode('ascii')).hexdigest()
             ab = Alphabet.objects.annotate(sha=SHA2('d', hash_len)).first()
-            self.assertEqual(ab.sha, pysha)
+            assert ab.sha == pysha
 
     def test_sha2_string_hash_len_default(self):
         string = 'A string'
         Alphabet.objects.create(d=string)
         pysha512 = hashlib.sha512(string.encode('ascii')).hexdigest()
         ab = Alphabet.objects.annotate(sha=SHA2('d')).first()
-        self.assertEqual(ab.sha, pysha512)
+        assert ab.sha == pysha512
 
     def test_sha2_bad_hash_len(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             SHA2('a', 123)
 
 
@@ -229,13 +230,13 @@ class InformationFunctionTests(TestCase):
         Alphabet.objects.create(a=7891)
         Alphabet.objects.update(a=LastInsertId('a') + 1)
         lid = LastInsertId.get()
-        self.assertEqual(lid, 7891)
+        assert lid == 7891
 
     def test_last_insert_id_other_db_connection(self):
         Alphabet.objects.using('other').create(a=9191)
         Alphabet.objects.using('other').update(a=LastInsertId('a') + 9)
         lid = LastInsertId.get(using='other')
-        self.assertEqual(lid, 9191)
+        assert lid == 9191
 
     def test_last_insert_id_in_query(self):
         ab1 = Alphabet.objects.create(a=3719, b=717612)
@@ -246,7 +247,7 @@ class InformationFunctionTests(TestCase):
         Alphabet.objects.filter(id=ab2.id).update(b=LastInsertId())
 
         ab = Alphabet.objects.get()
-        self.assertEqual(ab.b, 717612)
+        assert ab.b == 717612
 
 
 @skipIf(django.VERSION >= (1, 8),
@@ -254,13 +255,13 @@ class InformationFunctionTests(TestCase):
 class OldDjangoFunctionTests(TestCase):
 
     def test_single_arg_doesnt_work(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             CRC32('name')
 
     def test_multi_arg_doesnt_work(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             Greatest('a', 'b')
 
     def test_concat_ws_doesnt_work(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ConcatWS('a', 'b', separator='::')

--- a/tests/django_mysql_tests/test_listcharfield.py
+++ b/tests/django_mysql_tests/test_listcharfield.py
@@ -5,6 +5,7 @@ from unittest import skip, skipIf
 
 import ddt
 import django
+import pytest
 from django import forms
 from django.core import exceptions, serializers
 from django.core.management import call_command
@@ -26,55 +27,55 @@ class TestSaveLoad(TestCase):
 
     def test_char_easy(self):
         s = CharListModel.objects.create(field=["comfy", "big"])
-        self.assertEqual(s.field, ["comfy", "big"])
+        assert s.field == ["comfy", "big"]
         s = CharListModel.objects.get(id=s.id)
-        self.assertEqual(s.field, ["comfy", "big"])
+        assert s.field == ["comfy", "big"]
 
         s.field.append("round")
         s.save()
-        self.assertEqual(s.field, ["comfy", "big", "round"])
+        assert s.field == ["comfy", "big", "round"]
         s = CharListModel.objects.get(id=s.id)
-        self.assertEqual(s.field, ["comfy", "big", "round"])
+        assert s.field == ["comfy", "big", "round"]
 
     def test_char_string_direct(self):
         s = CharListModel.objects.create(field="big,bad")
         s = CharListModel.objects.get(id=s.id)
-        self.assertEqual(s.field, ['big', 'bad'])
+        assert s.field == ['big', 'bad']
 
     def test_is_a_list_immediately(self):
         s = CharListModel()
-        self.assertEqual(s.field, [])
+        assert s.field == []
         s.field.append("bold")
         s.field.append("brave")
         s.save()
-        self.assertEqual(s.field, ["bold", "brave"])
+        assert s.field == ["bold", "brave"]
         s = CharListModel.objects.get(id=s.id)
-        self.assertEqual(s.field, ["bold", "brave"])
+        assert s.field == ["bold", "brave"]
 
     def test_empty(self):
         s = CharListModel.objects.create()
-        self.assertEqual(s.field, [])
+        assert s.field == []
         s = CharListModel.objects.get(id=s.id)
-        self.assertEqual(s.field, [])
+        assert s.field == []
 
     def test_char_cant_create_lists_with_empty_string(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             CharListModel.objects.create(field=[""])
 
     def test_char_cant_create_sets_with_commas(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             CharListModel.objects.create(field=["co,mma", "contained"])
 
     def test_char_basic_lookup(self):
         mymodel = CharListModel.objects.create()
         empty = CharListModel.objects.filter(field="")
 
-        self.assertEqual(empty.count(), 1)
-        self.assertEqual(empty[0], mymodel)
+        assert empty.count() == 1
+        assert empty[0] == mymodel
 
         mymodel.delete()
 
-        self.assertEqual(empty.count(), 0)
+        assert empty.count() == 0
 
     @ddt.data('contains', 'icontains')
     def test_char_lookup(self, lookup):
@@ -82,94 +83,94 @@ class TestSaveLoad(TestCase):
         mymodel = CharListModel.objects.create(field=["mouldy", "rotten"])
 
         mouldy = CharListModel.objects.filter(**{lname: "mouldy"})
-        self.assertEqual(mouldy.count(), 1)
-        self.assertEqual(mouldy[0], mymodel)
+        assert mouldy.count() == 1
+        assert mouldy[0] == mymodel
 
         rotten = CharListModel.objects.filter(**{lname: "rotten"})
-        self.assertEqual(rotten.count(), 1)
-        self.assertEqual(rotten[0], mymodel)
+        assert rotten.count() == 1
+        assert rotten[0] == mymodel
 
         clean = CharListModel.objects.filter(**{lname: "clean"})
-        self.assertEqual(clean.count(), 0)
+        assert clean.count() == 0
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             list(CharListModel.objects.filter(**{lname: ["a", "b"]}))
 
         both = CharListModel.objects.filter(
             Q(**{lname: "mouldy"}) & Q(**{lname: "rotten"})
         )
-        self.assertEqual(both.count(), 1)
-        self.assertEqual(both[0], mymodel)
+        assert both.count() == 1
+        assert both[0] == mymodel
 
         either = CharListModel.objects.filter(
             Q(**{lname: "mouldy"}) | Q(**{lname: "clean"})
         )
-        self.assertEqual(either.count(), 1)
+        assert either.count() == 1
 
         not_clean = CharListModel.objects.exclude(**{lname: "clean"})
-        self.assertEqual(not_clean.count(), 1)
+        assert not_clean.count() == 1
 
         not_mouldy = CharListModel.objects.exclude(**{lname: "mouldy"})
-        self.assertEqual(not_mouldy.count(), 0)
+        assert not_mouldy.count() == 0
 
     def test_char_len_lookup_empty(self):
         mymodel = CharListModel.objects.create(field=[])
 
         empty = CharListModel.objects.filter(field__len=0)
-        self.assertEqual(empty.count(), 1)
-        self.assertEqual(empty[0], mymodel)
+        assert empty.count() == 1
+        assert empty[0] == mymodel
 
         one = CharListModel.objects.filter(field__len=1)
-        self.assertEqual(one.count(), 0)
+        assert one.count() == 0
 
         one_or_more = CharListModel.objects.filter(field__len__gte=0)
-        self.assertEqual(one_or_more.count(), 1)
+        assert one_or_more.count() == 1
 
     def test_char_len_lookup(self):
         mymodel = CharListModel.objects.create(field=["red", "expensive"])
 
         empty = CharListModel.objects.filter(field__len=0)
-        self.assertEqual(empty.count(), 0)
+        assert empty.count() == 0
 
         one_or_more = CharListModel.objects.filter(field__len__gte=1)
-        self.assertEqual(one_or_more.count(), 1)
-        self.assertEqual(one_or_more[0], mymodel)
+        assert one_or_more.count() == 1
+        assert one_or_more[0] == mymodel
 
         two = CharListModel.objects.filter(field__len=2)
-        self.assertEqual(two.count(), 1)
-        self.assertEqual(two[0], mymodel)
+        assert two.count() == 1
+        assert two[0] == mymodel
 
         three = CharListModel.objects.filter(field__len=3)
-        self.assertEqual(three.count(), 0)
+        assert three.count() == 0
 
     def test_char_default(self):
         mymodel = CharListDefaultModel.objects.create()
-        self.assertEqual(mymodel.field, ["a", "d"])
+        assert mymodel.field == ["a", "d"]
 
         mymodel = CharListDefaultModel.objects.get(id=mymodel.id)
-        self.assertEqual(mymodel.field, ["a", "d"])
+        assert mymodel.field == ["a", "d"]
 
     def test_char_position_lookup(self):
         mymodel = CharListModel.objects.create(field=["red", "blue"])
 
         blue0 = CharListModel.objects.filter(field__0="blue")
-        self.assertEqual(blue0.count(), 0)
+        assert blue0.count() == 0
 
         red0 = CharListModel.objects.filter(field__0="red")
-        self.assertEqual(list(red0), [mymodel])
+        assert list(red0) == [mymodel]
 
         red0_red1 = CharListModel.objects.filter(field__0="red",
                                                  field__1="red")
-        self.assertEqual(red0_red1.count(), 0)
+        assert red0_red1.count() == 0
 
         red0_blue1 = CharListModel.objects.filter(field__0="red",
                                                   field__1="blue")
-        self.assertEqual(list(red0_blue1), [mymodel])
+        assert list(red0_blue1) == [mymodel]
 
         red0_or_blue0 = CharListModel.objects.filter(
             Q(field__0="red") | Q(field__0="blue")
         )
-        self.assertEqual(list(red0_or_blue0), [mymodel])
+        assert list(red0_or_blue0) == [mymodel]
 
     def test_char_position_lookup_repeat_fails(self):
         """
@@ -178,70 +179,70 @@ class TestSaveLoad(TestCase):
         CharListModel.objects.create(field=["red", "red", "blue"])
 
         red1 = CharListModel.objects.filter(field__1="red")
-        self.assertEqual(list(red1), [])  # should be 'red'
+        assert list(red1) == []  # should be 'red'
 
     def test_char_position_lookup_too_long(self):
         CharListModel.objects.create(field=["red", "blue"])
 
         red1 = CharListModel.objects.filter(field__2="blue")
-        self.assertEqual(list(red1), [])
+        assert list(red1) == []
 
     def test_int_easy(self):
         mymodel = IntListModel.objects.create(field=[1, 2])
-        self.assertEqual(mymodel.field, [1, 2])
+        assert mymodel.field == [1, 2]
         mymodel = IntListModel.objects.get(id=mymodel.id)
-        self.assertEqual(mymodel.field, [1, 2])
+        assert mymodel.field == [1, 2]
 
     def test_int_contains_lookup(self):
         onetwo = IntListModel.objects.create(field=[1, 2])
 
         ones = IntListModel.objects.filter(field__contains=1)
-        self.assertEqual(ones.count(), 1)
-        self.assertEqual(ones[0], onetwo)
+        assert ones.count() == 1
+        assert ones[0] == onetwo
 
         twos = IntListModel.objects.filter(field__contains=2)
-        self.assertEqual(twos.count(), 1)
-        self.assertEqual(twos[0], onetwo)
+        assert twos.count() == 1
+        assert twos[0] == onetwo
 
         threes = IntListModel.objects.filter(field__contains=3)
-        self.assertEqual(threes.count(), 0)
+        assert threes.count() == 0
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             list(IntListModel.objects.filter(field__contains=[1, 2]))
 
         ones_and_twos = IntListModel.objects.filter(
             Q(field__contains=1) & Q(field__contains=2)
         )
-        self.assertEqual(ones_and_twos.count(), 1)
-        self.assertEqual(ones_and_twos[0], onetwo)
+        assert ones_and_twos.count() == 1
+        assert ones_and_twos[0] == onetwo
 
         ones_and_threes = IntListModel.objects.filter(
             Q(field__contains=1) & Q(field__contains=3)
         )
-        self.assertEqual(ones_and_threes.count(), 0)
+        assert ones_and_threes.count() == 0
 
         ones_or_threes = IntListModel.objects.filter(
             Q(field__contains=1) | Q(field__contains=3)
         )
-        self.assertEqual(ones_or_threes.count(), 1)
+        assert ones_or_threes.count() == 1
 
         no_three = IntListModel.objects.exclude(field__contains=3)
-        self.assertEqual(no_three.count(), 1)
+        assert no_three.count() == 1
 
         no_one = IntListModel.objects.exclude(field__contains=1)
-        self.assertEqual(no_one.count(), 0)
+        assert no_one.count() == 0
 
     def test_int_position_lookup(self):
         onetwo = IntListModel.objects.create(field=[1, 2])
 
         one0 = IntListModel.objects.filter(field__0=1)
-        self.assertEqual(list(one0), [onetwo])
+        assert list(one0) == [onetwo]
 
         two0 = IntListModel.objects.filter(field__0=2)
-        self.assertEqual(two0.count(), 0)
+        assert two0.count() == 0
 
         one0two1 = IntListModel.objects.filter(field__0=1, field__1=2)
-        self.assertEqual(list(one0two1), [onetwo])
+        assert list(one0two1) == [onetwo]
 
 
 @skipIf(django.VERSION <= (1, 8),
@@ -252,33 +253,33 @@ class TestListF(TestCase):
         CharListModel.objects.create(field=[])
         CharListModel.objects.update(field=ListF('field').append('first'))
         model = CharListModel.objects.get()
-        self.assertEqual(model.field, ["first"])
+        assert model.field == ["first"]
 
     def test_append_to_one(self):
         CharListModel.objects.create(field=["big"])
         CharListModel.objects.update(field=ListF('field').append('bad'))
         model = CharListModel.objects.get()
-        self.assertEqual(model.field, ["big", "bad"])
+        assert model.field == ["big", "bad"]
 
     def test_append_to_some(self):
         CharListModel.objects.create(field=["big", "blue"])
         CharListModel.objects.update(field=ListF('field').append('round'))
         model = CharListModel.objects.get()
-        self.assertEqual(model.field, ["big", "blue", "round"])
+        assert model.field == ["big", "blue", "round"]
 
     def test_append_to_multiple_objects(self):
         CharListModel.objects.create(field=["mouse"])
         CharListModel.objects.create(field=["keyboard"])
         CharListModel.objects.update(field=ListF('field').append("screen"))
         first, second = tuple(CharListModel.objects.all())
-        self.assertEqual(first.field, ["mouse", "screen"])
-        self.assertEqual(second.field, ["keyboard", "screen"])
+        assert first.field == ["mouse", "screen"]
+        assert second.field == ["keyboard", "screen"]
 
     def test_append_exists(self):
         CharListModel.objects.create(field=["nice"])
         CharListModel.objects.update(field=ListF('field').append("nice"))
         model = CharListModel.objects.get()
-        self.assertEqual(model.field, ["nice", "nice"])
+        assert model.field == ["nice", "nice"]
 
     @override_mysql_variables(SQL_MODE="ANSI")
     def test_append_works_in_ansi_mode(self):
@@ -286,46 +287,46 @@ class TestListF(TestCase):
         CharListModel.objects.update(field=ListF('field').append('big'))
         CharListModel.objects.update(field=ListF('field').append('bad'))
         model = CharListModel.objects.get()
-        self.assertEqual(model.field, ["big", "bad"])
+        assert model.field == ["big", "bad"]
 
     def test_append_assignment(self):
         model = CharListModel.objects.create(field=["red"])
         model.field = ListF('field').append('blue')
         model.save()
         model = CharListModel.objects.get()
-        self.assertEqual(model.field, ['red', 'blue'])
+        assert model.field == ['red', 'blue']
 
     def test_appendleft_to_none(self):
         CharListModel.objects.create(field=[])
         CharListModel.objects.update(field=ListF('field').appendleft('first'))
         model = CharListModel.objects.get()
-        self.assertEqual(model.field, ["first"])
+        assert model.field == ["first"]
 
     def test_appendleft_to_one(self):
         CharListModel.objects.create(field=["big"])
         CharListModel.objects.update(field=ListF('field').appendleft('bad'))
         model = CharListModel.objects.get()
-        self.assertEqual(model.field, ["bad", "big"])
+        assert model.field == ["bad", "big"]
 
     def test_appendleft_to_some(self):
         CharListModel.objects.create(field=["big", "blue"])
         CharListModel.objects.update(field=ListF('field').appendleft('round'))
         model = CharListModel.objects.get()
-        self.assertEqual(model.field, ["round", "big", "blue"])
+        assert model.field == ["round", "big", "blue"]
 
     def test_appendleft_to_multiple_objects(self):
         CharListModel.objects.create(field=["mouse"])
         CharListModel.objects.create(field=["keyboard"])
         CharListModel.objects.update(field=ListF('field').appendleft("screen"))
         first, second = tuple(CharListModel.objects.all())
-        self.assertEqual(first.field, ["screen", "mouse"])
-        self.assertEqual(second.field, ["screen", "keyboard"])
+        assert first.field == ["screen", "mouse"]
+        assert second.field == ["screen", "keyboard"]
 
     def test_appendleft_exists(self):
         CharListModel.objects.create(field=["nice"])
         CharListModel.objects.update(field=ListF('field').appendleft("nice"))
         model = CharListModel.objects.get()
-        self.assertEqual(model.field, ["nice", "nice"])
+        assert model.field == ["nice", "nice"]
 
     @override_mysql_variables(SQL_MODE="ANSI")
     def test_appendleft_works_in_ansi_mode(self):
@@ -333,62 +334,62 @@ class TestListF(TestCase):
         CharListModel.objects.update(field=ListF('field').appendleft('big'))
         CharListModel.objects.update(field=ListF('field').appendleft('bad'))
         model = CharListModel.objects.get()
-        self.assertEqual(model.field, ["bad", "big"])
+        assert model.field == ["bad", "big"]
 
     def test_appendleft_assignment(self):
         model = CharListModel.objects.create(field=["red"])
         model.field = ListF('field').appendleft('blue')
         model.save()
         model = CharListModel.objects.get()
-        self.assertEqual(model.field, ['blue', 'red'])
+        assert model.field == ['blue', 'red']
 
     def test_pop_none(self):
         CharListModel.objects.create(field=[])
         CharListModel.objects.update(field=ListF('field').pop())
         model = CharListModel.objects.get()
-        self.assertEqual(model.field, [])
+        assert model.field == []
 
     def test_pop_one(self):
         CharListModel.objects.create(field=["red"])
         CharListModel.objects.update(field=ListF('field').pop())
         model = CharListModel.objects.get()
-        self.assertEqual(model.field, [])
+        assert model.field == []
 
     def test_pop_two(self):
         CharListModel.objects.create(field=["red", "blue"])
         CharListModel.objects.update(field=ListF('field').pop())
         model = CharListModel.objects.get()
-        self.assertEqual(model.field, ["red"])
+        assert model.field == ["red"]
 
     def test_pop_three(self):
         CharListModel.objects.create(field=["green", "yellow", "p"])
         CharListModel.objects.update(field=ListF('field').pop())
         model = CharListModel.objects.get()
-        self.assertEqual(model.field, ["green", "yellow"])
+        assert model.field == ["green", "yellow"]
 
     def test_popleft_none(self):
         CharListModel.objects.create(field=[])
         CharListModel.objects.update(field=ListF('field').popleft())
         model = CharListModel.objects.get()
-        self.assertEqual(model.field, [])
+        assert model.field == []
 
     def test_popleft_one(self):
         CharListModel.objects.create(field=["red"])
         CharListModel.objects.update(field=ListF('field').popleft())
         model = CharListModel.objects.get()
-        self.assertEqual(model.field, [])
+        assert model.field == []
 
     def test_popleft_two(self):
         CharListModel.objects.create(field=["red", "blue"])
         CharListModel.objects.update(field=ListF('field').popleft())
         model = CharListModel.objects.get()
-        self.assertEqual(model.field, ["blue"])
+        assert model.field == ["blue"]
 
     def test_popleft_three(self):
         CharListModel.objects.create(field=["green", "yellow", "p"])
         CharListModel.objects.update(field=ListF('field').popleft())
         model = CharListModel.objects.get()
-        self.assertEqual(model.field, ["yellow", "p"])
+        assert model.field == ["yellow", "p"]
 
 
 class TestValidation(TestCase):
@@ -402,10 +403,10 @@ class TestValidation(TestCase):
 
         field.clean({'a', 'b', 'c'}, None)
 
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean({'a', 'b', 'c', 'd'}, None)
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            excinfo.value.messages[0] ==
             'List contains 4 items, it should contain no more than 3.'
         )
 
@@ -416,10 +417,10 @@ class TestCheck(TestCase):
         field = ListCharField(models.CharField(), max_length=32)
         field.set_attributes_from_name('field')
         errors = field.check()
-        self.assertEqual(len(errors), 1)
-        self.assertEqual(errors[0].id, 'django_mysql.E004')
-        self.assertIn('Base field for list has errors', errors[0].msg)
-        self.assertIn('max_length', errors[0].msg)
+        assert len(errors) == 1
+        assert errors[0].id == 'django_mysql.E004'
+        assert 'Base field for list has errors' in errors[0].msg
+        assert 'max_length' in errors[0].msg
 
     def test_invalid_base_fields(self):
         field = ListCharField(
@@ -428,9 +429,9 @@ class TestCheck(TestCase):
         )
         field.set_attributes_from_name('field')
         errors = field.check()
-        self.assertEqual(len(errors), 1)
-        self.assertEqual(errors[0].id, 'django_mysql.E005')
-        self.assertIn('Base field for list must be', errors[0].msg)
+        assert len(errors) == 1
+        assert errors[0].id == 'django_mysql.E005'
+        assert 'Base field for list must be' in errors[0].msg
 
     def test_max_length_including_base(self):
         field = ListCharField(
@@ -438,9 +439,9 @@ class TestCheck(TestCase):
             size=2, max_length=32)
         field.set_attributes_from_name('field')
         errors = field.check()
-        self.assertEqual(len(errors), 1)
-        self.assertEqual(errors[0].id, 'django_mysql.E006')
-        self.assertIn('Field can overrun', errors[0].msg)
+        assert len(errors) == 1
+        assert errors[0].id == 'django_mysql.E006'
+        assert 'Field can overrun' in errors[0].msg
 
 
 class TestMigrations(TestCase):
@@ -449,22 +450,19 @@ class TestMigrations(TestCase):
         field = ListCharField(models.IntegerField(), max_length=32)
         name, path, args, kwargs = field.deconstruct()
         new = ListCharField(*args, **kwargs)
-        self.assertEqual(type(new.base_field), type(field.base_field))
+        assert new.base_field.__class__ == field.base_field.__class__
 
     def test_deconstruct_with_size(self):
         field = ListCharField(models.IntegerField(), size=3, max_length=32)
         name, path, args, kwargs = field.deconstruct()
         new = ListCharField(*args, **kwargs)
-        self.assertEqual(new.size, field.size)
+        assert new.size == field.size
 
     def test_deconstruct_args(self):
         field = ListCharField(models.CharField(max_length=5), max_length=32)
         name, path, args, kwargs = field.deconstruct()
         new = ListCharField(*args, **kwargs)
-        self.assertEqual(
-            new.base_field.max_length,
-            field.base_field.max_length
-        )
+        assert new.base_field.max_length == field.base_field.max_length
 
     def test_makemigrations(self):
         field = ListCharField(models.CharField(max_length=5), max_length=32)
@@ -472,20 +470,17 @@ class TestMigrations(TestCase):
 
         # The order of the output max_length/size statements varies by
         # python version, hence a little regexp to match them
-        self.assertRegexpMatches(
-            statement,
-            re.compile(
-                r"""^django_mysql\.models\.ListCharField\(
-                    models\.CharField\(max_length=5\),\ # space here
-                    (
-                        max_length=32,\ size=None|
-                        size=None,\ max_length=32
-                    )
-                    \)$
-                """,
-                re.VERBOSE
-            )
-        )
+        assert re.compile(
+            r"""^django_mysql\.models\.ListCharField\(
+                models\.CharField\(max_length=5\),\ # space here
+                (
+                    max_length=32,\ size=None|
+                    size=None,\ max_length=32
+                )
+                \)$
+            """,
+            re.VERBOSE
+        ).match(statement)
 
     def test_makemigrations_with_size(self):
         field = ListCharField(
@@ -497,20 +492,17 @@ class TestMigrations(TestCase):
 
         # The order of the output max_length/size statements varies by
         # python version, hence a little regexp to match them
-        self.assertRegexpMatches(
-            statement,
-            re.compile(
-                r"""^django_mysql\.models\.ListCharField\(
-                    models\.CharField\(max_length=5\),\ # space here
-                    (
-                        max_length=32,\ size=5|
-                        size=5,\ max_length=32
-                    )
-                    \)$
-                """,
-                re.VERBOSE
-            )
-        )
+        assert re.compile(
+            r"""^django_mysql\.models\.ListCharField\(
+                models\.CharField\(max_length=5\),\ # space here
+                (
+                    max_length=32,\ size=5|
+                    size=5,\ max_length=32
+                )
+                \)$
+            """,
+            re.VERBOSE
+        ).match(statement)
 
     @skip("Unforunately this and the SetCharField equivalent interfere with "
           "each other - the migrations don't seem to roll back smoothly.")
@@ -519,25 +511,17 @@ class TestMigrations(TestCase):
     })
     def test_adding_field_with_default(self):
         table_name = 'django_mysql_tests_intlistdefaultmodel'
+        table_names = connection.introspection.table_names
         with connection.cursor() as cursor:
-            self.assertNotIn(
-                table_name,
-                connection.introspection.table_names(cursor)
-            )
+            assert table_name not in table_names(cursor)
 
         call_command('migrate', 'django_mysql_tests', verbosity=0)
         with connection.cursor() as cursor:
-            self.assertIn(
-                table_name,
-                connection.introspection.table_names(cursor)
-            )
+            assert table_name in table_names(cursor)
 
         call_command('migrate', 'django_mysql_tests', 'zero', verbosity=0)
         with connection.cursor() as cursor:
-            self.assertNotIn(
-                table_name,
-                connection.introspection.table_names(cursor)
-            )
+            assert table_name not in table_names(cursor)
 
 
 class TestSerialization(TestCase):
@@ -546,7 +530,7 @@ class TestSerialization(TestCase):
         instance = CharListModel(field=["big", "comfy"])
         data = json.loads(serializers.serialize('json', [instance]))[0]
         field = data['fields']['field']
-        self.assertEqual(sorted(field.split(',')), ["big", "comfy"])
+        assert sorted(field.split(',')) == ["big", "comfy"]
 
     def test_loading(self):
         test_data = '''
@@ -555,21 +539,18 @@ class TestSerialization(TestCase):
         '''
         objs = list(serializers.deserialize('json', test_data))
         instance = objs[0].object
-        self.assertEqual(instance.field, ["big", "leather", "comfy"])
+        assert instance.field == ["big", "leather", "comfy"]
 
 
 class TestDescription(TestCase):
 
     def test_char(self):
         field = ListCharField(models.CharField(max_length=5), max_length=32)
-        self.assertEqual(
-            field.description,
-            "List of String (up to %(max_length)s)"
-        )
+        assert field.description == "List of String (up to %(max_length)s)"
 
     def test_int(self):
         field = ListCharField(models.IntegerField(), max_length=32)
-        self.assertEqual(field.description, "List of Integer")
+        assert field.description == "List of Integer"
 
 
 class TestFormField(TestCase):
@@ -577,12 +558,12 @@ class TestFormField(TestCase):
     def test_model_field_formfield(self):
         model_field = ListCharField(models.CharField(max_length=27))
         form_field = model_field.formfield()
-        self.assertIsInstance(form_field, SimpleListField)
-        self.assertIsInstance(form_field.base_field, forms.CharField)
-        self.assertEqual(form_field.base_field.max_length, 27)
+        assert isinstance(form_field, SimpleListField)
+        assert isinstance(form_field.base_field, forms.CharField)
+        assert form_field.base_field.max_length == 27
 
     def test_model_field_formfield_size(self):
         model_field = ListCharField(models.IntegerField(), size=4)
         form_field = model_field.formfield()
-        self.assertIsInstance(form_field, SimpleListField)
-        self.assertEqual(form_field.max_length, 4)
+        assert isinstance(form_field, SimpleListField)
+        assert form_field.max_length == 4

--- a/tests/django_mysql_tests/test_locks.py
+++ b/tests/django_mysql_tests/test_locks.py
@@ -1,6 +1,7 @@
 # -*- coding:utf-8 -*-
 from threading import Thread
 
+import pytest
 from django.db import connection
 from django.test import TestCase
 from django.utils.six.moves import queue
@@ -55,9 +56,9 @@ class LockTests(TestCase):
     def test_error_on_unneeded_exit(self):
         mylock = Lock("mylock")
         assert not mylock.is_held()
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as excinfo:
             mylock.__exit__(None, None, None)
-        assert "unheld lock" in str(cm.exception)
+        assert "unheld lock" in str(excinfo.value)
 
     def test_defined_at_import_time(self):
         import_time_lock = self.import_time_lock
@@ -101,7 +102,7 @@ class LockTests(TestCase):
             assert threading_test.is_held()
             assert threading_test.holding_connection_id() != own_connection_id
 
-            with self.assertRaises(TimeoutError):
+            with pytest.raises(TimeoutError):
                 with threading_test:
                         pass
 
@@ -141,7 +142,7 @@ class LockTests(TestCase):
             assert the_lock.is_held()
             assert the_lock.holding_connection_id() != own_connection_id
 
-            with self.assertRaises(TimeoutError):
+            with pytest.raises(TimeoutError):
                 with the_lock:
                     pass
 

--- a/tests/django_mysql_tests/test_locks.py
+++ b/tests/django_mysql_tests/test_locks.py
@@ -36,45 +36,45 @@ class LockTests(TestCase):
 
     def test_simple(self):
         mylock = Lock("mylock")
-        self.assertFalse(mylock.is_held())
+        assert not mylock.is_held()
 
         with mylock:
-            self.assertTrue(mylock.is_held())
-            self.assertTrue(Lock("mylock").is_held())
+            assert mylock.is_held()
+            assert Lock("mylock").is_held()
 
             cursor = connection.cursor()
             cursor.execute("SELECT CONNECTION_ID();")
             own_connection_id = cursor.fetchone()[0]
-            self.assertEqual(mylock.holding_connection_id(),
-                             own_connection_id)
+            assert mylock.holding_connection_id() == own_connection_id
 
-        self.assertFalse(mylock.is_held())
-        self.assertFalse(Lock("mylock").is_held())
+        assert not mylock.is_held()
+        assert not Lock("mylock").is_held()
 
     import_time_lock = Lock('defined_at_import_time')
 
     def test_error_on_unneeded_exit(self):
         mylock = Lock("mylock")
-        self.assertFalse(mylock.is_held())
+        assert not mylock.is_held()
         with self.assertRaises(ValueError) as cm:
             mylock.__exit__(None, None, None)
-        self.assertIn("unheld lock", str(cm.exception))
+        assert "unheld lock" in str(cm.exception)
 
     def test_defined_at_import_time(self):
         import_time_lock = self.import_time_lock
 
-        self.assertFalse(import_time_lock.is_held())
+        assert not import_time_lock.is_held()
 
         with import_time_lock:
-            self.assertTrue(import_time_lock.is_held())
+            assert import_time_lock.is_held()
 
             cursor = connection.cursor()
             cursor.execute("SELECT CONNECTION_ID();")
             own_connection_id = cursor.fetchone()[0]
-            self.assertEqual(import_time_lock.holding_connection_id(),
-                             own_connection_id)
+            assert (
+                import_time_lock.holding_connection_id() == own_connection_id
+            )
 
-        self.assertFalse(import_time_lock.is_held())
+        assert not import_time_lock.is_held()
 
     def test_timeout_with_threads(self):
         to_me = queue.Queue()
@@ -86,21 +86,20 @@ class LockTests(TestCase):
                 to_you.get(True)
 
         threading_test = Lock('threading_test', 0.05)
-        self.assertTrue(not threading_test.is_held())
+        assert not threading_test.is_held()
 
         other_thread = Thread(target=lock_until_told)
         other_thread.start()
         try:
             item = to_me.get(True)
-            self.assertEqual(item, "Locked")
+            assert item == "Locked"
 
             cursor = connection.cursor()
             cursor.execute("SELECT CONNECTION_ID();")
             own_connection_id = cursor.fetchone()[0]
 
-            self.assertTrue(threading_test.is_held())
-            self.assertNotEqual(threading_test.holding_connection_id(),
-                                own_connection_id)
+            assert threading_test.is_held()
+            assert threading_test.holding_connection_id() != own_connection_id
 
             with self.assertRaises(TimeoutError):
                 with threading_test:
@@ -110,7 +109,7 @@ class LockTests(TestCase):
         finally:
             other_thread.join()
 
-        self.assertFalse(threading_test.is_held())
+        assert not threading_test.is_held()
         with threading_test:
             pass
 
@@ -124,7 +123,7 @@ class LockTests(TestCase):
         the_lock = Lock('THElock', 0.05)
 
         def check_it_lock_it():
-            self.assertFalse(the_lock.is_held())
+            assert not the_lock.is_held()
             with the_lock:
                 to_me.put("Locked")
                 to_you.get(True)
@@ -133,15 +132,14 @@ class LockTests(TestCase):
         other_thread.start()
         try:
             item = to_me.get(True)
-            self.assertEqual(item, "Locked")
+            assert item == "Locked"
 
             cursor = connection.cursor()
             cursor.execute("SELECT CONNECTION_ID()")
             own_connection_id = cursor.fetchone()[0]
 
-            self.assertTrue(the_lock.is_held())
-            self.assertNotEqual(the_lock.holding_connection_id(),
-                                own_connection_id)
+            assert the_lock.is_held()
+            assert the_lock.holding_connection_id() != own_connection_id
 
             with self.assertRaises(TimeoutError):
                 with the_lock:
@@ -169,7 +167,7 @@ class LockTests(TestCase):
         lock_a = Lock("a")
         lock_b = Lock("b")
         with lock_a, lock_b:
-            self.assertTrue(lock_a.is_held())
+            assert lock_a.is_held()
 
     def test_multi_connection(self):
         lock_a = Lock("a")
@@ -177,8 +175,8 @@ class LockTests(TestCase):
 
         with lock_a, lock_b:
             # Different connections = can hold > 1!
-            self.assertTrue(lock_a.is_held())
-            self.assertTrue(lock_b.is_held())
+            assert lock_a.is_held()
+            assert lock_b.is_held()
 
     def test_held_with_prefix(self):
         if not self.supports_lock_info:
@@ -187,22 +185,22 @@ class LockTests(TestCase):
                 "which held_with_prefix relies"
             )
 
-        self.assertEqual(Lock.held_with_prefix(''), {})
-        self.assertEqual(Lock.held_with_prefix('mylock'), {})
+        assert Lock.held_with_prefix('') == {}
+        assert Lock.held_with_prefix('mylock') == {}
 
         with Lock('mylock-alpha') as lock:
-            self.assertEqual(
-                Lock.held_with_prefix(''),
+            assert (
+                Lock.held_with_prefix('') ==
                 {'mylock-alpha': lock.holding_connection_id()}
             )
-            self.assertEqual(
-                Lock.held_with_prefix('mylock'),
+            assert (
+                Lock.held_with_prefix('mylock') ==
                 {'mylock-alpha': lock.holding_connection_id()}
             )
-            self.assertEqual(
-                Lock.held_with_prefix('mylock-beta'),
+            assert (
+                Lock.held_with_prefix('mylock-beta') ==
                 {}
             )
 
-        self.assertEqual(Lock.held_with_prefix(''), {})
-        self.assertEqual(Lock.held_with_prefix('mylock'), {})
+        assert Lock.held_with_prefix('') == {}
+        assert Lock.held_with_prefix('mylock') == {}

--- a/tests/django_mysql_tests/test_lookups.py
+++ b/tests/django_mysql_tests/test_lookups.py
@@ -10,31 +10,31 @@ class CaseExactTests(TestCase):
         dickie = Author.objects.create(name="Dickens")
 
         authors = Author.objects.filter(name__case_exact="dickens")
-        self.assertEqual(list(authors), [])
+        assert list(authors) == []
 
         authors = Author.objects.filter(name__case_exact="Dickens")
-        self.assertEqual(list(authors), [dickie])
+        assert list(authors) == [dickie]
 
         authors = Author.objects.filter(name__case_exact="DICKENS")
-        self.assertEqual(list(authors), [])
+        assert list(authors) == []
 
     def test_charfield_lowercase(self):
         dickie = Author.objects.create(name="dickens")
 
         authors = Author.objects.filter(name__case_exact="dickens")
-        self.assertEqual(list(authors), [dickie])
+        assert list(authors) == [dickie]
 
         authors = Author.objects.filter(name__case_exact="Dickens")
-        self.assertEqual(list(authors), [])
+        assert list(authors) == []
 
     def test_textfield(self):
         dickie = Author.objects.create(name="Dickens", bio="Aged 10, bald.")
 
         authors = Author.objects.filter(bio__case_exact="Aged 10, bald.")
-        self.assertEqual(list(authors), [dickie])
+        assert list(authors) == [dickie]
 
         authors = Author.objects.filter(bio__case_exact="Aged 10, BALD.")
-        self.assertEqual(list(authors), [])
+        assert list(authors) == []
 
 
 class SoundexTests(TestCase):
@@ -45,14 +45,14 @@ class SoundexTests(TestCase):
 
         for name in principles:
             sounding = Author.objects.filter(name__sounds_like=name)
-            self.assertEqual(set(sounding), created)
+            assert set(sounding) == created
 
         sounding = Author.objects.filter(name__sounds_like='')
-        self.assertEqual(set(sounding), set())
+        assert set(sounding) == set()
 
         sounding = Author.objects.filter(name__sounds_like='nothing')
-        self.assertEqual(set(sounding), set())
+        assert set(sounding) == set()
 
     def test_soundex_strings(self):
         author = Author.objects.create(name='Robert')
-        self.assertEqual(Author.objects.get(name__soundex='R163'), author)
+        assert Author.objects.get(name__soundex='R163') == author

--- a/tests/django_mysql_tests/test_models.py
+++ b/tests/django_mysql_tests/test_models.py
@@ -1,7 +1,9 @@
 # -*- coding:utf-8 -*-
 import mock
+import re
 from unittest import skipUnless
 
+import pytest
 from django.db.models.query import QuerySet
 from django.template import Context, Template
 from django.test import TransactionTestCase
@@ -23,61 +25,60 @@ class ApproximateCountTests(TransactionTestCase):
         # For a fresh table with 10 items we seem to always get back the actual
         # count, but to be sure we'll just assert it's within 55%
         approx_count = Author.objects.approx_count(min_size=1)
-        self.assertGreaterEqual(approx_count, 4)
-        self.assertLessEqual(approx_count, 16)
+        assert 4 <= approx_count <= 16
 
     def test_activation_deactivation(self):
         qs = Author.objects.all()
-        self.assertFalse(qs._count_tries_approx)
+        assert not qs._count_tries_approx
 
         qs2 = qs.count_tries_approx(min_size=2)
-        self.assertNotEqual(qs, qs2)
-        self.assertTrue(qs2._count_tries_approx)
+        assert qs != qs2
+        assert qs2._count_tries_approx
         count = qs2.count()
-        self.assertTrue(isinstance(count, ApproximateInt))
+        assert isinstance(count, ApproximateInt)
 
         qs3 = qs2.count_tries_approx(False)
-        self.assertNotEqual(qs2, qs3)
-        self.assertFalse(qs3._count_tries_approx)
+        assert qs2 != qs3
+        assert not qs3._count_tries_approx
 
     def test_activation_but_fallback(self):
         qs = Author.objects.exclude(name='TEST').count_tries_approx()
         count = qs.count()
-        self.assertEqual(count, 10)
-        self.assertFalse(isinstance(count, ApproximateInt))
+        assert count == 10
+        assert not isinstance(count, ApproximateInt)
 
     def test_activation_but_fallback_due_to_min_size(self):
         qs = Author.objects.count_tries_approx()
         count = qs.count()
-        self.assertEqual(count, 10)
-        self.assertFalse(isinstance(count, ApproximateInt))
+        assert count == 10
+        assert not isinstance(count, ApproximateInt)
 
     def test_output_in_templates(self):
         approx_count = Author.objects.approx_count(min_size=1)
         text = Template('{{ var }}').render(Context({'var': approx_count}))
-        self.assertTrue(text.startswith('Approximately '))
+        assert text.startswith('Approximately ')
 
         approx_count2 = Author.objects.approx_count(
             min_size=1,
             return_approx_int=False
         )
         text = Template('{{ var }}').render(Context({'var': approx_count2}))
-        self.assertFalse(text.startswith('Approximately '))
+        assert not text.startswith('Approximately ')
 
     def test_fallback_with_filters(self):
         filtered = Author.objects.filter(name='')
-        self.assertEqual(filtered.approx_count(fall_back=True), 10)
-        with self.assertRaises(ValueError):
+        assert filtered.approx_count(fall_back=True) == 10
+        with pytest.raises(ValueError):
             filtered.approx_count(fall_back=False)
 
     def test_fallback_with_slice(self):
-        self.assertEqual(Author.objects.all()[:100].approx_count(), 10)
-        with self.assertRaises(ValueError):
+        assert Author.objects.all()[:100].approx_count() == 10
+        with pytest.raises(ValueError):
             Author.objects.all()[:100].approx_count(fall_back=False)
 
     def test_fallback_with_distinct(self):
-        self.assertEqual(Author.objects.distinct().approx_count(), 10)
-        with self.assertRaises(ValueError):
+        assert Author.objects.distinct().approx_count() == 10
+        with pytest.raises(ValueError):
             Author.objects.distinct().approx_count(fall_back=False)
 
 
@@ -88,17 +89,17 @@ class SmartIteratorTests(TransactionTestCase):
         Author.objects.bulk_create([Author() for i in range(10)])
 
     def test_bad_querysets(self):
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as excinfo:
             Author.objects.all().order_by('name').iter_smart_chunks()
-        self.assertIn("ordering", str(cm.exception))
+        assert "ordering" in str(excinfo.value)
 
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as excinfo:
             Author.objects.all()[:5].iter_smart_chunks()
-        self.assertIn("sliced QuerySet", str(cm.exception))
+        assert "sliced QuerySet" in str(excinfo.value)
 
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as excinfo:
             NameAuthor.objects.all().iter_smart_chunks()
-        self.assertIn("non-integer primary key", str(cm.exception))
+        assert "non-integer primary key" in str(excinfo.value)
 
     def test_chunks(self):
         seen = []
@@ -107,32 +108,32 @@ class SmartIteratorTests(TransactionTestCase):
 
         all_ids = list(Author.objects.order_by('id')
                                      .values_list('id', flat=True))
-        self.assertEqual(seen, all_ids)
+        assert seen == all_ids
 
     def test_objects(self):
         seen = [author.id for author in Author.objects.iter_smart()]
         all_ids = list(Author.objects.order_by('id')
                                      .values_list('id', flat=True))
-        self.assertEqual(seen, all_ids)
+        assert seen == all_ids
 
     def test_objects_non_atomic(self):
         seen = [author.id for author in
                 Author.objects.iter_smart(atomically=False)]
         all_ids = list(Author.objects.order_by('id')
                                      .values_list('id', flat=True))
-        self.assertEqual(seen, all_ids)
+        assert seen == all_ids
 
     def test_objects_pk_range_all(self):
         seen = [author.id for author in
                 Author.objects.iter_smart(pk_range='all')]
         all_ids = list(Author.objects.order_by('id')
                                      .values_list('id', flat=True))
-        self.assertEqual(seen, all_ids)
+        assert seen == all_ids
 
     def test_objects_pk_range_tuple(self):
         seen = [author.id for author in
                 Author.objects.iter_smart(pk_range=(0, 0))]
-        self.assertEqual(seen, [])
+        assert seen == []
 
         min_id = Author.objects.earliest('id').id
         max_id = Author.objects.order_by('id')[5].id
@@ -142,12 +143,12 @@ class SmartIteratorTests(TransactionTestCase):
         cut_ids = list(Author.objects.order_by('id')
                                      .filter(id__gte=min_id, id__lte=max_id)
                                      .values_list('id', flat=True))
-        self.assertEqual(seen, cut_ids)
+        assert seen == cut_ids
 
     def test_objects_pk_range_bad(self):
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as excinfo:
             list(Author.objects.iter_smart(pk_range="My Bad Value"))
-        self.assertIn("Unrecognized value for pk_range", str(cm.exception))
+        assert "Unrecognized value for pk_range" in str(excinfo.value)
 
     def test_pk_range_race_condition(self):
         getitem = QuerySet.__getitem__
@@ -167,31 +168,31 @@ class SmartIteratorTests(TransactionTestCase):
 
         with mock.patch(path, fail_second_slice):
             seen = [author.id for author in Author.objects.iter_smart()]
-        self.assertEqual(seen, [])
+        assert seen == []
 
     def test_objects_max_size(self):
         seen = [author.id for author in
                 Author.objects.iter_smart(chunk_max=1)]
         all_ids = list(Author.objects.order_by('id')
                                      .values_list('id', flat=True))
-        self.assertEqual(seen, all_ids)
+        assert seen == all_ids
 
     def test_no_matching_objects(self):
         seen = [author.id for author in
                 Author.objects.filter(name="Waaa").iter_smart()]
-        self.assertEqual(seen, [])
+        assert seen == []
 
     def test_no_objects(self):
         Author.objects.all().delete()
         seen = [author.id for author in Author.objects.iter_smart()]
-        self.assertEqual(seen, [])
+        assert seen == []
 
     def test_pk_hole(self):
         first = Author.objects.earliest('id')
         last = Author.objects.latest('id')
         Author.objects.filter(id__gt=first.id, id__lt=last.id).delete()
         seen = [author.id for author in Author.objects.iter_smart()]
-        self.assertEqual(seen, [first.id, last.id])
+        assert seen == [first.id, last.id]
 
     def test_reporting(self):
         with captured_stdout() as output:
@@ -203,13 +204,13 @@ class SmartIteratorTests(TransactionTestCase):
 
         reports = lines[0].split('\r')
         for report in reports:
-            self.assertRegexpMatches(
-                report,
+            assert re.match(
                 r"AuthorSmartChunkedIterator processed \d+/10 objects "
-                r"\(\d+\.\d+%\) in \d+ chunks(; highest pk so far \d+)?"
+                r"\(\d+\.\d+%\) in \d+ chunks(; highest pk so far \d+)?",
+                report
             )
 
-        self.assertEqual(lines[1], 'Finished!')
+        assert lines[1] == 'Finished!'
 
     def test_reporting_with_total(self):
         with captured_stdout() as output:
@@ -221,13 +222,13 @@ class SmartIteratorTests(TransactionTestCase):
 
         reports = lines[0].split('\r')
         for report in reports:
-            self.assertRegexpMatches(
-                report,
+            assert re.match(
                 r"AuthorSmartChunkedIterator processed \d+/4 objects "
-                r"\(\d+\.\d+%\) in \d+ chunks(; highest pk so far \d+)?"
+                r"\(\d+\.\d+%\) in \d+ chunks(; highest pk so far \d+)?",
+                report
             )
 
-        self.assertEqual(lines[1], 'Finished!')
+        assert lines[1] == 'Finished!'
 
     def test_reporting_on_uncounted_qs(self):
         Author.objects.create(name="pants")
@@ -241,15 +242,15 @@ class SmartIteratorTests(TransactionTestCase):
 
         reports = lines[0].split('\r')
         for report in reports:
-            self.assertRegexpMatches(
-                report,
+            assert re.match(
                 # We should have ??? since the deletion means the objects
                 # aren't fetched into python
                 r"AuthorSmartChunkedIterator processed (0|\?\?\?)/1 objects "
-                r"\(\d+\.\d+%\) in \d+ chunks(; highest pk so far \d+)?"
+                r"\(\d+\.\d+%\) in \d+ chunks(; highest pk so far \d+)?",
+                report
             )
 
-        self.assertEqual(lines[1], 'Finished!')
+        assert lines[1] == 'Finished!'
 
     def test_running_on_non_mysql_model(self):
         VanillaAuthor.objects.create(name="Alpha")
@@ -259,13 +260,13 @@ class SmartIteratorTests(TransactionTestCase):
 
         bad_authors = VanillaAuthor.objects.filter(name="pants")
 
-        self.assertEqual(bad_authors.count(), 2)
+        assert bad_authors.count() == 2
 
         with captured_stdout():
             for author in SmartIterator(bad_authors, report_progress=True):
                 author.delete()
 
-        self.assertEqual(bad_authors.count(), 0)
+        assert bad_authors.count() == 0
 
 
 @skipUnless(have_program('pt-visual-explain'),
@@ -276,26 +277,23 @@ class VisualExplainTests(TransactionTestCase):
         with captured_stdout() as capture:
             Author.objects.all().pt_visual_explain()
         output = capture.getvalue()
-        self.assertGreater(output, "")
         # Can't be too strict about the output since different database and pt-
         # visual-explain versions give different output
-        self.assertIn("django_mysql_tests_author", output)
-        self.assertIn("rows", output)
-        self.assertIn("Table", output)
+        assert "django_mysql_tests_author" in output
+        assert "rows" in output
+        assert "Table" in output
 
     def test_basic_no_display(self):
         output = Author.objects.all().pt_visual_explain(display=False)
-        self.assertGreater(output, "")
-        self.assertIn("django_mysql_tests_author", output)
-        self.assertIn("rows", output)
-        self.assertIn("Table", output)
+        assert "django_mysql_tests_author" in output
+        assert "rows" in output
+        assert "Table" in output
 
     def test_subquery(self):
         subq = Author.objects.all().values_list('id', flat=True)
         output = Author.objects.filter(id__in=subq) \
                                .pt_visual_explain(display=False)
-        self.assertGreater(output, "")
-        self.assertIn("possible_keys", output)
-        self.assertIn("django_mysql_tests_author", output)
-        self.assertIn("rows", output)
-        self.assertIn("Table", output)
+        assert "possible_keys" in output
+        assert "django_mysql_tests_author" in output
+        assert "rows" in output
+        assert "Table" in output

--- a/tests/django_mysql_tests/test_monkey_patches.py
+++ b/tests/django_mysql_tests/test_monkey_patches.py
@@ -14,7 +14,7 @@ class IsMariaDBTests(TestCase):
                 version = cursor.fetchone()[0]
 
             is_mariadb = ('MariaDB' in version)
-            self.assertEqual(connection.is_mariadb, is_mariadb)
+            assert connection.is_mariadb == is_mariadb
 
             # Check it was cached by cached_property
-            self.assertIn('is_mariadb', connection.__dict__)
+            assert 'is_mariadb' in connection.__dict__

--- a/tests/django_mysql_tests/test_setcharfield.py
+++ b/tests/django_mysql_tests/test_setcharfield.py
@@ -5,6 +5,7 @@ from unittest import skipIf
 
 import ddt
 import django
+import pytest
 from django import forms
 from django.core import exceptions, serializers
 from django.core.management import call_command
@@ -26,55 +27,55 @@ class TestSaveLoad(TestCase):
 
     def test_char_easy(self):
         s = CharSetModel.objects.create(field={"big", "comfy"})
-        self.assertEqual(s.field, {"comfy", "big"})
+        assert s.field == {"comfy", "big"}
         s = CharSetModel.objects.get(id=s.id)
-        self.assertEqual(s.field, {"comfy", "big"})
+        assert s.field == {"comfy", "big"}
 
         s.field.add("round")
         s.save()
-        self.assertEqual(s.field, {"comfy", "big", "round"})
+        assert s.field == {"comfy", "big", "round"}
         s = CharSetModel.objects.get(id=s.id)
-        self.assertEqual(s.field, {"comfy", "big", "round"})
+        assert s.field == {"comfy", "big", "round"}
 
     def test_char_string_direct(self):
         s = CharSetModel.objects.create(field="big,bad")
         s = CharSetModel.objects.get(id=s.id)
-        self.assertEqual(s.field, {'big', 'bad'})
+        assert s.field == {'big', 'bad'}
 
     def test_is_a_set_immediately(self):
         s = CharSetModel()
-        self.assertEqual(s.field, set())
+        assert s.field == set()
         s.field.add("bold")
         s.field.add("brave")
         s.save()
-        self.assertEqual(s.field, {"bold", "brave"})
+        assert s.field == {"bold", "brave"}
         s = CharSetModel.objects.get(id=s.id)
-        self.assertEqual(s.field, {"bold", "brave"})
+        assert s.field == {"bold", "brave"}
 
     def test_empty(self):
         s = CharSetModel.objects.create()
-        self.assertEqual(s.field, set())
+        assert s.field == set()
         s = CharSetModel.objects.get(id=s.id)
-        self.assertEqual(s.field, set())
+        assert s.field == set()
 
     def test_char_cant_create_sets_with_empty_string(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             CharSetModel.objects.create(field={""})
 
     def test_char_cant_create_sets_with_commas(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             CharSetModel.objects.create(field={"co,mma", "contained"})
 
     def test_char_basic_lookup(self):
         mymodel = CharSetModel.objects.create()
         empty = CharSetModel.objects.filter(field="")
 
-        self.assertEqual(empty.count(), 1)
-        self.assertEqual(empty[0], mymodel)
+        assert empty.count() == 1
+        assert empty[0] == mymodel
 
         mymodel.delete()
 
-        self.assertEqual(empty.count(), 0)
+        assert empty.count() == 0
 
     @ddt.data('contains', 'icontains')
     def test_char_lookup(self, lookup):
@@ -82,117 +83,117 @@ class TestSaveLoad(TestCase):
         mymodel = CharSetModel.objects.create(field={"mouldy", "rotten"})
 
         mouldy = CharSetModel.objects.filter(**{lname: "mouldy"})
-        self.assertEqual(mouldy.count(), 1)
-        self.assertEqual(mouldy[0], mymodel)
+        assert mouldy.count() == 1
+        assert mouldy[0] == mymodel
 
         rotten = CharSetModel.objects.filter(**{lname: "rotten"})
-        self.assertEqual(rotten.count(), 1)
-        self.assertEqual(rotten[0], mymodel)
+        assert rotten.count() == 1
+        assert rotten[0] == mymodel
 
         clean = CharSetModel.objects.filter(**{lname: "clean"})
-        self.assertEqual(clean.count(), 0)
+        assert clean.count() == 0
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             list(CharSetModel.objects.filter(**{lname: {"a", "b"}}))
 
         both = CharSetModel.objects.filter(
             Q(**{lname: "mouldy"}) & Q(**{lname: "rotten"})
         )
-        self.assertEqual(both.count(), 1)
-        self.assertEqual(both[0], mymodel)
+        assert both.count() == 1
+        assert both[0] == mymodel
 
         either = CharSetModel.objects.filter(
             Q(**{lname: "mouldy"}) | Q(**{lname: "clean"})
         )
-        self.assertEqual(either.count(), 1)
+        assert either.count() == 1
 
         not_clean = CharSetModel.objects.exclude(**{lname: "clean"})
-        self.assertEqual(not_clean.count(), 1)
+        assert not_clean.count() == 1
 
         not_mouldy = CharSetModel.objects.exclude(**{lname: "mouldy"})
-        self.assertEqual(not_mouldy.count(), 0)
+        assert not_mouldy.count() == 0
 
     def test_char_len_lookup_empty(self):
         mymodel = CharSetModel.objects.create(field=set())
 
         empty = CharSetModel.objects.filter(field__len=0)
-        self.assertEqual(empty.count(), 1)
-        self.assertEqual(empty[0], mymodel)
+        assert empty.count() == 1
+        assert empty[0] == mymodel
 
         one = CharSetModel.objects.filter(field__len=1)
-        self.assertEqual(one.count(), 0)
+        assert one.count() == 0
 
         one_or_more = CharSetModel.objects.filter(field__len__gte=0)
-        self.assertEqual(one_or_more.count(), 1)
+        assert one_or_more.count() == 1
 
     def test_char_len_lookup(self):
         mymodel = CharSetModel.objects.create(field={"red", "expensive"})
 
         empty = CharSetModel.objects.filter(field__len=0)
-        self.assertEqual(empty.count(), 0)
+        assert empty.count() == 0
 
         one_or_more = CharSetModel.objects.filter(field__len__gte=1)
-        self.assertEqual(one_or_more.count(), 1)
-        self.assertEqual(one_or_more[0], mymodel)
+        assert one_or_more.count() == 1
+        assert one_or_more[0] == mymodel
 
         two = CharSetModel.objects.filter(field__len=2)
-        self.assertEqual(two.count(), 1)
-        self.assertEqual(two[0], mymodel)
+        assert two.count() == 1
+        assert two[0] == mymodel
 
         three = CharSetModel.objects.filter(field__len=3)
-        self.assertEqual(three.count(), 0)
+        assert three.count() == 0
 
     def test_char_default(self):
         mymodel = CharSetDefaultModel.objects.create()
-        self.assertEqual(mymodel.field, {"a", "d"})
+        assert mymodel.field == {"a", "d"}
 
         mymodel = CharSetDefaultModel.objects.get(id=mymodel.id)
-        self.assertEqual(mymodel.field, {"a", "d"})
+        assert mymodel.field == {"a", "d"}
 
     def test_int_easy(self):
         mymodel = IntSetModel.objects.create(field={1, 2})
-        self.assertEqual(mymodel.field, {1, 2})
+        assert mymodel.field == {1, 2}
         mymodel = IntSetModel.objects.get(id=mymodel.id)
-        self.assertEqual(mymodel.field, {1, 2})
+        assert mymodel.field == {1, 2}
 
     def test_int_contains_lookup(self):
         onetwo = IntSetModel.objects.create(field={1, 2})
 
         ones = IntSetModel.objects.filter(field__contains=1)
-        self.assertEqual(ones.count(), 1)
-        self.assertEqual(ones[0], onetwo)
+        assert ones.count() == 1
+        assert ones[0] == onetwo
 
         twos = IntSetModel.objects.filter(field__contains=2)
-        self.assertEqual(twos.count(), 1)
-        self.assertEqual(twos[0], onetwo)
+        assert twos.count() == 1
+        assert twos[0] == onetwo
 
         threes = IntSetModel.objects.filter(field__contains=3)
-        self.assertEqual(threes.count(), 0)
+        assert threes.count() == 0
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             list(IntSetModel.objects.filter(field__contains={1, 2}))
 
         ones_and_twos = IntSetModel.objects.filter(
             Q(field__contains=1) & Q(field__contains=2)
         )
-        self.assertEqual(ones_and_twos.count(), 1)
-        self.assertEqual(ones_and_twos[0], onetwo)
+        assert ones_and_twos.count() == 1
+        assert ones_and_twos[0] == onetwo
 
         ones_and_threes = IntSetModel.objects.filter(
             Q(field__contains=1) & Q(field__contains=3)
         )
-        self.assertEqual(ones_and_threes.count(), 0)
+        assert ones_and_threes.count() == 0
 
         ones_or_threes = IntSetModel.objects.filter(
             Q(field__contains=1) | Q(field__contains=3)
         )
-        self.assertEqual(ones_or_threes.count(), 1)
+        assert ones_or_threes.count() == 1
 
         no_three = IntSetModel.objects.exclude(field__contains=3)
-        self.assertEqual(no_three.count(), 1)
+        assert no_three.count() == 1
 
         no_one = IntSetModel.objects.exclude(field__contains=1)
-        self.assertEqual(no_one.count(), 0)
+        assert no_one.count() == 0
 
 
 @skipIf(django.VERSION <= (1, 8),
@@ -203,33 +204,33 @@ class TestSetF(TestCase):
         CharSetModel.objects.create(field=set())
         CharSetModel.objects.update(field=SetF('field').add('first'))
         model = CharSetModel.objects.get()
-        self.assertEqual(model.field, {"first"})
+        assert model.field == {"first"}
 
     def test_add_to_one(self):
         CharSetModel.objects.create(field={"big"})
         CharSetModel.objects.update(field=SetF('field').add('bad'))
         model = CharSetModel.objects.get()
-        self.assertEqual(model.field, {"big", "bad"})
+        assert model.field == {"big", "bad"}
 
     def test_add_to_some(self):
         CharSetModel.objects.create(field={"big", "blue"})
         CharSetModel.objects.update(field=SetF('field').add('round'))
         model = CharSetModel.objects.get()
-        self.assertEqual(model.field, {"big", "blue", "round"})
+        assert model.field == {"big", "blue", "round"}
 
     def test_add_to_multiple_objects(self):
         CharSetModel.objects.create(field={"mouse"})
         CharSetModel.objects.create(field={"keyboard"})
         CharSetModel.objects.update(field=SetF('field').add("screen"))
         first, second = tuple(CharSetModel.objects.all())
-        self.assertEqual(first.field, {"mouse", "screen"})
-        self.assertEqual(second.field, {"keyboard", "screen"})
+        assert first.field == {"mouse", "screen"}
+        assert second.field == {"keyboard", "screen"}
 
     def test_add_exists(self):
         CharSetModel.objects.create(field={"nice"})
         CharSetModel.objects.update(field=SetF('field').add("nice"))
         model = CharSetModel.objects.get()
-        self.assertEqual(model.field, {"nice"})
+        assert model.field == {"nice"}
 
     @override_mysql_variables(SQL_MODE="ANSI")
     def test_add_works_in_ansi_mode(self):
@@ -237,67 +238,67 @@ class TestSetF(TestCase):
         CharSetModel.objects.update(field=SetF('field').add('big'))
         CharSetModel.objects.update(field=SetF('field').add('bad'))
         model = CharSetModel.objects.get()
-        self.assertEqual(model.field, {"big", "bad"})
+        assert model.field == {"big", "bad"}
 
     def test_add_assignment(self):
         model = CharSetModel.objects.create(field={"red"})
         model.field = SetF('field').add('blue')
         model.save()
         model = CharSetModel.objects.get()
-        self.assertEqual(model.field, {'red', 'blue'})
+        assert model.field == {'red', 'blue'}
 
     def test_remove_one(self):
         CharSetModel.objects.create(field={"dopey", "knifey"})
         CharSetModel.objects.update(field=SetF('field').remove('knifey'))
         model = CharSetModel.objects.get()
-        self.assertEqual(model.field, {"dopey"})
+        assert model.field == {"dopey"}
 
     def test_remove_only_one(self):
         CharSetModel.objects.create(field={"pants"})
         CharSetModel.objects.update(field=SetF('field').remove('pants'))
         model = CharSetModel.objects.get()
-        self.assertEqual(model.field, set())
+        assert model.field == set()
 
     def test_remove_from_none(self):
         CharSetModel.objects.create(field=set())
         CharSetModel.objects.update(field=SetF("field").remove("jam"))
         model = CharSetModel.objects.get()
-        self.assertEqual(model.field, set())
+        assert model.field == set()
 
     def test_remove_first(self):
         CharSetModel.objects.create()
         CharSetModel.objects.update(field="a,b,c")
         CharSetModel.objects.update(field=SetF('field').remove('a'))
         model = CharSetModel.objects.get()
-        self.assertEqual(model.field, {"b", "c"})
+        assert model.field == {"b", "c"}
 
     def test_remove_middle(self):
         CharSetModel.objects.create()
         CharSetModel.objects.update(field="a,b,c")
         CharSetModel.objects.update(field=SetF('field').remove('b'))
         model = CharSetModel.objects.get()
-        self.assertEqual(model.field, {"a", "c"})
+        assert model.field == {"a", "c"}
 
     def test_remove_last(self):
         CharSetModel.objects.create()
         CharSetModel.objects.update(field="a,b,c")
         CharSetModel.objects.update(field=SetF('field').remove('c'))
         model = CharSetModel.objects.get()
-        self.assertEqual(model.field, {"a", "b"})
+        assert model.field == {"a", "b"}
 
     def test_remove_not_exists(self):
         CharSetModel.objects.create(field={"nice"})
         CharSetModel.objects.update(field=SetF("field").remove("naughty"))
         model = CharSetModel.objects.get()
-        self.assertEqual(model.field, {"nice"})
+        assert model.field == {"nice"}
 
     def test_remove_from_multiple_objects(self):
         CharSetModel.objects.create(field={"mouse", "chair"})
         CharSetModel.objects.create(field={"keyboard", "chair"})
         CharSetModel.objects.update(field=SetF('field').remove("chair"))
         first, second = tuple(CharSetModel.objects.all())
-        self.assertEqual(first.field, {"mouse"})
-        self.assertEqual(second.field, {"keyboard"})
+        assert first.field == {"mouse"}
+        assert second.field == {"keyboard"}
 
     @override_mysql_variables(SQL_MODE="ANSI")
     def test_remove_works_in_ansi_mode(self):
@@ -306,14 +307,14 @@ class TestSetF(TestCase):
         CharSetModel.objects.update(field=SetF('field').remove('bold'))
         CharSetModel.objects.update(field=SetF('field').remove('bad'))
         model = CharSetModel.objects.get()
-        self.assertEqual(model.field, set())
+        assert model.field == set()
 
     def test_remove_assignment(self):
         model = IntSetModel.objects.create(field={24, 89})
         model.field = SetF('field').remove(89)
         model.save()
         model = IntSetModel.objects.get()
-        self.assertEqual(model.field, {24})
+        assert model.field == {24}
 
     def test_works_with_two_fields(self):
         CharSetModel.objects.create(field={"snickers", "lion"},
@@ -323,22 +324,22 @@ class TestSetF(TestCase):
         CharSetModel.objects.update(field=SetF('field').add("mars"),
                                     field2=SetF('field2').add("banana"))
         model = CharSetModel.objects.get()
-        self.assertEqual(model.field, {"snickers", "lion", "mars"})
-        self.assertEqual(model.field2, {"apple", "orange", "banana"})
+        assert model.field == {"snickers", "lion", "mars"}
+        assert model.field2 == {"apple", "orange", "banana"}
 
         # Concurrent add and remove
         CharSetModel.objects.update(field=SetF('field').add("reeses"),
                                     field2=SetF('field2').remove("banana"))
         model = CharSetModel.objects.get()
-        self.assertEqual(model.field, {"snickers", "lion", "mars", "reeses"})
-        self.assertEqual(model.field2, {"apple", "orange"})
+        assert model.field == {"snickers", "lion", "mars", "reeses"}
+        assert model.field2 == {"apple", "orange"}
 
         # Swap
         CharSetModel.objects.update(field=SetF('field').remove("lion"),
                                     field2=SetF('field2').remove("apple"))
         model = CharSetModel.objects.get()
-        self.assertEqual(model.field, {"snickers", "mars", "reeses"})
-        self.assertEqual(model.field2, {"orange"})
+        assert model.field == {"snickers", "mars", "reeses"}
+        assert model.field2 == {"orange"}
 
 
 @skipIf(django.VERSION >= (1, 8),
@@ -346,7 +347,7 @@ class TestSetF(TestCase):
 class TestSetFFails(TestCase):
 
     def test_cannot_instantiate(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             SetF('field').add("something")
 
 
@@ -361,10 +362,10 @@ class TestValidation(TestCase):
 
         field.clean({'a', 'b', 'c'}, None)
 
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with pytest.raises(exceptions.ValidationError) as excinfo:
             field.clean({'a', 'b', 'c', 'd'}, None)
-        self.assertEqual(
-            cm.exception.messages[0],
+        assert (
+            excinfo.value.messages[0] ==
             'Set contains 4 items, it should contain no more than 3.'
         )
 
@@ -375,10 +376,10 @@ class TestCheck(TestCase):
         field = SetCharField(models.CharField(), max_length=32)
         field.set_attributes_from_name('field')
         errors = field.check()
-        self.assertEqual(len(errors), 1)
-        self.assertEqual(errors[0].id, 'django_mysql.E001')
-        self.assertIn('Base field for set has errors', errors[0].msg)
-        self.assertIn('max_length', errors[0].msg)
+        assert len(errors) == 1
+        assert errors[0].id == 'django_mysql.E001'
+        assert 'Base field for set has errors' in errors[0].msg
+        assert 'max_length' in errors[0].msg
 
     def test_invalid_base_fields(self):
         field = SetCharField(
@@ -387,9 +388,9 @@ class TestCheck(TestCase):
         )
         field.set_attributes_from_name('field')
         errors = field.check()
-        self.assertEqual(len(errors), 1)
-        self.assertEqual(errors[0].id, 'django_mysql.E002')
-        self.assertIn('Base field for set must be', errors[0].msg)
+        assert len(errors) == 1
+        assert errors[0].id == 'django_mysql.E002'
+        assert 'Base field for set must be' in errors[0].msg
 
     def test_max_length_including_base(self):
         field = SetCharField(
@@ -397,9 +398,9 @@ class TestCheck(TestCase):
             size=2, max_length=32)
         field.set_attributes_from_name('field')
         errors = field.check()
-        self.assertEqual(len(errors), 1)
-        self.assertEqual(errors[0].id, 'django_mysql.E003')
-        self.assertIn('Field can overrun', errors[0].msg)
+        assert len(errors) == 1
+        assert errors[0].id == 'django_mysql.E003'
+        assert 'Field can overrun' in errors[0].msg
 
 
 class TestMigrations(TestCase):
@@ -408,22 +409,19 @@ class TestMigrations(TestCase):
         field = SetCharField(models.IntegerField(), max_length=32)
         name, path, args, kwargs = field.deconstruct()
         new = SetCharField(*args, **kwargs)
-        self.assertEqual(type(new.base_field), type(field.base_field))
+        assert new.base_field.__class__ == field.base_field.__class__
 
     def test_deconstruct_with_size(self):
         field = SetCharField(models.IntegerField(), size=3, max_length=32)
         name, path, args, kwargs = field.deconstruct()
         new = SetCharField(*args, **kwargs)
-        self.assertEqual(new.size, field.size)
+        assert new.size == field.size
 
     def test_deconstruct_args(self):
         field = SetCharField(models.CharField(max_length=5), max_length=32)
         name, path, args, kwargs = field.deconstruct()
         new = SetCharField(*args, **kwargs)
-        self.assertEqual(
-            new.base_field.max_length,
-            field.base_field.max_length
-        )
+        assert new.base_field.max_length == field.base_field.max_length
 
     def test_makemigrations(self):
         field = SetCharField(models.CharField(max_length=5), max_length=32)
@@ -431,20 +429,17 @@ class TestMigrations(TestCase):
 
         # The order of the output max_length/size statements varies by
         # python version, hence a little regexp to match them
-        self.assertRegexpMatches(
-            statement,
-            re.compile(
-                r"""^django_mysql\.models\.SetCharField\(
-                    models\.CharField\(max_length=5\),\ # space here
-                    (
-                        max_length=32,\ size=None|
-                        size=None,\ max_length=32
-                    )
-                    \)$
-                """,
-                re.VERBOSE
-            )
-        )
+        assert re.compile(
+            r"""^django_mysql\.models\.SetCharField\(
+                models\.CharField\(max_length=5\),\ # space here
+                (
+                    max_length=32,\ size=None|
+                    size=None,\ max_length=32
+                )
+                \)$
+            """,
+            re.VERBOSE
+        ).match(statement)
 
     def test_makemigrations_with_size(self):
         field = SetCharField(
@@ -456,45 +451,34 @@ class TestMigrations(TestCase):
 
         # The order of the output max_length/size statements varies by
         # python version, hence a little regexp to match them
-        self.assertRegexpMatches(
-            statement,
-            re.compile(
-                r"""^django_mysql\.models\.SetCharField\(
-                    models\.CharField\(max_length=5\),\ # space here
-                    (
-                        max_length=32,\ size=5|
-                        size=5,\ max_length=32
-                    )
-                    \)$
-                """,
-                re.VERBOSE
-            )
-        )
+        assert re.compile(
+            r"""^django_mysql\.models\.SetCharField\(
+                models\.CharField\(max_length=5\),\ # space here
+                (
+                    max_length=32,\ size=5|
+                    size=5,\ max_length=32
+                )
+                \)$
+            """,
+            re.VERBOSE
+        ).match(statement)
 
     @override_settings(MIGRATION_MODULES={
         "django_mysql_tests": "django_mysql_tests.set_default_migrations",
     })
     def test_adding_field_with_default(self):
         table_name = 'django_mysql_tests_intsetdefaultmodel'
+        table_names = connection.introspection.table_names
         with connection.cursor() as cursor:
-            self.assertNotIn(
-                table_name,
-                connection.introspection.table_names(cursor)
-            )
+            assert table_name not in table_names(cursor)
 
         call_command('migrate', 'django_mysql_tests', verbosity=0)
         with connection.cursor() as cursor:
-            self.assertIn(
-                table_name,
-                connection.introspection.table_names(cursor)
-            )
+            assert table_name in table_names(cursor)
 
         call_command('migrate', 'django_mysql_tests', 'zero', verbosity=0)
         with connection.cursor() as cursor:
-            self.assertNotIn(
-                table_name,
-                connection.introspection.table_names(cursor)
-            )
+            assert table_name not in table_names(cursor)
 
 
 class TestSerialization(TestCase):
@@ -503,7 +487,7 @@ class TestSerialization(TestCase):
         instance = CharSetModel(field={"big", "comfy"})
         data = json.loads(serializers.serialize('json', [instance]))[0]
         field = data['fields']['field']
-        self.assertEqual(sorted(field.split(',')), ["big", "comfy"])
+        assert sorted(field.split(',')) == ["big", "comfy"]
 
     def test_loading(self):
         test_data = '''
@@ -512,21 +496,18 @@ class TestSerialization(TestCase):
         '''
         objs = list(serializers.deserialize('json', test_data))
         instance = objs[0].object
-        self.assertEqual(instance.field, {"big", "leather", "comfy"})
+        assert instance.field == {"big", "leather", "comfy"}
 
 
 class TestDescription(TestCase):
 
     def test_char(self):
         field = SetCharField(models.CharField(max_length=5), max_length=32)
-        self.assertEqual(
-            field.description,
-            "Set of String (up to %(max_length)s)"
-        )
+        assert field.description == "Set of String (up to %(max_length)s)"
 
     def test_int(self):
         field = SetCharField(models.IntegerField(), max_length=32)
-        self.assertEqual(field.description, "Set of Integer")
+        assert field.description == "Set of Integer"
 
 
 class TestFormField(TestCase):
@@ -534,12 +515,12 @@ class TestFormField(TestCase):
     def test_model_field_formfield(self):
         model_field = SetCharField(models.CharField(max_length=27))
         form_field = model_field.formfield()
-        self.assertIsInstance(form_field, SimpleSetField)
-        self.assertIsInstance(form_field.base_field, forms.CharField)
-        self.assertEqual(form_field.base_field.max_length, 27)
+        assert isinstance(form_field, SimpleSetField)
+        assert isinstance(form_field.base_field, forms.CharField)
+        assert form_field.base_field.max_length == 27
 
     def test_model_field_formfield_size(self):
         model_field = SetCharField(models.IntegerField(), size=4)
         form_field = model_field.formfield()
-        self.assertIsInstance(form_field, SimpleSetField)
-        self.assertEqual(form_field.max_length, 4)
+        assert isinstance(form_field, SimpleSetField)
+        assert form_field.max_length == 4

--- a/tests/django_mysql_tests/test_status.py
+++ b/tests/django_mysql_tests/test_status.py
@@ -11,58 +11,58 @@ class GlobalStatusTests(TestCase):
 
     def test_get(self):
         running = global_status.get('Threads_running')
-        self.assertTrue(isinstance(running, int))
-        self.assertGreaterEqual(running, 1)
+        assert isinstance(running, int)
+        assert running >= 1
 
         cost = global_status.get('Last_query_cost')
-        self.assertTrue(isinstance(cost, float))
-        self.assertGreaterEqual(cost, 0.00)
+        assert isinstance(cost, float)
+        assert cost >= 0.0
 
         with self.assertRaises(ValueError) as cm:
             global_status.get('foo%')
-        self.assertIn('wildcards', str(cm.exception))
+        assert 'wildcards' in str(cm.exception)
 
         with self.assertRaises(KeyError):
             global_status.get('Does_not_exist')
 
     def test_get_many(self):
         myvars = global_status.get_many([])
-        self.assertEqual(myvars, {})
+        assert myvars == {}
 
         myvars = global_status.get_many(['Threads_running', 'Uptime'])
-        self.assertTrue(isinstance(myvars, dict))
-        self.assertIn('Threads_running', myvars)
-        self.assertTrue(isinstance(myvars['Threads_running'], int))
-        self.assertIn('Uptime', myvars)
-        self.assertTrue(isinstance(myvars['Uptime'], int))
+        assert isinstance(myvars, dict)
+        assert 'Threads_running' in myvars
+        assert isinstance(myvars['Threads_running'], int)
+        assert 'Uptime' in myvars
+        assert isinstance(myvars['Uptime'], int)
 
         with self.assertRaises(ValueError) as cm:
             global_status.get_many(['foo%'])
-        self.assertIn('wildcards', str(cm.exception))
+        assert 'wildcards' in str(cm.exception)
 
     def test_as_dict(self):
         status_dict = global_status.as_dict()
 
-        self.assertIn('Aborted_clients', status_dict)  # Global-only variable
+        assert 'Aborted_clients' in status_dict  # Global-only variable
 
-        self.assertTrue(isinstance(status_dict['Threads_running'], int))
-        self.assertGreaterEqual(status_dict['Threads_running'], 1)
+        assert isinstance(status_dict['Threads_running'], int)
+        assert status_dict['Threads_running'] >= 1
 
-        self.assertTrue(isinstance(status_dict['Last_query_cost'], float))
-        self.assertGreaterEqual(status_dict['Last_query_cost'], 0.0)
+        assert isinstance(status_dict['Last_query_cost'], float)
+        assert status_dict['Last_query_cost'] >= 0.0
 
-        self.assertTrue(isinstance(status_dict['Compression'], bool))
+        assert isinstance(status_dict['Compression'], bool)
 
     def test_as_dict_prefix(self):
         status_dict = global_status.as_dict()
 
         status_dict_threads = global_status.as_dict('Threads_')
-        self.assertLess(len(status_dict_threads), len(status_dict))
+        assert len(status_dict_threads) < len(status_dict)
         for key in status_dict_threads:
-            self.assertTrue(key.startswith('Threads_'))
+            assert key.startswith('Threads_')
 
         status_dict_foo = global_status.as_dict('Foo_Non_Existent')
-        self.assertEqual(len(status_dict_foo), 0)
+        assert len(status_dict_foo) == 0
 
     def test_wait_until_load_low(self):
         # Assume tests are running on a non-busy server
@@ -77,8 +77,8 @@ class GlobalStatusTests(TestCase):
                 sleep=0.0005
             )
         message = str(cm.exception)
-        self.assertIn('Threads_running', message)
-        self.assertIn('-1', message)
+        assert 'Threads_running' in message
+        assert '-1' in message
 
         with self.assertRaises(TimeoutError) as cm:
             global_status.wait_until_load_low(
@@ -88,36 +88,36 @@ class GlobalStatusTests(TestCase):
                 sleep=0.0005
             )
         message = str(cm.exception)
-        self.assertIn('Uptime', message)
-        self.assertIn('-1', message)
-        self.assertNotIn('Threads_running', message)
-        self.assertNotIn('1000000', message)
+        assert 'Uptime' in message
+        assert '-1' in message
+        assert 'Threads_running' not in message
+        assert '1000000' not in message
 
     def test_other_databases(self):
         status = GlobalStatus(using='other')
 
         running = status.get('Threads_running')
-        self.assertTrue(isinstance(running, int))
-        self.assertGreaterEqual(running, 1)
+        assert isinstance(running, int)
+        assert running >= 1
 
 
 class SessionStatusTests(TestCase):
 
     def test_get(self):
         bytes_received = session_status.get('Bytes_received')
-        self.assertTrue(isinstance(bytes_received, int))
-        self.assertGreaterEqual(bytes_received, 0)
+        assert isinstance(bytes_received, int)
+        assert bytes_received >= 0
 
         bytes_received_2 = session_status.get('Bytes_received')
-        self.assertGreaterEqual(bytes_received_2, bytes_received)
+        assert bytes_received_2 >= bytes_received
 
         cost = session_status.get('Last_query_cost')
-        self.assertTrue(isinstance(cost, float))
-        self.assertGreaterEqual(cost, 0.00)
+        assert isinstance(cost, float)
+        assert cost >= 0.00
 
         with self.assertRaises(ValueError) as cm:
             session_status.get('foo%')
-        self.assertIn('wildcards', str(cm.exception))
+        assert 'wildcards' in str(cm.exception)
 
         with self.assertRaises(KeyError):
             session_status.get('Does_not_exist')
@@ -125,13 +125,13 @@ class SessionStatusTests(TestCase):
     def test_as_dict(self):
         status_dict = session_status.as_dict()
 
-        self.assertIn('Compression', status_dict)
+        assert 'Compression' in status_dict
 
-        self.assertTrue(isinstance(status_dict['Threads_running'], int))
-        self.assertGreaterEqual(status_dict['Threads_running'], 1)
+        assert isinstance(status_dict['Threads_running'], int)
+        assert status_dict['Threads_running'] >= 1
 
     def test_other_databases(self):
         status = SessionStatus(using='other')
         running = status.get('Threads_running')
-        self.assertTrue(isinstance(running, int))
-        self.assertGreaterEqual(running, 1)
+        assert isinstance(running, int)
+        assert running >= 1

--- a/tests/django_mysql_tests/test_status.py
+++ b/tests/django_mysql_tests/test_status.py
@@ -1,4 +1,5 @@
 # -*- coding:utf-8 -*-
+import pytest
 from django.test import TestCase
 
 from django_mysql.exceptions import TimeoutError
@@ -18,11 +19,11 @@ class GlobalStatusTests(TestCase):
         assert isinstance(cost, float)
         assert cost >= 0.0
 
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as excinfo:
             global_status.get('foo%')
-        assert 'wildcards' in str(cm.exception)
+        assert 'wildcards' in str(excinfo.value)
 
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             global_status.get('Does_not_exist')
 
     def test_get_many(self):
@@ -36,9 +37,9 @@ class GlobalStatusTests(TestCase):
         assert 'Uptime' in myvars
         assert isinstance(myvars['Uptime'], int)
 
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as excinfo:
             global_status.get_many(['foo%'])
-        assert 'wildcards' in str(cm.exception)
+        assert 'wildcards' in str(excinfo.value)
 
     def test_as_dict(self):
         status_dict = global_status.as_dict()
@@ -70,24 +71,24 @@ class GlobalStatusTests(TestCase):
         global_status.wait_until_load_low({'Threads_running': 50,
                                            'Threads_connected': 100})
 
-        with self.assertRaises(TimeoutError) as cm:
+        with pytest.raises(TimeoutError) as excinfo:
             global_status.wait_until_load_low(
                 {'Threads_running': -1},  # obviously impossible
                 timeout=0.001,
                 sleep=0.0005
             )
-        message = str(cm.exception)
+        message = str(excinfo.value)
         assert 'Threads_running' in message
         assert '-1' in message
 
-        with self.assertRaises(TimeoutError) as cm:
+        with pytest.raises(TimeoutError) as excinfo:
             global_status.wait_until_load_low(
                 {'Threads_running': 1000000,
                  'Uptime': -1},  # obviously impossible
                 timeout=0.001,
                 sleep=0.0005
             )
-        message = str(cm.exception)
+        message = str(excinfo.value)
         assert 'Uptime' in message
         assert '-1' in message
         assert 'Threads_running' not in message
@@ -115,11 +116,11 @@ class SessionStatusTests(TestCase):
         assert isinstance(cost, float)
         assert cost >= 0.00
 
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as excinfo:
             session_status.get('foo%')
-        assert 'wildcards' in str(cm.exception)
+        assert 'wildcards' in str(excinfo.value)
 
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             session_status.get('Does_not_exist')
 
     def test_as_dict(self):

--- a/tests/django_mysql_tests/test_test_utils.py
+++ b/tests/django_mysql_tests/test_test_utils.py
@@ -16,7 +16,7 @@ class OverrideVarsMethodTest(TestCase):
             mode = cursor.fetchone()[0]
 
         mode = mode.split(',')
-        self.assertIn(expected, mode)
+        assert expected in mode
 
 
 @override_mysql_variables(SQL_MODE="ANSI")

--- a/tests/django_mysql_tests/test_test_utils.py
+++ b/tests/django_mysql_tests/test_test_utils.py
@@ -1,3 +1,4 @@
+import pytest
 from django.db import connections
 from django.test import TestCase
 
@@ -31,7 +32,7 @@ class OverrideVarsClassTest(OverrideVarsMethodTest):
         self.check_sql_mode("MSSQL", using='other')
 
     def test_it_fails_on_non_test_classes(self):
-        with self.assertRaises(Exception):
+        with pytest.raises(Exception):
             @override_mysql_variables(SQL_MODE="ANSI")
             class MyClass(object):
                 pass

--- a/tests/django_mysql_tests/test_utils.py
+++ b/tests/django_mysql_tests/test_utils.py
@@ -17,37 +17,37 @@ class WeightedAverageRateTests(TestCase):
         # If we keep achieving a rate of 100 rows in 0.5 seconds, it should
         # recommend that we keep there
         rate = WeightedAverageRate(0.5)
-        self.assertEqual(rate.update(100, 0.5), 100)
-        self.assertEqual(rate.update(100, 0.5), 100)
-        self.assertEqual(rate.update(100, 0.5), 100)
+        assert rate.update(100, 0.5) == 100
+        assert rate.update(100, 0.5) == 100
+        assert rate.update(100, 0.5) == 100
 
     def test_slow(self):
         # If we keep achieving a rate of 100 rows in 1 seconds, it should
         # recommend that we move to 50
         rate = WeightedAverageRate(0.5)
-        self.assertEqual(rate.update(100, 1.0), 50)
-        self.assertEqual(rate.update(100, 1.0), 50)
-        self.assertEqual(rate.update(100, 1.0), 50)
+        assert rate.update(100, 1.0) == 50
+        assert rate.update(100, 1.0) == 50
+        assert rate.update(100, 1.0) == 50
 
     def test_fast(self):
         # If we keep achieving a rate of 100 rows in 0.25 seconds, it should
         # recommend that we move to 200
         rate = WeightedAverageRate(0.5)
-        self.assertEqual(rate.update(100, 0.25), 200)
-        self.assertEqual(rate.update(100, 0.25), 200)
-        self.assertEqual(rate.update(100, 0.25), 200)
+        assert rate.update(100, 0.25) == 200
+        assert rate.update(100, 0.25) == 200
+        assert rate.update(100, 0.25) == 200
 
     def test_good_guess(self):
         # If we are first slow then hit the target at 50, we should be good
         rate = WeightedAverageRate(0.5)
-        self.assertEqual(rate.update(100, 1.0), 50)
-        self.assertEqual(rate.update(50, 0.5), 50)
-        self.assertEqual(rate.update(50, 0.5), 50)
-        self.assertEqual(rate.update(50, 0.5), 50)
+        assert rate.update(100, 1.0) == 50
+        assert rate.update(50, 0.5) == 50
+        assert rate.update(50, 0.5) == 50
+        assert rate.update(50, 0.5) == 50
 
     def test_zero_division(self):
         rate = WeightedAverageRate(0.5)
-        self.assertEqual(rate.update(1, 0.0), 500)
+        assert rate.update(1, 0.0) == 500
 
 
 @skipUnless(have_program('pt-fingerprint'),
@@ -55,8 +55,8 @@ class WeightedAverageRateTests(TestCase):
 class PTFingerprintTests(TestCase):
 
     def test_basic(self):
-        self.assertEqual(pt_fingerprint('SELECT 5'), 'select ?')
-        self.assertEqual(pt_fingerprint('SELECT 5;'), 'select ?')
+        assert pt_fingerprint('SELECT 5') == 'select ?'
+        assert pt_fingerprint('SELECT 5;') == 'select ?'
 
     def test_long(self):
         query = """
@@ -79,8 +79,8 @@ class PTFingerprintTests(TestCase):
                 rental_date + INTERVAL film.rental_duration DAY <
                     CURRENT_DATE()
             LIMIT 5"""
-        self.assertEqual(
-            pt_fingerprint(query),
+        assert (
+            pt_fingerprint(query) ==
             "select concat(customer.last_name, ?, customer.first_name) as "
             "customer, address.phone, film.title from rental inner join "
             "customer on rental.customer_id = customer.customer_id inner join "
@@ -95,5 +95,5 @@ class PTFingerprintTests(TestCase):
         PTFingerprintThread.PROCESS_LIFETIME = 0.1
         pt_fingerprint("select 123")
         sleep(0.2)
-        self.assertIsNone(PTFingerprintThread.the_thread)
+        assert PTFingerprintThread.the_thread is None
         PTFingerprintThread.PROCESS_LIFETIME = 60


### PR DESCRIPTION
* Stop using `unittest`'s `assertEquals`, etc. since pytest's output for the plain `assert` statement is great.
* Convert some custom `assertX` functions
* Use `pytest.raises` instead of `assertRaises`

Keep using `assertNumQueries` and other django unittest extensions though.