### PR TITLE
Checks - fix check_variables so it runs properly, add extra test

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,7 @@ Pending
 -------
 
 * New release notes here
-
+* Fixed the new system checks to actually work
 
 1.0.3 (2016-02-02)
 ------------------

--- a/django_mysql/checks.py
+++ b/django_mysql/checks.py
@@ -14,7 +14,7 @@ def register_checks():
         register(Tags.compatibility)(check_variables)
 
 
-def check_variables():
+def check_variables(app_configs, **kwargs):
     errors = []
 
     for alias, connection in mysql_connections():

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -92,7 +92,9 @@ TEMPLATES = [
         'DIRS': [],
         'APP_DIRS': True,
         'OPTIONS': {
-            'context_processors': [],
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+            ],
         },
     },
 ]

--- a/tests/testapp/test_checks.py
+++ b/tests/testapp/test_checks.py
@@ -2,7 +2,8 @@
 from unittest import skipIf
 
 import django
-from django.test import TransactionTestCase
+from django.core.management import call_command
+from django.test import TestCase, TransactionTestCase
 
 from django_mysql.checks import check_variables
 from django_mysql.test.utils import override_mysql_variables
@@ -13,29 +14,35 @@ requiresNoDBConnection = skipIf(
 )
 
 
+class CallCheckTest(TestCase):
+
+    def test_check(self):
+        call_command('check')
+
+
 @requiresNoDBConnection
 class VariablesTests(TransactionTestCase):
 
     def test_passes(self):
-        assert check_variables() == []
+        assert check_variables([]) == []
 
     @override_mysql_variables(sql_mode="")
     def test_fails_if_no_strict(self):
-        errors = check_variables()
+        errors = check_variables([])
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.W001'
         assert "MySQL Strict Mode" in errors[0].msg
 
     @override_mysql_variables(innodb_strict_mode=0)
     def test_fails_if_no_innodb_strict(self):
-        errors = check_variables()
+        errors = check_variables([])
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.W002'
         assert "InnoDB Strict Mode" in errors[0].msg
 
     @override_mysql_variables(character_set_connection='utf8')
     def test_fails_if_not_utf8mb4(self):
-        errors = check_variables()
+        errors = check_variables([])
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.W003'
         assert "utf8mb4" in errors[0].msg

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,1 @@
+urlpatterns = []


### PR DESCRIPTION
The checks were slightly broken due to `check_variables` having the wrong signature,
this fixes that and ensures that checks get run during tests so that any future errors
are found. If only django/django#5293 had been merged :)