### PR TITLE
Add Github template files

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,9 @@
+Summary: *summarize the issue here*
+
+*If this is a bug, please fill in the below, else delete*
+
+Django Version: *e.g. Django 1.9.2*
+
+Database and version used: *e.g. MySQL 5.6*
+
+Version: *e.g. Django-MySQL 1.0.1*

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+Summary: *please summarize what this PR fixes/adds*
+
+Checklist:
+
+- [ ] Docs updated, or N/A
+- [ ] Line added to HISTORY.rst, or N/A
+- [ ] Added extra items to checklist as applicable
+- [ ] All commits squashed into one.
+
+Test Plan: <summarize how you tested your fix/addition here>


### PR DESCRIPTION
Summary: As per their [new features](https://github.com/blog/2111-issue-and-pull-request-templates).

Checklist:

- [N/A] Docs updated, or N/A
- [N/A] Line added to HISTORY.rst, or N/A
- [x] All commits squashed into one.

Test Plan: I don't think we can try these until they are on `master`. However I read the docs carefully.
