### PR TITLE
JSONField lookups

### DIFF
--- a/django_mysql/models/functions.py
+++ b/django_mysql/models/functions.py
@@ -229,8 +229,8 @@ class JSONKeys(Func):
 class JSONLength(Func):
     function = 'JSON_LENGTH'
 
-    def __init__(self, expression, path=None):
-        from django_mysql.models.fields import JSONField
+    def __init__(self, expression, path=None, **extra):
+        output_field = extra.pop('output_field', IntegerField())
 
         exprs = [expression]
         if path is not None:
@@ -238,7 +238,7 @@ class JSONLength(Func):
                 path = Value(path)
             exprs.append(path)
 
-        super(JSONLength, self).__init__(*exprs, output_field=JSONField())
+        super(JSONLength, self).__init__(*exprs, output_field=output_field)
 
 
 # MariaDB Regexp Functions

--- a/django_mysql/models/lookups.py
+++ b/django_mysql/models/lookups.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+import json
+
 from django.db.models import CharField, Lookup, Transform
 from django.db.models.lookups import BuiltinLookup
 
@@ -29,7 +31,78 @@ class Soundex(Transform):
         return "SOUNDEX(%s)" % lhs, params
 
 
-# These are mostly used for custom fields
+# Custom field class lookups
+
+
+# JSONField
+
+
+class JSONContainedBy(Lookup):
+    lookup_name = 'contained_by'
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = rhs_params + lhs_params
+        return 'JSON_CONTAINS({}, {})'.format(rhs, lhs), params
+
+
+class JSONContains(Lookup):
+    lookup_name = 'contains'
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = lhs_params + rhs_params
+        return 'JSON_CONTAINS({}, {})'.format(lhs, rhs), params
+
+
+class JSONHasKey(Lookup):
+    lookup_name = 'has_key'
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        key_name = self.rhs
+        path = '$.{}'.format(json.dumps(key_name))
+        params = lhs_params + [path]
+        return "JSON_CONTAINS_PATH({}, 'one', %s)".format(lhs), params
+
+
+class JSONHasKeys(Lookup):
+    lookup_name = 'has_keys'
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        paths = [
+            '$.{}'.format(json.dumps(key_name))
+            for key_name in self.rhs
+        ]
+        params = lhs_params + paths
+
+        sql = ['JSON_CONTAINS_PATH(', lhs, ", 'all', "]
+        sql.append(', '.join('%s' for _ in paths))
+        sql.append(')')
+        return ''.join(sql), params
+
+
+class JSONHasAnyKeys(Lookup):
+    lookup_name = 'has_any_keys'
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        paths = [
+            '$.{}'.format(json.dumps(key_name))
+            for key_name in self.rhs
+        ]
+        params = lhs_params + paths
+
+        sql = ['JSON_CONTAINS_PATH(', lhs, ", 'one', "]
+        sql.append(', '.join('%s' for _ in paths))
+        sql.append(')')
+        return ''.join(sql), params
+
+
+# Set{Char,Text}Field
 
 
 class SetContains(Lookup):
@@ -45,6 +118,9 @@ class SetContains(Lookup):
 
 class SetIContains(SetContains):
     lookup_name = 'icontains'
+
+
+# DynamicField
 
 
 class DynColHasKey(Lookup):

--- a/tests/testapp/test_functions.py
+++ b/tests/testapp/test_functions.py
@@ -374,6 +374,14 @@ class JSONFunctionTests(JSONFieldTestCase):
         )
         assert results == [len(self.obj.attrs['sub'])]
 
+    def test_json_length_type(self):
+        results = list(
+            JSONModel.objects.annotate(
+                x=JSONLength('attrs')
+            ).filter(x__range=[3, 5])
+        )
+        assert results == [self.obj]
+
 
 @requiresDatabaseFunctions
 class RegexpFunctionTests(TestCase):

--- a/tests/testapp/utils.py
+++ b/tests/testapp/utils.py
@@ -70,7 +70,7 @@ class CaptureLastQuery(object):
         return self.capturer.captured_queries[-1]['sql']
 
 
-class PrintAllQueries(object):
+class print_all_queries(object):
     def __init__(self, conn=None):
         if conn is None:
             self.conn = connection


### PR DESCRIPTION
Summary: Fixes #244 .

Checklist:

- [x] Docs updated
- [x] Not necessary to add a line to HISTORY.rst, as JSONField is not released and these features count as part of that
- [x] All commits squashed into one.
- [x] `has_key`
- [x] `has_keys`
- [x] `has_any_keys`
- [x] `length`
- [x] `contains`
- [x] `contained_by`

Test Plan: Added plenty of tests, checked against JSON Path syntax from the [MySQL Manual](https://dev.mysql.com/doc/refman/5.7/en/json-path-syntax.html).