### PR TITLE
Tests - minor improvements from other projects

### DIFF
--- a/requirements/requirements-codestyle.txt
+++ b/requirements/requirements-codestyle.txt
@@ -1,7 +1,1 @@
-# Import sorting
-enum34==1.1.2
-ipaddress==1.0.16
 isort==4.2.2
-natsort==4.0.4
-pies2overrides==2.6.7
-pies==2.6.7

--- a/runtests.py
+++ b/runtests.py
@@ -33,7 +33,10 @@ def main():
         exit_on_failure(run_flake8())
         exit_on_failure(run_2to3())
         exit_on_failure(run_isort())
-        exit_on_failure(run_setup_py_check())
+
+        # Broken on 2.7.9 due to http://bugs.python.org/issue23063
+        if sys.version_info[:3] != (2, 7, 9):
+            exit_on_failure(run_setup_py_check())
 
 
 def tests_main():


### PR DESCRIPTION
* Installing old `isort` dependencies no longer necessary
* Disable `setup.py check` test on Python 2.7.9 due to bug in its rst parsing.