### PR TITLE
MySQL 5.7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   matrix:
     - "DB=mysql DB_VERSION=5.5"
     - "DB=mysql DB_VERSION=5.6"
+    - "DB=mysql DB_VERSION=5.7"
     - "DB=mariadb DB_VERSION=5.5"
     - "DB=mariadb DB_VERSION=10.0"
     - "DB=mariadb DB_VERSION=10.1"

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -32,7 +32,7 @@ then
   # Nuke default
   sudo apt-get -y purge mysql-server
   sudo apt-get -y autoremove --purge
-  sudo rm -rf /var/lib/mysql
+  sudo rm -rf /var/lib/mysql /etc/mysql
   # Install
   sudo apt-get install -y python-software-properties
   sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db
@@ -41,6 +41,6 @@ then
   yes Y | sudo DEBIAN_FRONTEND=noninteractive apt-get install -y mariadb-server libmariadbclient-dev
 fi
 
-mysql -u root -e "create user travis@localhost identified by '';" || true
+sudo mysql -u root -e "create user travis@localhost identified by '';" || true
 
-mysql -u root -e 'grant all privileges on *.* to travis@localhost;'
+sudo mysql -u root -e 'grant all privileges on *.* to travis@localhost;'

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ Pending
 -------
 
 * New release notes here
+* Now MySQL 5.7 compatible
 
 1.0.5 (2016-02-10)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Tested with all combinations of:
 
 * Python: 2.7, 3.4, 3.5
 * Django: 1.7, 1.8, master
-* MySQL: 5.5, 5.6 / MariaDB: 5.5, 10.0, 10.1
+* MySQL: 5.5, 5.6, 5.7 / MariaDB: 5.5, 10.0, 10.1
 * mysqlclient: 1.3.7 (Python 3 compatible version of ``MySQL-python``)
 
 Any combination of these should be good, and also ``MySQL-python`` should work

--- a/django_mysql/test/utils.py
+++ b/django_mysql/test/utils.py
@@ -21,7 +21,7 @@ class override_mysql_variables(object):
     def __init__(self, using=DEFAULT_DB_ALIAS, **kwargs):
         self.db = using
         self.options = kwargs
-        self.prefix = uuid.uuid1().hex.replace('-', '')
+        self.prefix = uuid.uuid1().hex.replace('-', '')[:16]
 
     def __enter__(self):
         self.enable()

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,7 +9,7 @@ Tested with all combinations of:
 
 * Python: 2.7, 3.4, 3.5
 * Django: 1.7, 1.8, master
-* MySQL: 5.5, 5.6 / MariaDB: 5.5, 10.0, 10.1
+* MySQL: 5.5, 5.6, 5.7 / MariaDB: 5.5, 10.0, 10.1
 * mysqlclient: 1.3.7 (Python 3 compatible version of ``MySQL-python``)
 
 Any combination of these should be good, and also ``MySQL-python`` should work

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -19,8 +19,10 @@ DATABASES = {
         'PORT': '',
         'OPTIONS': {
             'charset': 'utf8mb4',
-            'init_command': "SET sql_mode='STRICT_TRANS_TABLES', "
-                            "innodb_strict_mode=1",
+            # The most forward compatible sql_mode, for 5.7
+            'init_command': "SET sql_mode='STRICT_TRANS_TABLES,NO_ZERO_DATE,"
+                            "NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,"
+                            "NO_AUTO_CREATE_USER', innodb_strict_mode=1",
         },
         'TEST': {
             'COLLATION': "utf8mb4_general_ci",
@@ -36,8 +38,10 @@ DATABASES = {
         'PORT': '',
         'OPTIONS': {
             'charset': 'utf8mb4',
-            'init_command': "SET sql_mode='STRICT_TRANS_TABLES', "
-                            "innodb_strict_mode=1",
+            # The most forward compatible sql_mode, for 5.7
+            'init_command': "SET sql_mode='STRICT_TRANS_TABLES,NO_ZERO_DATE,"
+                            "NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,"
+                            "NO_AUTO_CREATE_USER', innodb_strict_mode=1",
         },
         'TEST': {
             'COLLATION': "utf8mb4_general_ci",

--- a/tests/testapp/utils.py
+++ b/tests/testapp/utils.py
@@ -73,4 +73,15 @@ def used_indexes(query, using=DEFAULT_DB_ALIAS):
     """
     with connections[using].cursor() as cursor:
         cursor.execute("EXPLAIN " + query)
-        return {row[5] for row in cursor.fetchall() if row[5]}
+        return {row['key'] for row in fetchall_dicts(cursor)
+                if row['key'] is not None}
+
+
+def fetchall_dicts(cursor):
+    columns = [x[0] for x in cursor.description]
+    rows = []
+    for row in cursor.fetchall():
+        rows.append(
+            dict(zip(columns, row))
+        )
+    return rows


### PR DESCRIPTION
* Test on Travis
* Fix `approx_count` to always pull from `information_schema`
* New forwards-compatible SQL mode used in tests
* Fix global status tests to use variables that exist on all MySQL versions
