### PR TITLE
Add .cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[cod]
+.cache
 
 # C extensions
 *.so


### PR DESCRIPTION
`.cache` which seems to be generated by the tests should be added to the project's .gitignore list rather than a users global .gitignore list.