### PR TITLE
setup.py - use find_packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 import os
 import re
-from setuptools import setup
+from setuptools import find_packages, setup
 import sys
 
 
@@ -14,15 +14,6 @@ def get_version(package):
     """
     init_py = open(os.path.join(package, '__init__.py')).read()
     return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
-
-
-def get_packages(package):
-    """
-    Return root package and all sub-packages.
-    """
-    return [dirpath
-            for dirpath, dirnames, filenames in os.walk(package)
-            if os.path.exists(os.path.join(dirpath, '__init__.py'))]
 
 
 version = get_version('django_mysql')
@@ -62,7 +53,7 @@ setup(
     author="Adam Johnson",
     author_email='me@adamj.eu',
     url='https://github.com/adamchainz/django-mysql',
-    packages=get_packages('django_mysql'),
+    packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,
     install_requires=requirements,
     license="BSD",


### PR DESCRIPTION
No need to mess around with the custom `get_packages` stolen from Django REST Framework, `setuptools` got this.