### PR TITLE
Add lock and unlock methods to Lock/TableLock classes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ Pending
 * Now MySQL 5.7 compatible
 * The final message from ``SmartChunkedIterator`` is now rounded to the nearest
   second.
+* Lock supports lock / unlock methods
 
 1.0.5 (2016-02-10)
 ------------------

--- a/django_mysql/locks.py
+++ b/django_mysql/locks.py
@@ -41,7 +41,7 @@ class Lock(object):
         return self.lock()
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.unlock(exc_type, exc_value, traceback)
+        self.unlock()
 
     def lock(self):
         with self.get_cursor() as cursor:
@@ -58,7 +58,7 @@ class Lock(object):
                         self.acquire_timeout)
                 )
 
-    def unlock(self, *exc):
+    def unlock(self):
         with self.get_cursor() as cursor:
             cursor.execute("SELECT RELEASE_LOCK(%s)", (self.name,))
             result = cursor.fetchone()[0]
@@ -150,9 +150,9 @@ class TableLock(object):
                 locks.append("{} WRITE".format(qn(name)))
             cursor.execute("LOCK TABLES {}".format(", ".join(locks)))
 
-    def unlock(self, *exc):
+    def unlock(self, exc_type=None, exc_value=None, traceback=None):
         connection = connections[self.db]
         with connection.cursor() as cursor:
-            self._atomic.__exit__(*exc)
+            self._atomic.__exit__(exc_type, exc_value, traceback)
             self._atomic = None
             cursor.execute("UNLOCK TABLES")

--- a/django_mysql/locks.py
+++ b/django_mysql/locks.py
@@ -38,6 +38,12 @@ class Lock(object):
         return connections[self.db].cursor()
 
     def __enter__(self):
+        return self.lock()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.unlock(exc_type, exc_value, traceback)
+
+    def lock(self):
         with self.get_cursor() as cursor:
             cursor.execute(
                 "SELECT GET_LOCK(%s, %s)",
@@ -52,7 +58,7 @@ class Lock(object):
                         self.acquire_timeout)
                 )
 
-    def __exit__(self, a, b, c):
+    def unlock(self, *exc):
         with self.get_cursor() as cursor:
             cursor.execute("SELECT RELEASE_LOCK(%s)", (self.name,))
             result = cursor.fetchone()[0]
@@ -119,7 +125,7 @@ class TableLock(object):
         return table_names.keys()
 
     def __enter__(self):
-        self.lock()
+        return self.lock()
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.unlock(exc_type, exc_value, traceback)
@@ -144,9 +150,9 @@ class TableLock(object):
                 locks.append("{} WRITE".format(qn(name)))
             cursor.execute("LOCK TABLES {}".format(", ".join(locks)))
 
-    def unlock(self, exc_type, exc_value, traceback):
+    def unlock(self, *exc):
         connection = connections[self.db]
         with connection.cursor() as cursor:
-            self._atomic.__exit__(exc_type, exc_value, traceback)
+            self._atomic.__exit__(*exc)
             self._atomic = None
             cursor.execute("UNLOCK TABLES")

--- a/docs/locks.rst
+++ b/docs/locks.rst
@@ -88,6 +88,23 @@ The following can be imported from ``django_mysql.locks``.
         Returns the MySQL ``CONNECTION_ID()`` of the holder of the lock, or
         ``None`` if it is not currently held.
 
+    .. method:: lock()
+
+        This method is useful if you prefer to use Lock without a context manager::
+
+            from django_mysql.locks import Lock
+
+            lock = Lock('no_context_manager')
+            lock.lock()
+            try:
+                mutually_exclusive_process()
+            finally:
+                lock.unlock()
+
+    .. method:: unlock()
+
+        See method above.
+
     .. classmethod:: held_with_prefix(prefix, using=DEFAULT_DB_ALIAS)
 
         Queries the held locks that match the given prefix, for the given
@@ -158,6 +175,23 @@ The following can be imported from ``django_mysql.locks``.
 
         The connection alias from ``DATABASES`` to use. Defaults to Django's
         ``DEFAULT_DB_ALIAS`` to use your main database connection.
+
+    .. method:: lock()
+
+        TableLock can be used without a context manager::
+
+            from django_mysql.locks import TableLock
+
+            table_lock = TableLock('no_context_manager')
+            table_lock.lock()
+            try:
+                mutually_exclusive_process()
+            finally:
+                table_lock.unlock()
+
+    .. method:: unlock()
+
+        See method above.
 
     .. note::
 

--- a/tests/testapp/test_locks.py
+++ b/tests/testapp/test_locks.py
@@ -211,6 +211,13 @@ class LockTests(TestCase):
         assert Lock.held_with_prefix('') == {}
         assert Lock.held_with_prefix('mylock') == {}
 
+    def test_no_context_manager(self):
+        lock = Lock('no_context_manager')
+        try:
+            lock.lock()
+        finally:
+            lock.unlock()
+
 
 class TableLockTests(TransactionTestCase):
     def tearDown(self):
@@ -390,3 +397,10 @@ class TableLockTests(TransactionTestCase):
             assert to_me.get() == "Reading"
         finally:
             other_thread.join()
+
+    def test_no_context_manager(self):
+        lock = TableLock(read=[Alphabet])
+        try:
+            lock.lock()
+        finally:
+            lock.unlock()


### PR DESCRIPTION
Summary: Refactored `Lock` a bit so `lock` / `unlock` can be used without `with`-statement

Checklist:

- [x] Docs
- [x] HISTORY.rst
- [x] Tests
- [x] All commits squashed into one.

Test Plan: `./runtests.py`

