### PR TITLE
Tests - don't run codestyle checks on Python 3.4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35}-codestyle,
+    py{27,35}-codestyle,
     py{27,34,35}-django{18,19,master},py{27,34}-django17
 
 [testenv]


### PR DESCRIPTION
Running on Python 3.5 only for Python 3 should be sufficient - it's never found a discrepancy before, and the syntax isn't really different.