### PR TITLE
Fix some features to work when there are non-MySQL databases configured

### DIFF
--- a/django_mysql/models/fields/dynamic.py
+++ b/django_mysql/models/fields/dynamic.py
@@ -65,14 +65,15 @@ class DynamicField(field_class(Field)):
     def _check_mariadb_version(self):
         errors = []
 
-        any_conn_works = False
+        any_conn_works = True
         conn_names = ['default'] + list(set(connections) - {'default'})
         for db in conn_names:
+            conn = connections[db]
             if (
-                connections[db].is_mariadb and
-                connections[db].mysql_version >= (10, 0, 1)
+                hasattr(conn, 'mysql_version') and
+                (not conn.is_mariadb or conn.mysql_version < (10, 0, 1))
             ):
-                any_conn_works = True
+                any_conn_works = False
 
         if not any_conn_works:
             errors.append(

--- a/django_mysql/models/fields/json.py
+++ b/django_mysql/models/fields/json.py
@@ -72,14 +72,15 @@ class JSONField(field_class(Field)):
     def _check_mysql_version(self):
         errors = []
 
-        any_conn_works = False
+        any_conn_works = True
         conn_names = ['default'] + list(set(connections) - {'default'})
         for db in conn_names:
+            conn = connections[db]
             if (
-                not connections[db].is_mariadb and
-                connections[db].mysql_version >= (5, 7)
+                hasattr(conn, 'mysql_version') and
+                (conn.is_mariadb or conn.mysql_version < (5, 7))
             ):
-                any_conn_works = True
+                any_conn_works = False
 
         if not any_conn_works:
             errors.append(

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -48,7 +48,15 @@ DATABASES = {
             'CHARSET': "utf8mb4"
         }
     },
+    'other2': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    }
 }
+
+DATABASE_ROUTERS = [
+    'testapp.routers.TestAppRouter',
+]
 
 ALLOWED_HOSTS = []
 

--- a/tests/testapp/routers.py
+++ b/tests/testapp/routers.py
@@ -1,0 +1,11 @@
+class TestAppRouter(object):
+
+    def allow_relation(self, obj1, obj2, **hints):
+        if obj1._meta.app_label == 'testapp' or obj2._meta.app_label == 'testapp':
+            return True
+        return None
+
+    def allow_migrate(self, db, app_label, **hints):
+        if app_label == 'testapp':
+            return db == 'default' or db == 'other'
+        return None

--- a/tests/testapp/test_monkey_patches.py
+++ b/tests/testapp/test_monkey_patches.py
@@ -8,7 +8,8 @@ class IsMariaDBTests(TestCase):
     def test_connections(self):
         for alias in connections:
             connection = connections[alias]
-
+            if not hasattr(connection, 'mysql_version'):
+                continue
             with connection.cursor() as cursor:
                 cursor.execute("SELECT VERSION()")
                 version = cursor.fetchone()[0]


### PR DESCRIPTION
- Changed method  `_check_mariadb_version` of `JSONField` to not raise an error when a non MySQL database is configured
- Changed method `_check_mariadb_version` of `DynamicField` to not raise an error when a non MySQL database is configured
- Changed testapp database settings to include a dummy sqlite3 database
- Added a router to the testapp to avoid migrations to be run on the sqlite3 database
- Fixed `monkey_patches` test