### PR TITLE
Tests run with STRICT_TRANS_TABLES sql_mode on

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -17,7 +17,10 @@ DATABASES = {
         'PASSWORD': '',
         'HOST': '',
         'PORT': '',
-        'OPTIONS': {'charset': 'utf8mb4'},
+        'OPTIONS': {
+            'charset': 'utf8mb4',
+            'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
+        },
         'TEST': {
             'COLLATION': "utf8mb4_general_ci",
             'CHARSET': "utf8mb4"
@@ -30,7 +33,10 @@ DATABASES = {
         'PASSWORD': '',
         'HOST': '',
         'PORT': '',
-        'OPTIONS': {'charset': 'utf8mb4'},
+        'OPTIONS': {
+            'charset': 'utf8mb4',
+            'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
+        },
         'TEST': {
             'COLLATION': "utf8mb4_general_ci",
             'CHARSET': "utf8mb4"


### PR DESCRIPTION
Turns truncation warnings into errors, saves us a whole lot of trouble. And others should do it too!