### PR TITLE
MySQLCache accept MAX_ENTRIES = -1 to not limit the cache size

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,8 @@ History
 * Pending release
 * Added Regexp database functions for MariaDB - ``RegexpInstr``,
   ``RegexpReplace``, and ``RegexpSubstr``
+* Added the option to not limit the size of a ``MySQLCache`` by setting
+  ``MAX_ENTRIES`` = -1.
 
 0.2.0 (2015-05-14)
 ------------------

--- a/django_mysql/cache.py
+++ b/django_mysql/cache.py
@@ -419,6 +419,10 @@ class MySQLCache(BaseDatabaseCache):
                 (now,)
             )
 
+            # -1 means "Don't limit size"
+            if self._max_entries == -1:
+                return
+
             cursor.execute("SELECT COUNT(*) FROM {table}".format(table=table))
             num = cursor.fetchone()[0]
 

--- a/docs/cache.rst
+++ b/docs/cache.rst
@@ -188,6 +188,22 @@ ways:
    ...will call ``caches['default'].cull()`` and
    ``caches['other_cache'].cull()``.
 
+You can also disable the ``MAX_ENTRIES`` behaviour, which avoids the ``SELECT
+COUNT(*)`` entirely, and makes ``cull()`` only delete expired keys. To do this,
+set ``MAX_ENTRIES`` to -1::
+
+    CACHES = {
+        'default': {
+            'BACKEND': 'django_mysql.cache.MySQLCache',
+            'LOCATION': 'some_table_name',
+            'OPTIONS': {
+                'MAX_ENTRIES': -1
+            }
+        }
+    }
+
+Note that you should then of course monitor the size of your cache table well,
+since it has no bounds on its growth.
 
 compression
 ~~~~~~~~~~~

--- a/tests/django_mysql_tests/test_cache.py
+++ b/tests/django_mysql_tests/test_cache.py
@@ -1089,6 +1089,25 @@ class MySQLCacheTests(TransactionTestCase):
 
     # cull_mysql_caches tests
 
+    @override_cache_settings(options={'MAX_ENTRIES': -1})
+    def test_cull_max_entries_minus_one(self):
+        # cull with MAX_ENTRIES = -1 should never clear anything that is not
+        # expired
+
+        # one expired key
+        cache.set('key', 'value', 0.1)
+        time.sleep(0.2)
+
+        # 9k non-expired keys
+        for n in six.moves.range(9):
+            cache.set_many({
+                str(n * 1000 + i): True
+                for i in six.moves.range(1000)
+            })
+
+        cache.cull()
+        assert self.table_count() == 9000
+
     def test_cull_mysql_caches_basic(self):
         cache.set('key', 'value', 0.3)
         time.sleep(0.4)


### PR DESCRIPTION
An unlimited cache may be useful, and makes cull faster.