### PR TITLE
Upgrade mysqlclient to 1.3.7

### DIFF
--- a/django_mysql/models/fields/bit.py
+++ b/django_mysql/models/fields/bit.py
@@ -14,7 +14,8 @@ class Bit1Mixin(object):
         if isinstance(value, six.binary_type):
             value = (value == b'\x01')
         elif isinstance(value, six.text_type):
-            value = (value == '\x01')
+            # Only on older versions of mysqlclient and Py 2.7
+            value = (value == '\x01')  # pragma: no cover
         return value
 
     def from_db_value(self, value, expression, connection, context):
@@ -22,7 +23,8 @@ class Bit1Mixin(object):
         if isinstance(value, six.binary_type):
             value = (value == b'\x01')
         elif isinstance(value, six.text_type):
-            value = (value == '\x01')
+            # Only on older versions of mysqlclient and Py 2.7
+            value = (value == '\x01')  # pragma: no cover
         return value
 
     def get_prep_value(self, value):

--- a/requirements/requirements-testing.txt
+++ b/requirements/requirements-testing.txt
@@ -5,7 +5,7 @@ flake8==2.5.0
 funcsigs==0.4
 mariadb-dyncol==1.1.0
 mock==1.3.0
-mysqlclient==1.3.6
+mysqlclient==1.3.7
 pbr==1.8.1
 pep8==1.6.2
 py==1.4.30


### PR DESCRIPTION
Due to improvements in the type handling there are now some uncovered lines in `Bit1BooleanField`'s conversion of data from the DB. IIRC they are only there for some Python 2.7 compatibility with the mixup between strings and bytes anyway. 