### PR TITLE
MySQLCache query improvements

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ History
   ``RegexpReplace``, and ``RegexpSubstr``
 * Added the option to not limit the size of a ``MySQLCache`` by setting
   ``MAX_ENTRIES`` = -1.
+* `MySQLCache` performance improvements in `get`, `get_many`, and `has_key`
 
 0.2.0 (2015-05-14)
 ------------------


### PR DESCRIPTION
* Make `get` and `get_many` more efficient by doing the expired calculation in MySQL and therefore not pulling the data back into python
* Make `has_key` more idiomatic by separating its query and using `.format()`, as well as slightly improving its efficiency with `SELECT 1`