### PR TITLE
tox test against Django 1.9b1 rather than 1.9a1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ install_command = pip install --no-deps {opts} {packages}
 deps =
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
-    django19: Django==1.9a1
+    django19: Django==1.9b1
     -rrequirements/requirements-testing.txt
     coverage
 commands = coverage run -p --source=django_mysql ./runtests.py --nolint {posargs}


### PR DESCRIPTION
Django 1.9 is getting more stable, test against it to check for any surprises.