### PR TITLE
No QuerySet.extra on Django 1.8+

### DIFF
--- a/django_mysql/compat.py
+++ b/django_mysql/compat.py
@@ -8,7 +8,8 @@ import functools
 import django
 from django.utils import six
 
-__all__ = ('BaseExpression', 'Func', 'Value', 'field_class')
+__all__ = ('BaseExpression', 'Func', 'Value', 'field_class',
+           'add_raw_condition')
 
 
 # Handle the deprecation of SubfieldBase
@@ -38,3 +39,19 @@ if django.VERSION < (1, 8):
     Value = tuple
 else:
     from django.db.models.expressions import BaseExpression, Func, Value
+
+
+# QuerySet.extra is ugly and deprecated, maybe there is a way of replacing it
+# with an Expression in Django 1.8+.. experimenting but not finding anything...
+
+if django.VERSION < (1, 8):
+
+    def add_raw_condition(queryset, condition):
+        return queryset.extra(where=[condition])
+
+else:
+
+    from django.db.models.expressions import RawSQL
+
+    def add_raw_condition(queryset, condition):
+        return queryset.filter(RawSQL(condition, ()))

--- a/django_mysql/models/query.py
+++ b/django_mysql/models/query.py
@@ -12,6 +12,7 @@ from django.utils import six
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext as _
 
+from django_mysql.compat import add_raw_condition
 from django_mysql.models.handler import Handler
 from django_mysql.status import GlobalStatus
 from django_mysql.utils import (
@@ -84,25 +85,26 @@ class QuerySetMixin(object):
         """
         if '*/' in string:
             raise ValueError("Bad label - cannot be embedded in SQL comment")
-        return self.extra(where=["/*QueryRewrite':label={}*/1".format(string)])
+        return add_raw_condition(self,
+                                 "/*QueryRewrite':label={}*/".format(string))
 
     def straight_join(self):
-        return self.extra(where=["/*QueryRewrite':STRAIGHT_JOIN*/1"])
+        return add_raw_condition(self, "/*QueryRewrite':STRAIGHT_JOIN*/1")
 
     def sql_small_result(self):
-        return self.extra(where=["/*QueryRewrite':SQL_SMALL_RESULT*/1"])
+        return add_raw_condition(self, "/*QueryRewrite':SQL_SMALL_RESULT*/1")
 
     def sql_big_result(self):
-        return self.extra(where=["/*QueryRewrite':SQL_BIG_RESULT*/1"])
+        return add_raw_condition(self, "/*QueryRewrite':SQL_BIG_RESULT*/1")
 
     def sql_buffer_result(self):
-        return self.extra(where=["/*QueryRewrite':SQL_BUFFER_RESULT*/1"])
+        return add_raw_condition(self, "/*QueryRewrite':SQL_BUFFER_RESULT*/1")
 
     def sql_cache(self):
-        return self.extra(where=["/*QueryRewrite':SQL_CACHE*/1"])
+        return add_raw_condition(self, "/*QueryRewrite':SQL_CACHE*/1")
 
     def sql_no_cache(self):
-        return self.extra(where=["/*QueryRewrite':SQL_NO_CACHE*/1"])
+        return add_raw_condition(self, "/*QueryRewrite':SQL_NO_CACHE*/1")
 
     # Features handled by extra classes/functions
 


### PR DESCRIPTION
As discussed on [django developers mailing list](https://groups.google.com/forum/#!topic/django-developers/FojuU0syO8Y), `.extra()` is deprecated-ish and the only use of it in **django-mysql** shoudl be replaced with `RawSQL`. However it seems this is not possible, since we need a `RawQ` to just add `WHERE 1`.