### PR TITLE
Add check to JSONField to error on mutable defaults

### DIFF
--- a/docs/model_fields/json_field.rst
+++ b/docs/model_fields/json_field.rst
@@ -40,6 +40,15 @@ Django-MySQL supports the JSON data type and related functions through
     checked by the field and you'll get sensible errors for them when Django's
     checks run if you're not up to date on either.
 
+    .. warning::
+
+        If you give the field a ``default``, ensure it's a callable, such as
+        ``dict``, ``list``, or ``lambda: {'key': 'value'}``. Incorrectly using
+        a mutable object, such as ``default={}``, creates a single object that
+        is shared between all instances of the field. There's a field check
+        that errors if a plain ``list`` or ``dict`` instance is used for
+        ``default``, so there is some protection against this.
+
 JSONFields in Forms
 -------------------
 

--- a/tests/testapp/test_jsonfield.py
+++ b/tests/testapp/test_jsonfield.py
@@ -411,6 +411,24 @@ class TestCheck(JSONFieldTestCase):
         assert errors[0].id == 'django_mysql.E015'
         assert 'Django 1.8+ is required' in errors[0].msg
 
+    def test_mutable_default_list(self):
+        class InvalidJSONModel(TemporaryModel):
+            field = JSONField(default=[])
+
+        errors = InvalidJSONModel.check(actually_check=True)
+        assert len(errors) == 1
+        assert errors[0].id == 'django_mysql.E017'
+        assert 'Do not use mutable defaults for JSONField' in errors[0].msg
+
+    def test_mutable_default_dict(self):
+        class InvalidJSONModel(TemporaryModel):
+            field = JSONField(default=[])
+
+        errors = InvalidJSONModel.check(actually_check=True)
+        assert len(errors) == 1
+        assert errors[0].id == 'django_mysql.E017'
+        assert 'Do not use mutable defaults for JSONField' in errors[0].msg
+
     wrapper_path = 'django.db.backends.mysql.base.DatabaseWrapper'
 
     @mock.patch(wrapper_path + '.is_mariadb', new=True)


### PR DESCRIPTION
Summary: Fixes #248 .

Checklist:

- [x] Docs updated - there should be a line or two warning against mutable defaults
- [x] Line added to HISTORY.rst - N/A, this is a feature of `JSONField` which still isn't deployed on PyPI
- [x] Added tests for `list`, `dict`
- [x] All commits squashed into one.

Test Plan: <summarize how you tested your fix/addition here>

