### PR TITLE
Travis - fix build on their new Precise infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 sudo: required
+dist: precise
+group: edge
 
 notifications:
   email: false

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -1,7 +1,10 @@
 #!/bin/bash -e
 
+set -o verbose
+
 # Add percona - have to use non-apt version since Travis' ubuntu 12.04 repo is
 # way out of date
+sudo apt-get update
 sudo apt-get install -y libio-socket-ssl-perl
 wget https://www.percona.com/downloads/percona-toolkit/2.2.13/deb/percona-toolkit_2.2.13_all.deb
 sudo dpkg -i percona-toolkit_2.2.13_all.deb

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -4,7 +4,7 @@ import os
 import django
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-DEBUG = True
+DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 
 SECRET_KEY = 'THISuISdNOT9A$SECRET9x&ji!vceayg+wwt472!bgs$0!i3k4'

--- a/tests/testapp/test_cache.py
+++ b/tests/testapp/test_cache.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 import imp
 import os
 import time
-import warnings
 from decimal import Decimal
 from unittest import skipUnless
 
@@ -896,13 +895,10 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
         cache.key_func = func
 
         try:
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
+            with pytest.warns(CacheKeyWarning):
                 # memcached does not allow whitespace or control characters in
                 # keys
-                cache.set('key with spaces', 'value')
-                assert len(w) == 2
-                assert isinstance(w[0].message, CacheKeyWarning)
+                cache.set('space key', 'value')
 
             with pytest.raises(ValueError):
                 # memcached limits key length to 250


### PR DESCRIPTION
* Explicitly route to the new infrastructure
* Force `apt-get update` since packages weren't installing without it
* Use `pytest.warns` for improved warning catching, and remove `DEBUG = True` from test settings - stops the buggy cache data warnings from erroring - fixes #188 / #189 .

As per https://blog.travis-ci.com/2015-11-27-moving-to-a-more-elastic-future and the linked instructions.