### PR TITLE
Fix some broken assertions picked up by new pyflakes

### DIFF
--- a/tests/testapp/test_jsonfield.py
+++ b/tests/testapp/test_jsonfield.py
@@ -395,9 +395,9 @@ class ExtraLookupsQueryTests(JSONFieldTestCase):
 
     def test_usage_in_subquery(self):
         assert (
-            JSONModel.objects.filter(
+            list(JSONModel.objects.filter(
                 id__in=JSONModel.objects.filter(attrs__c=1)
-            ),
+            )) ==
             [self.objs[1], self.objs[2]]
         )
 

--- a/tests/testapp/test_operations.py
+++ b/tests/testapp/test_operations.py
@@ -166,8 +166,7 @@ class AlterStorageEngineTests(TransactionTestCase):
             operation.database_forwards("test_arstd", editor, project_state,
                                         new_state)
         queries = [q['sql'] for q in capturer.captured_queries]
-        assert (
-            not any(q.startswith('ALTER TABLE ') for q in queries),
+        assert not any(q.startswith('ALTER TABLE ') for q in queries), (
             "One of the executed queries was an unexpected ALTER TABLE:\n{}"
             .format("\n".join(queries))
         )


### PR DESCRIPTION
After pyflakes upgrade in 5f48f963969da20bb59065c0e832c73c64505492, some tests were found to be broken due to meaningless assertions. Fix those assertions!