### PR TITLE
SmartChunkedIterator allows models whose primary key is a ForeignKey

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,8 @@ History
 * Pending release
 * ``SmartChunkedIterator`` now takes an argument ``chunk_size`` as the initial
   chunk size
+* ``SmartChunkedIterator`` now allows models whose primary key is a
+  ``ForeignKey``
 * Added ``iter_smart_pk_ranges`` which is similar to ``iter_smart_chunks`` but
   yields only the start and end primary keys for each chunks, in a tuple.
 * Added prefix methods to ``MySQLCache`` - ``delete_with_prefix``,

--- a/django_mysql/models/query.py
+++ b/django_mysql/models/query.py
@@ -209,13 +209,21 @@ class SmartChunkedIterator(object):
             )
 
         pk = queryset.model._meta.pk
-        if not isinstance(pk, (models.IntegerField, models.AutoField)):
+        if not isinstance(pk, self.ALLOWED_PK_FIELD_CLASSES):
+            # If your custom field class should be allowed, just add it to
+            # ALLOWED_PK_FIELD_CLASSES
             raise ValueError(
                 "You can't use %s on a model with a non-integer primary key." %
                 self.__class__.__name__
             )
 
         return queryset.order_by('pk')
+
+    ALLOWED_PK_FIELD_CLASSES = (
+        models.IntegerField,  # Also covers e.g. PositiveIntegerField
+        models.AutoField,  # Is an integer field but doesn't subclass it :(
+        models.ForeignKey  # Should always point to an integer
+    )
 
     def get_min_and_max(self):
         if isinstance(self.pk_range, tuple) and len(self.pk_range) == 2:

--- a/tests/django_mysql_tests/models.py
+++ b/tests/django_mysql_tests/models.py
@@ -94,6 +94,11 @@ class VanillaAuthor(VanillaModel):
         return "{} {}".format(self.id, self.name)
 
 
+class AuthorExtra(Model):
+    author = ForeignKey(Author, primary_key=True)
+    legs = IntegerField(default=2)
+
+
 class NameAuthor(Model):
     name = CharField(max_length=32, primary_key=True)
 

--- a/tests/django_mysql_tests/test_models.py
+++ b/tests/django_mysql_tests/test_models.py
@@ -11,7 +11,9 @@ from django.test.utils import override_settings
 
 from django_mysql.models import ApproximateInt, SmartIterator
 from django_mysql.utils import have_program
-from django_mysql_tests.models import Author, Book, NameAuthor, VanillaAuthor
+from django_mysql_tests.models import (
+    Author, AuthorExtra, Book, NameAuthor, VanillaAuthor
+)
 from django_mysql_tests.utils import CaptureLastQuery, captured_stdout
 
 
@@ -376,6 +378,16 @@ class SmartIteratorTests(TransactionTestCase):
         all_ids = list(Author.objects.order_by('id')
                                      .values_list('id', flat=True))
         assert seen == all_ids
+
+    def test_iter_smart_fk_primary_key(self):
+        author, author2 = Author.objects.all()[:2]
+        AuthorExtra.objects.create(author=author, legs=2)
+        AuthorExtra.objects.create(author=author2, legs=1)
+
+        seen_author_ids = []
+        for extra in AuthorExtra.objects.iter_smart():
+            seen_author_ids.append(extra.author_id)
+        assert seen_author_ids == [author.id, author2.id]
 
     def test_reporting(self):
         with captured_stdout() as output:


### PR DESCRIPTION
Fixes #137 .