### PR TITLE
Smart Iterator - fail when primary key is a non-integer foreign key

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,8 @@ History
 Pending
 -------
 
-* New release notes here
+* ``SmartChunkedIterator`` now fails properly for models whose primary key is a
+  non-integer foreign key.
 
 
 1.0.7 (2016-03-04)

--- a/django_mysql/models/query.py
+++ b/django_mysql/models/query.py
@@ -340,7 +340,13 @@ class SmartChunkedIterator(object):
             )
 
         pk = queryset.model._meta.pk
-        if not isinstance(pk, self.ALLOWED_PK_FIELD_CLASSES):
+        allowed_field = (
+            isinstance(pk, self.ALLOWED_PK_FIELD_CLASSES) or
+            (isinstance(pk, models.ForeignKey) and
+             isinstance(pk.foreign_related_fields[0],
+                        self.ALLOWED_PK_FIELD_CLASSES))
+        )
+        if not allowed_field:
             # If your custom field class should be allowed, just add it to
             # ALLOWED_PK_FIELD_CLASSES
             raise ValueError(
@@ -353,7 +359,6 @@ class SmartChunkedIterator(object):
     ALLOWED_PK_FIELD_CLASSES = (
         models.IntegerField,  # Also covers e.g. PositiveIntegerField
         models.AutoField,  # Is an integer field but doesn't subclass it :(
-        models.ForeignKey  # Should always point to an integer
     )
 
     def get_first_and_last(self):

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -184,6 +184,10 @@ class NameAuthor(Model):
         return "{} {}".format(self.id, self.name)
 
 
+class NameAuthorExtra(Model):
+    name = OneToOneField(NameAuthor, primary_key=True)
+
+
 class AuthorMultiIndex(Model):
     class Meta(object):
         index_together = ('name', 'country')

--- a/tests/testapp/test_models.py
+++ b/tests/testapp/test_models.py
@@ -16,7 +16,8 @@ from django_mysql.models import (
 )
 from django_mysql.utils import have_program, index_name
 from testapp.models import (
-    Author, AuthorExtra, AuthorMultiIndex, Book, NameAuthor, VanillaAuthor
+    Author, AuthorExtra, AuthorMultiIndex, Book, NameAuthor, NameAuthorExtra,
+    VanillaAuthor
 )
 from testapp.utils import CaptureLastQuery, captured_stdout, used_indexes
 
@@ -611,6 +612,11 @@ class SmartIteratorTests(TestCase):
         for extra in AuthorExtra.objects.iter_smart():
             seen_author_ids.append(extra.author_id)
         assert seen_author_ids == [author.id, author2.id]
+
+    def test_iter_smart_fk_string_primary_key_fails(self):
+        with pytest.raises(ValueError) as excinfo:
+            NameAuthorExtra.objects.iter_smart()
+        assert "non-integer primary key" in str(excinfo.value)
 
     def test_reporting(self):
         with captured_stdout() as output:


### PR DESCRIPTION
Fixes #261 .