### PR TITLE
Tests - fix duplicate key in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: required
 
 notifications:
   email: false
+  webhooks: https://coveralls.io/webhook?repo_token=7l8yKtg4su0M31T0eGIaM0tnjvH0Rd5PM
 
 language: python
 python: '3.5'
@@ -28,6 +29,3 @@ script:
 after_success:
   - coverage combine
   - coveralls
-
-notifications:
-  webhooks: https://coveralls.io/webhook?repo_token=7l8yKtg4su0M31T0eGIaM0tnjvH0Rd5PM


### PR DESCRIPTION
'notifications' was doubled up, causing the first to be ignored, and thus email notifications were re-enabled. Woops.