### PR TITLE
MySQL 5.7 compatible JSONField

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,11 @@ Pending
 -------
 
 * New release notes here
+* Added new ``JSONField`` class backed by the JSON type added in MySQL 5.7.
+* Added database functions ``JSONExtract``, ``JSONKeys``, and ``JSONLength``
+  that wrap the JSON functions added in MySQL 5.7, which can be used with the
+  JSON type columns as well as JSON data held in text/varchar columns.
+
 
 1.0.6 (2016-02-26)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,7 @@ Includes:
 
 * Model fields:
 
+  * MySQL 5.7+ JSON Field
   * MariaDB Dynamic Columns for storing dictionaries
   * Comma-separated fields for storing lists and sets
   * 'Missing' fields: differently sized ``BinaryField``/``TextField`` classes,

--- a/django_mysql/forms.py
+++ b/django_mysql/forms.py
@@ -1,6 +1,8 @@
 # -*- coding:utf-8 -*-
 from __future__ import absolute_import
 
+import json
+
 from django import forms
 from django.core import validators
 from django.core.exceptions import ValidationError
@@ -219,3 +221,28 @@ class SimpleSetField(forms.CharField):
                         ))
         if errors:
             raise ValidationError(errors)
+
+
+class JSONField(forms.CharField):
+    default_error_messages = {
+        'invalid': _("'%(value)s' value must be valid JSON."),
+    }
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault('widget', forms.Textarea)
+        super(JSONField, self).__init__(**kwargs)
+
+    def to_python(self, value):
+        if value in self.empty_values:
+            return None
+        try:
+            return json.loads(value)
+        except ValueError:
+            raise forms.ValidationError(
+                self.error_messages['invalid'],
+                code='invalid',
+                params={'value': value},
+            )
+
+    def prepare_value(self, value):
+        return json.dumps(value)

--- a/django_mysql/models/__init__.py
+++ b/django_mysql/models/__init__.py
@@ -8,7 +8,7 @@ from django_mysql.models.query import (  # noqa
     pt_visual_explain, QuerySet, QuerySetMixin
 )
 from django_mysql.models.fields import (  # noqa
-    Bit1BooleanField, DynamicField, EnumField, ListCharField, ListTextField,
-    NullBit1BooleanField, SetCharField, SetTextField, SizedBinaryField,
-    SizedTextField,
+    Bit1BooleanField, DynamicField, EnumField, JSONField, ListCharField,
+    ListTextField, NullBit1BooleanField, SetCharField, SetTextField,
+    SizedBinaryField, SizedTextField,
 )

--- a/django_mysql/models/fields/__init__.py
+++ b/django_mysql/models/fields/__init__.py
@@ -3,6 +3,7 @@ from django_mysql.models.fields.bit import (  # noqa
 )
 from django_mysql.models.fields.dynamic import DynamicField  # noqa
 from django_mysql.models.fields.enum import EnumField  # noqa
+from django_mysql.models.fields.json import JSONField  # noqa
 from django_mysql.models.fields.lists import (  # noqa
     ListCharField, ListTextField
 )

--- a/django_mysql/models/fields/json.py
+++ b/django_mysql/models/fields/json.py
@@ -1,0 +1,168 @@
+# -*- coding:utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+import json
+
+import django
+from django.core import checks
+from django.db import connections
+from django.db.models import Field, Transform
+from django.utils import six
+
+from django_mysql import forms
+from django_mysql.compat import field_class
+
+__all__ = ('JSONField',)
+
+
+class JSONField(field_class(Field)):
+    def __init__(self, *args, **kwargs):
+        if 'default' not in kwargs:
+            kwargs['default'] = dict
+        super(JSONField, self).__init__(*args, **kwargs)
+
+    def check(self, **kwargs):
+        errors = super(JSONField, self).check(**kwargs)
+        errors.extend(self._check_django_version())
+
+        if django.VERSION[:2] >= (1, 8):
+            # This check connects to the DB, which only works on Django 1.8+
+            errors.extend(self._check_mysql_version())
+
+        return errors
+
+    def _check_django_version(self):
+        errors = []
+        if django.VERSION[:2] < (1, 8):
+            errors.append(
+                checks.Error(
+                    "Django 1.8+ is required to use JSONField",
+                    obj=self,
+                    id='django_mysql.E015',
+                )
+            )
+        return errors
+
+    def _check_mysql_version(self):
+        errors = []
+
+        any_conn_works = False
+        conn_names = ['default'] + list(set(connections) - {'default'})
+        for db in conn_names:
+            if (
+                not connections[db].is_mariadb and
+                connections[db].mysql_version >= (5, 7)
+            ):
+                any_conn_works = True
+
+        if not any_conn_works:
+            errors.append(
+                checks.Error(
+                    "MySQL 5.7+ is required to use JSONField",
+                    hint=None,
+                    obj=self,
+                    id='django_mysql.E016'
+                )
+            )
+        return errors
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(JSONField, self).deconstruct()
+        path = 'django_mysql.models.%s' % self.__class__.__name__
+        return name, path, args, kwargs
+
+    def db_type(self, connection):
+        return 'json'
+
+    def get_transform(self, name):
+        transform = super(JSONField, self).get_transform(name)
+        if transform:
+            return transform  # pragma: no cover
+        return KeyTransformFactory(name)
+
+    def from_db_value(self, value, expression, connection, context):
+        # Similar to to_python, for Django 1.8+
+        if isinstance(value, six.string_types):
+            return json.loads(value)
+        return value
+
+    def get_prep_value(self, value):
+        if value is not None and not isinstance(value, six.string_types):
+            # For some reason this value gets string quoted in Django's SQL
+            # compiler...
+            return json.dumps(value)
+        return value
+
+    def get_prep_lookup(self, lookup_type, value):
+        if (
+            not hasattr(value, '_prepare') and
+            lookup_type in ('exact', 'gt', 'gte', 'lt', 'lte') and
+            value is not None
+        ):
+            return JSONValue(value)
+
+        return super(JSONField, self).get_prep_lookup(lookup_type, value)
+
+    def get_lookup(self, lookup_name):
+        # Have to 'unregister' some incompatible lookups
+        if lookup_name in {
+            'range', 'in', 'iexact', 'contains', 'icontains', 'startswith',
+            'istartswith', 'endswith', 'iendswith', 'search', 'regex', 'iregex'
+        }:
+            raise NotImplementedError(
+                "Lookup '{}' doesn't work with JSONField".format(lookup_name)
+            )
+        return super(JSONField, self).get_lookup(lookup_name)
+
+    def formfield(self, **kwargs):
+        defaults = {'form_class': forms.JSONField}
+        defaults.update(kwargs)
+        return super(JSONField, self).formfield(**defaults)
+
+
+class JSONValue(object):
+    def __init__(self, value):
+        self.json_string = json.dumps(value)
+
+    def as_sql(self, *args, **kwargs):
+        return 'CAST(%s AS JSON)', (self.json_string,)
+
+
+class KeyTransform(Transform):
+
+    def __init__(self, key_name, *args, **kwargs):
+        super(KeyTransform, self).__init__(*args, **kwargs)
+        self.key_name = key_name
+
+    def as_sql(self, compiler, connection):
+        key_transforms = [self.key_name]
+        previous = self.lhs
+        while isinstance(previous, KeyTransform):
+            key_transforms.insert(0, previous.key_name)
+            previous = previous.lhs
+
+        lhs, params = compiler.compile(previous)
+
+        json_path = self.compile_json_path(key_transforms)
+
+        return 'JSON_EXTRACT({}, %s)'.format(lhs), params + [json_path]
+
+    def compile_json_path(self, key_transforms):
+        path = ['$']
+        for key_transform in key_transforms:
+            try:
+                num = int(key_transform)
+                path.append('[{}]'.format(num))
+            except ValueError:  # non-integer
+                path.append('.')
+                path.append(key_transform)
+        return ''.join(path)
+
+
+class KeyTransformFactory(object):
+
+    def __init__(self, key_name):
+        self.key_name = key_name
+
+    def __call__(self, *args, **kwargs):
+        return KeyTransform(self.key_name, *args, **kwargs)

--- a/django_mysql/models/functions.py
+++ b/django_mysql/models/functions.py
@@ -194,6 +194,53 @@ class LastInsertId(Func):
             return cursor.fetchone()[0]
 
 
+# JSON Functions
+
+class JSONExtract(Func):
+    function = 'JSON_EXTRACT'
+
+    def __init__(self, expression, *paths):
+        from django_mysql.models.fields import JSONField
+
+        exprs = [expression]
+        for path in paths:
+            if not hasattr(path, 'resolve_expression'):
+                path = Value(path)
+            exprs.append(path)
+
+        super(JSONExtract, self).__init__(*exprs, output_field=JSONField())
+
+
+class JSONKeys(Func):
+    function = 'JSON_KEYS'
+
+    def __init__(self, expression, path=None):
+        from django_mysql.models.fields import JSONField
+
+        exprs = [expression]
+        if path is not None:
+            if not hasattr(path, 'resolve_expression'):
+                path = Value(path)
+            exprs.append(path)
+
+        super(JSONKeys, self).__init__(*exprs, output_field=JSONField())
+
+
+class JSONLength(Func):
+    function = 'JSON_LENGTH'
+
+    def __init__(self, expression, path=None):
+        from django_mysql.models.fields import JSONField
+
+        exprs = [expression]
+        if path is not None:
+            if not hasattr(path, 'resolve_expression'):
+                path = Value(path)
+            exprs.append(path)
+
+        super(JSONLength, self).__init__(*exprs, output_field=JSONField())
+
+
 # MariaDB Regexp Functions
 
 class RegexpInstr(Func):

--- a/docs/exposition.rst
+++ b/docs/exposition.rst
@@ -117,6 +117,29 @@ Model Fields
 
 Fields that use MySQL-specific features!
 
+JSON Field
+----------
+
+Implements MySQL 5.7+'s JSON data type for storing arbitrary JSON data:
+
+.. code-block:: python
+
+    class APIResponse(Model):
+        url = models.CharField(max_length=200)
+        data = JSONField()
+
+..
+
+    >>> APIResponse.objects.create(url='/api/twoots/1/', data={
+        'id': '123',
+        'message': 'Loving #django and #mysql',
+        'coords': [34.4, 56.2]
+    })
+    >>> APIResponse.objects.filter(data__coords__0=34.4)
+    [<APIResponse: /api/twoots/1/>]
+
+:ref:`Read more <json-field>`
+
 Dynamic Columns Field
 ---------------------
 

--- a/docs/form_fields.rst
+++ b/docs/form_fields.rst
@@ -8,6 +8,22 @@ The following can be imported from ``django_mysql.forms``.
 
 .. currentmodule:: django_mysql.forms
 
+---------
+JSONField
+---------
+
+.. class:: JSONField
+
+    A field which accepts JSON encoded data for a
+    :class:`~django_mysql.models.JSONField`. It is represented by an HTML
+    ``<textarea>``.
+
+    .. admonition:: User friendly forms
+
+        ``JSONField`` is not particularly user friendly in most cases, however
+        it is a useful way to format data from a client-side widget for
+        submission to the server.
+
 ---------------
 SimpleListField
 ---------------

--- a/docs/model_fields/index.rst
+++ b/docs/model_fields/index.rst
@@ -13,6 +13,7 @@ to the home of Django's native fields in ``django.db.models``.
 .. toctree::
    :maxdepth: 1
 
+   json_field
    dynamic_field
    list_fields
    set_fields

--- a/docs/model_fields/json_field.rst
+++ b/docs/model_fields/json_field.rst
@@ -1,0 +1,164 @@
+.. _json-field:
+
+---------
+JSONField
+---------
+
+.. currentmodule:: django_mysql.models
+
+**MySQL 5.7** comes with a JSON data type that stores JSON in a way that is
+queryable and updatable in place. This is ideal for data that varies widely, or
+very sparse columns, or just for storing API responses that you don't have time
+to turn into the relational format.
+
+Docs: `MySQL <https://dev.mysql.com/doc/refman/5.7/en/json.html>`_.
+
+Django-MySQL supports the JSON data type and related functions through
+``JSONField`` plus some :ref:`database functions <database_functions>`.
+
+
+.. class:: JSONField(**kwargs)
+
+    A field for storing JSON. The Python data type may be either ``str``
+    (``unicode`` on Python 2), ``int``, ``float``, ``dict``, or ``list`` -
+    basically anything that is supported by ``json.dumps``. There is no
+    restriction between these types - this may be surprising if you expect it
+    to just store JSON objects/``dict``\s.
+
+    So for example, the following all work:
+
+    .. code-block:: python
+
+        mymodel.myfield = "a string"
+        mymodel.myfield = 1
+        mymodel.myfield = 0.3
+        mymodel.myfield = ["a", "list"]
+        mymodel.myfield = {"a": "dict"}
+
+    This field requires Django 1.8+ and MySQL 5.7+. Both requirements are
+    checked by the field and you'll get sensible errors for them when Django's
+    checks run if you're not up to date on either.
+
+JSONFields in Forms
+-------------------
+
+By default this uses the simple Django-MySQL form field
+:class:`~django_mysql.forms.JSONField`, which simply displays the JSON in an
+HTML ``<textarea>``.
+
+
+Querying JSONField
+------------------
+
+You can query by object keys as well as array positions. In cases where names
+collide with existing lookups, you might want to use the
+:class:`~django_mysql.models.functions.JSONExtract` database function.
+
+.. warning::
+
+    Most of the standard lookups don't make sense for ``JSONField`` and so have
+    been made to fail with ``NotImplementedError``. There is scope for making
+    some of them work in the future, but it's non-trivial. Only the lookups
+    documented below work.
+
+    Also be careful with the key lookups. Since any string could be a key in a
+    JSON object, any lookup name other than the standard ones or those listed
+    below will be interpreted as a key lookup. No errors are raised. Be extra
+    careful for typing mistakes, and always check your queries, e.g.
+    ``myfield__eaxct`` as a typo of ``myfield__exact`` will not do what the
+    author intended!
+
+We'll use the following example model:
+
+.. code-block:: python
+
+    from django_mysql.models import DynamicField, Model
+
+    class ShopItem(Model):
+        name = models.CharField(max_length=200)
+        attrs = JSONField()
+
+        def __str__(self):  # __unicode__ on Python 3
+            return self.name
+
+Exact Lookups
+~~~~~~~~~~~~~
+
+To query based on an exact match, just use an object of any JSON type.
+
+For example:
+
+.. code-block:: python
+
+    >>> ShopItem.objects.create(name='Gruyère', attrs={'smelliness': 5})
+    >>> ShopItem.objects.create(name='Feta', attrs={'smelliness': 3, 'crumbliness': 10})
+    >>> ShopItem.objects.create(name='Hack', attrs=[1, 'arbitrary', 'data'])
+
+    >>> ShopItem.objects.filter(attrs={'smelliness': 5})
+    [<ShopItem: Gruyère>]
+    >>> ShopItem.objects.filter(attrs__exact={'smelliness': 3, 'crumbliness': 10})
+    [<ShopItem: Feta>]
+    >>> ShopItem.objects.filter(attrs=[1, 'arbitrary', 'data'])
+    [<ShopItem: Hack>]
+
+
+Ordering Lookups
+~~~~~~~~~~~~~~~~
+
+MySQL defines an ordering on JSON objects - see
+`the docs <https://dev.mysql.com/doc/refman/5.7/en/json.html#json-comparison>`_
+for more details. The ordering rules can make sense for some types (e.g.
+strings, arrays), however they can also be confusing if your data is of mixed
+types, so be careful. You can use the ordering by querying with Django's
+built-in ``gt``, ``gte``, ``lt``, and ``lte`` lookups.
+
+For example:
+
+.. code-block:: py
+
+    >>> ShopItem.objects.create(name='Cheshire', attrs=['Dense', 'Crumbly'])
+    >>> ShopItem.objects.create(name='Double Gloucester', attrs=['Semi-hard'])
+
+    >>> ShopItem.objects.filter(attrs__gt=['Dense', 'Crumbly'])
+    [<ShopItem: Double Gloucester>]
+    >>> ShopItem.objects.filter(attrs__lte=['ZZZ'])
+    [<ShopItem: Cheshire>, <ShopItem: Double Gloucester>]
+
+Key, Index, and Path Lookups
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To query based on a given dictionary key, use that key as the lookup name:
+
+.. code-block:: python
+
+    >>> ShopItem.objects.create(name='Gruyère', attrs={
+        'smelliness': 5,
+        'origin': {
+            'country': 'Switzerland',
+        }
+        'certifications': ['Swiss AOC', 'Swiss AOP'],
+    })
+    >>> ShopItem.objects.create(name='Feta', attrs={'smelliness': 3, 'crumbliness': 10})
+
+    >>> ShopItem.objects.filter(attrs__smelliness=3)
+    [<ShopItem: Feta>]
+
+Multiple keys can be chained together to form a path lookup:
+
+.. code-block:: python
+
+    >>> ShopItem.objects.filter(attrs__origin__country='Switzerland')
+    [<ShopItem: Gruyère>]
+
+If the key is an integer, it will be interpreted as an index lookup in an
+array:
+
+.. code-block:: python
+
+    >>> ShopItem.objects.filter(attrs__certifications__0='Swiss AOC')
+    [<ShopItem: Gruyère>]
+
+If the key you wish to query is not valid for a Python keyword argument (e.g.
+it contains unicode characters), or it clashes with the name of another field
+lookup, use the :class:`~django_mysql.models.functions.JSONExtract` database
+function to fetch it.

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,6 +1,8 @@
 # -*- coding:utf-8 -*-
+import json
 from datetime import date, datetime, time
 
+import django
 from django.db import connection
 from django.db.models import Model as VanillaModel
 from django.db.models import (
@@ -10,10 +12,11 @@ from django.db.models import (
 from django.utils import six, timezone
 
 from django_mysql.models import (
-    Bit1BooleanField, DynamicField, EnumField, ListCharField, ListTextField,
-    Model, NullBit1BooleanField, SetCharField, SetTextField, SizedBinaryField,
-    SizedTextField
+    Bit1BooleanField, DynamicField, EnumField, JSONField, ListCharField,
+    ListTextField, Model, NullBit1BooleanField, SetCharField, SetTextField,
+    SizedBinaryField, SizedTextField
 )
+from django_mysql.utils import connection_is_mariadb
 
 
 class TemporaryModel(Model):
@@ -251,6 +254,18 @@ class Bit1Model(Model):
 
 class NullBit1Model(Model):
     flag = NullBit1BooleanField()
+
+
+class JSONModel(Model):
+    if (
+        django.VERSION[:2] >= (1, 8) and
+        not connection_is_mariadb(connection._nodb_connection) and
+        connection._nodb_connection.mysql_version >= (5, 7)
+    ):
+        attrs = JSONField(null=True)
+
+    def __unicode__(self):
+        return six.text_type(json.dumps(self.attrs))
 
 
 # For cache tests

--- a/tests/testapp/test_jsonfield.py
+++ b/tests/testapp/test_jsonfield.py
@@ -1,0 +1,319 @@
+# -*- coding:utf-8 -*-
+import mock
+from unittest import SkipTest
+
+import django
+import pytest
+from django.db import connection, connections
+from django.db.models import F
+from django.test import TestCase
+
+from django_mysql import forms
+from django_mysql.models import JSONField
+from testapp.models import JSONModel, TemporaryModel
+
+
+class JSONFieldTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        if not (
+            django.VERSION[:2] >= (1, 8) and
+            not connection.is_mariadb and
+            connection.mysql_version >= (5, 7)
+        ):
+            raise SkipTest("Dynamic Columns require MySQL 5.7+")
+        super(JSONFieldTestCase, cls).setUpClass()
+
+
+class TestSaveLoad(JSONFieldTestCase):
+
+    def test_empty_dict(self):
+        m = JSONModel()
+        assert m.attrs == {}
+        m.save()
+        m = JSONModel.objects.get()
+        assert m.attrs == {}
+
+    def test_values(self):
+        m = JSONModel(attrs={'key': 'value'})
+        assert m.attrs == {'key': 'value'}
+        m.save()
+        m = JSONModel.objects.get()
+        assert m.attrs == {'key': 'value'}
+
+    def test_list(self):
+        m = JSONModel(attrs=[1, 2, 4])
+        assert m.attrs == [1, 2, 4]
+        m.save()
+        m = JSONModel.objects.get()
+        assert m.attrs == [1, 2, 4]
+
+    def test_null(self):
+        m = JSONModel(attrs=None)
+        assert m.attrs is None
+        m.save()
+        m = JSONModel.objects.get()
+        assert m.attrs is None
+
+
+class QueryTests(JSONFieldTestCase):
+
+    def setUp(self):
+        super(QueryTests, self).setUp()
+        JSONModel.objects.bulk_create([
+            JSONModel(attrs={'a': 'b'}),
+            JSONModel(attrs=1337),
+            JSONModel(attrs=['an', 'array']),
+            JSONModel(attrs=None),
+        ])
+        self.objs = list(JSONModel.objects.all().order_by('id'))
+
+    def test_equal(self):
+        assert (
+            list(JSONModel.objects.filter(attrs={'a': 'b'})) ==
+            [self.objs[0]]
+        )
+
+    def test_equal_value(self):
+        assert (
+            list(JSONModel.objects.filter(attrs=1337)) ==
+            [self.objs[1]]
+        )
+
+    def test_equal_array(self):
+        assert (
+            list(JSONModel.objects.filter(attrs=['an', 'array'])) ==
+            [self.objs[2]]
+        )
+
+    def test_equal_no_match(self):
+        assert (
+            list(JSONModel.objects.filter(attrs={'c': 'z'})) ==
+            []
+        )
+
+    def test_equal_F_attrs(self):
+        assert (
+            list(JSONModel.objects.filter(attrs=F('attrs'))) ==
+            [self.objs[0], self.objs[1], self.objs[2]]
+        )
+
+    def test_isnull_True(self):
+        assert (
+            list(JSONModel.objects.filter(attrs__isnull=True)) ==
+            [self.objs[3]]
+        )
+
+    def test_isnull_False(self):
+        assert (
+            list(JSONModel.objects.filter(attrs__isnull=False)) ==
+            [self.objs[0], self.objs[1], self.objs[2]]
+        )
+
+    def test_range_broken(self):
+        with pytest.raises(NotImplementedError) as excinfo:
+            JSONModel.objects.filter(attrs__range=[1, 2])
+
+        assert (
+            "Lookup 'range' doesn't work with JSONField" in str(excinfo.value)
+        )
+
+
+class ArrayQueryTests(JSONFieldTestCase):
+
+    def setUp(self):
+        super(ArrayQueryTests, self).setUp()
+        JSONModel.objects.bulk_create([
+            JSONModel(attrs=[1, 3]),
+            JSONModel(attrs=[1, 3, 3]),
+            JSONModel(attrs=[1, 3, 3, 7]),
+            JSONModel(attrs=[2, 4]),
+        ])
+        self.objs = list(JSONModel.objects.all().order_by('id'))
+
+    def test_lt_1(self):
+        assert (
+            list(JSONModel.objects.filter(attrs__lt=[1])) ==
+            []
+        )
+
+    def test_lt_3(self):
+        assert (
+            list(JSONModel.objects.filter(attrs__lt=[3])) ==
+            self.objs
+        )
+
+    def test_lte_1_3_3(self):
+        assert (
+            list(JSONModel.objects.filter(attrs__lte=[1, 3, 3])) ==
+            [self.objs[0], self.objs[1]]
+        )
+
+    def test_lte_1(self):
+        assert (
+            list(JSONModel.objects.filter(attrs__lte=[1])) ==
+            []
+        )
+
+    def test_gt_1(self):
+        assert (
+            list(JSONModel.objects.filter(attrs__gt=[1])) ==
+            self.objs
+        )
+
+    def test_gt_1_3(self):
+        assert (
+            list(JSONModel.objects.filter(attrs__gt=[1, 3])) ==
+            self.objs[1:]
+        )
+
+    def test_gt_2_5(self):
+        assert (
+            list(JSONModel.objects.filter(attrs__gt=[2, 5])) ==
+            []
+        )
+
+    def test_gte_1_3(self):
+        assert (
+            list(JSONModel.objects.filter(attrs__gte=[1, 3])) ==
+            self.objs
+        )
+
+    def test_gte_2(self):
+        assert (
+            list(JSONModel.objects.filter(attrs__gte=[2])) ==
+            [self.objs[3]]
+        )
+
+
+class SubKeyQueryTests(JSONFieldTestCase):
+
+    def setUp(self):
+        super(SubKeyQueryTests, self).setUp()
+
+        self.objs = [
+            JSONModel.objects.create(attrs={}),
+            JSONModel.objects.create(attrs={
+                'a': 'b',
+                'c': 1,
+            }),
+            JSONModel.objects.create(attrs={
+                'a': 'b',
+                'c': 1,
+                'd': ['e', {'f': 'g'}],
+                'h': True,
+                'i': False,
+                'j': None,
+                'k': {'l': 'm'},
+            }),
+            JSONModel.objects.create(attrs=[1, [2]]),
+            JSONModel.objects.create(attrs={
+                'k': True,
+                'l': False,
+            }),
+        ]
+
+    def test_shallow_list_lookup(self):
+        assert (
+            list(JSONModel.objects.filter(attrs__0=1)) ==
+            [self.objs[3]]
+        )
+
+    def test_shallow_obj_lookup(self):
+        assert (
+            list(JSONModel.objects.filter(attrs__a='b')) ==
+            [self.objs[1], self.objs[2]]
+        )
+
+    def test_deep_lookup_objs(self):
+        assert (
+            list(JSONModel.objects.filter(attrs__k__l='m')) ==
+            [self.objs[2]]
+        )
+
+    def test_shallow_lookup_obj_target(self):
+        assert (
+            list(JSONModel.objects.filter(attrs__k={'l': 'm'})) ==
+            [self.objs[2]]
+        )
+
+    def test_deep_lookup_array(self):
+        assert (
+            list(JSONModel.objects.filter(attrs__1__0=2)) ==
+            [self.objs[3]]
+        )
+
+    def test_deep_lookup_mixed(self):
+        assert (
+            list(JSONModel.objects.filter(attrs__d__1__f='g')) ==
+            [self.objs[2]]
+        )
+
+    def test_deep_lookup_gt(self):
+        assert (
+            list(JSONModel.objects.filter(attrs__c__gt=1)) ==
+            []
+        )
+        assert (
+            list(JSONModel.objects.filter(attrs__c__lt=5)) ==
+            [self.objs[1], self.objs[2]]
+        )
+
+    def test_usage_in_subquery(self):
+        assert (
+            JSONModel.objects.filter(
+                id__in=JSONModel.objects.filter(attrs__c=1)
+            ),
+            [self.objs[1], self.objs[2]]
+        )
+
+
+class TestCheck(JSONFieldTestCase):
+
+    @mock.patch('django.VERSION', new=(1, 7, 2))
+    def test_old_django(self):
+        errors = JSONModel.check()
+        assert len(errors) == 1
+        assert errors[0].id == 'django_mysql.E015'
+        assert 'Django 1.8+ is required' in errors[0].msg
+
+    wrapper_path = 'django.db.backends.mysql.base.DatabaseWrapper'
+
+    @mock.patch(wrapper_path + '.is_mariadb', new=True)
+    def test_db_not_mysql(self):
+        # Uncache cached_property
+        for db in connections:
+            if 'is_mariadb' in connections[db].__dict__:
+                del connections[db].__dict__['is_mariadb']
+
+        class InvalidJSONModel(TemporaryModel):
+            field = JSONField()
+
+        errors = InvalidJSONModel.check(actually_check=True)
+        assert len(errors) == 1
+        assert errors[0].id == 'django_mysql.E016'
+        assert "MySQL 5.7+ is required" in errors[0].msg
+
+    @mock.patch(wrapper_path + '.mysql_version', new=(5, 5, 3))
+    def test_mysql_old_version(self):
+        # Uncache cached_property
+        for db in connections:
+            if 'mysql_version' in connections[db].__dict__:
+                del connections[db].__dict__['mysql_version']
+
+        class InvalidJSONModel(TemporaryModel):
+            field = JSONField()
+
+        errors = InvalidJSONModel.check(actually_check=True)
+        assert len(errors) == 1
+        assert errors[0].id == 'django_mysql.E016'
+        assert "MySQL 5.7+ is required" in errors[0].msg
+
+
+class TestFormField(JSONFieldTestCase):
+
+    def test_model_field_formfield(self):
+        model_field = JSONField()
+        form_field = model_field.formfield()
+        assert isinstance(form_field, forms.JSONField)

--- a/tests/testapp/utils.py
+++ b/tests/testapp/utils.py
@@ -1,3 +1,6 @@
+# -*- encoding:utf-8 -*-
+from __future__ import print_function
+
 import sys
 from contextlib import contextmanager
 from unittest import skipUnless
@@ -65,6 +68,24 @@ class CaptureLastQuery(object):
     @property
     def query(self):
         return self.capturer.captured_queries[-1]['sql']
+
+
+class PrintAllQueries(object):
+    def __init__(self, conn=None):
+        if conn is None:
+            self.conn = connection
+        else:
+            self.conn = conn
+
+    def __enter__(self):
+        self.capturer = CaptureQueriesContext(self.conn)
+        self.capturer.__enter__()
+        return self
+
+    def __exit__(self, a, b, c):
+        self.capturer.__exit__(a, b, c)
+        for q in self.capturer.captured_queries:
+            print(q['sql'])
 
 
 def used_indexes(query, using=DEFAULT_DB_ALIAS):


### PR DESCRIPTION
Fixes #94 .

- [x] Docs
- [x] Line added to HISTORY.rst, or N/A
- [x] Basic read/write etc
- [x] A selection of JSON functions which are easy to use
- [x] Matches querying like the `django.contrib.postgres` `JSONField`
- [x] Yes tests and yes 100% coverage
- [x] All commits squashed into one.
