### PR TITLE
Linting requires __future__.absolute_import in all files

### DIFF
--- a/django_mysql/__init__.py
+++ b/django_mysql/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 
 __author__ = 'Adam Johnson'
 __email__ = 'me@adamj.eu'

--- a/django_mysql/apps.py
+++ b/django_mysql/apps.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 from django.apps import AppConfig
 from django.utils.translation import ugettext_lazy as _
 

--- a/django_mysql/cache.py
+++ b/django_mysql/cache.py
@@ -1,5 +1,5 @@
 # -*- coding:utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import re
 import zlib

--- a/django_mysql/checks.py
+++ b/django_mysql/checks.py
@@ -1,5 +1,5 @@
 # -*- coding:utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.core.checks import Tags, Warning, register
 from django.db import DEFAULT_DB_ALIAS, connections

--- a/django_mysql/exceptions.py
+++ b/django_mysql/exceptions.py
@@ -1,4 +1,5 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
 
 
 class TimeoutError(Exception):

--- a/django_mysql/locks.py
+++ b/django_mysql/locks.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 from collections import OrderedDict
 
 from django.db import connections

--- a/django_mysql/management/__init__.py
+++ b/django_mysql/management/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/django_mysql/management/commands/__init__.py
+++ b/django_mysql/management/commands/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/django_mysql/management/commands/cull_mysql_caches.py
+++ b/django_mysql/management/commands/cull_mysql_caches.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import django
 from django.conf import settings

--- a/django_mysql/management/commands/dbparams.py
+++ b/django_mysql/management/commands/dbparams.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import django
 from django.core.management import BaseCommand, CommandError

--- a/django_mysql/management/commands/fix_datetime_columns.py
+++ b/django_mysql/management/commands/fix_datetime_columns.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import django
 from django.apps import apps

--- a/django_mysql/management/commands/mysql_cache_migration.py
+++ b/django_mysql/management/commands/mysql_cache_migration.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import django
 from django.conf import settings

--- a/django_mysql/models/__init__.py
+++ b/django_mysql/models/__init__.py
@@ -1,6 +1,8 @@
 """
 isort:skip_file
 """
+from __future__ import absolute_import
+
 from django_mysql.models.base import Model  # noqa
 from django_mysql.models.aggregates import (  # noqa
     BitAnd, BitOr, BitXor, GroupConcat

--- a/django_mysql/models/aggregates.py
+++ b/django_mysql/models/aggregates.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from django.db.models import Aggregate, CharField
 
 

--- a/django_mysql/models/base.py
+++ b/django_mysql/models/base.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 from django.db import models
 
 from django_mysql.models.query import QuerySet

--- a/django_mysql/models/expressions.py
+++ b/django_mysql/models/expressions.py
@@ -1,5 +1,5 @@
 # -*- coding:utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.db.models import F, Value
 from django.db.models.expressions import BaseExpression

--- a/django_mysql/models/fields/__init__.py
+++ b/django_mysql/models/fields/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from django_mysql.models.fields.bit import (  # noqa
     Bit1BooleanField, NullBit1BooleanField
 )

--- a/django_mysql/models/fields/bit.py
+++ b/django_mysql/models/fields/bit.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 from django.db.models import BooleanField, NullBooleanField
 from django.utils import six
 

--- a/django_mysql/models/fields/sizes.py
+++ b/django_mysql/models/fields/sizes.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from django.core import checks
 from django.db.models import BinaryField, TextField
 

--- a/django_mysql/models/functions.py
+++ b/django_mysql/models/functions.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.db.models import Field as DjangoField
 from django.db.models import CharField, Func, IntegerField, TextField, Value

--- a/django_mysql/models/handler.py
+++ b/django_mysql/models/handler.py
@@ -1,5 +1,5 @@
 # -*- coding:utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import re
 from random import randint

--- a/django_mysql/models/lookups.py
+++ b/django_mysql/models/lookups.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 import collections
 import json
 

--- a/django_mysql/models/query.py
+++ b/django_mysql/models/query.py
@@ -1,5 +1,5 @@
 # -*- coding:utf-8 -*-
-from __future__ import print_function, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 import operator
 import sys

--- a/django_mysql/models/transforms.py
+++ b/django_mysql/models/transforms.py
@@ -1,5 +1,5 @@
 # -*- coding:utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.db.models import IntegerField, Transform
 

--- a/django_mysql/monkey_patches.py
+++ b/django_mysql/monkey_patches.py
@@ -1,5 +1,5 @@
 # -*- coding:utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import functools
 

--- a/django_mysql/operations.py
+++ b/django_mysql/operations.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from django.db.migrations.operations.base import Operation
 from django.utils.functional import cached_property
 

--- a/django_mysql/rewrite_query.py
+++ b/django_mysql/rewrite_query.py
@@ -4,7 +4,7 @@ Implements a function for hoisting specially constructed comments in SQL
 queries and using them to rewrite that query. This is done to support query
 hints whilst obviating patching Django's ORM in complex ways.
 """
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import operator
 import re

--- a/django_mysql/test/__init__.py
+++ b/django_mysql/test/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/django_mysql/test/utils.py
+++ b/django_mysql/test/utils.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import uuid
 from functools import wraps
 

--- a/django_mysql/utils.py
+++ b/django_mysql/utils.py
@@ -1,5 +1,5 @@
 # -*- coding:utf-8 -*-
-from __future__ import division
+from __future__ import absolute_import, division
 
 import os
 import time

--- a/django_mysql/validators.py
+++ b/django_mysql/validators.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 from django.core.validators import MaxLengthValidator, MinLengthValidator
 from django.utils.translation import ungettext_lazy
 

--- a/runtests.py
+++ b/runtests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 import os
 import sys

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,8 @@ known_standard_library = mock
 known_third_party = pytest,django
 multi_line_output = 5
 not_skip = __init__.py
+add_imports =
+    from __future__ import absolute_import
 
 [multilint]
 paths = django_mysql

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ from __future__ import (
 import os
 import re
 import sys
+
 from setuptools import find_packages, setup
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,2 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
 # -*- coding:utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import django
 from django.db import connection
+
 from pytest_django.plugin import _blocking_manager
 
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 import os
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))

--- a/tests/testapp/__init__.py
+++ b/tests/testapp/__init__.py
@@ -1,1 +1,2 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import

--- a/tests/testapp/enum_default_migrations/0001_initial.py
+++ b/tests/testapp/enum_default_migrations/0001_initial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.db import migrations, models
 

--- a/tests/testapp/enum_default_migrations/0002_add_some_fields.py
+++ b/tests/testapp/enum_default_migrations/0002_add_some_fields.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.db import migrations
 

--- a/tests/testapp/enum_default_migrations/0003_remove_some_fields.py
+++ b/tests/testapp/enum_default_migrations/0003_remove_some_fields.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.db import migrations
 

--- a/tests/testapp/enum_default_migrations/__init__.py
+++ b/tests/testapp/enum_default_migrations/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/testapp/list_default_migrations/0001_initial.py
+++ b/tests/testapp/list_default_migrations/0001_initial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.db import migrations, models
 

--- a/tests/testapp/list_default_migrations/0002_add_some_fields.py
+++ b/tests/testapp/list_default_migrations/0002_add_some_fields.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.db import migrations, models
 

--- a/tests/testapp/list_default_migrations/__init__.py
+++ b/tests/testapp/list_default_migrations/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/testapp/management/__init__.py
+++ b/tests/testapp/management/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/testapp/management/commands/__init__.py
+++ b/tests/testapp/management/commands/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/testapp/management/commands/test_dbparams.py
+++ b/tests/testapp/management/commands/test_dbparams.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 import mock
 from unittest import skipIf
 

--- a/tests/testapp/management/commands/test_fix_datetime_columns.py
+++ b/tests/testapp/management/commands/test_fix_datetime_columns.py
@@ -1,5 +1,5 @@
 # -*- coding:utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import mock
 from textwrap import dedent

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 import json
 from datetime import date, datetime, time
 

--- a/tests/testapp/routers.py
+++ b/tests/testapp/routers.py
@@ -1,4 +1,7 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
+
 class NothingOnSQLiteRouter(object):
 
     def allow_migrate(self, db, app_label, **hints):

--- a/tests/testapp/set_default_migrations/0001_initial.py
+++ b/tests/testapp/set_default_migrations/0001_initial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.db import migrations, models
 

--- a/tests/testapp/set_default_migrations/0002_add_some_fields.py
+++ b/tests/testapp/set_default_migrations/0002_add_some_fields.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.db import migrations, models
 

--- a/tests/testapp/set_default_migrations/__init__.py
+++ b/tests/testapp/set_default_migrations/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/testapp/sizedbinaryfield_migrations/0001_initial.py
+++ b/tests/testapp/sizedbinaryfield_migrations/0001_initial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.db import migrations, models
 

--- a/tests/testapp/sizedbinaryfield_migrations/0002_alter_field.py
+++ b/tests/testapp/sizedbinaryfield_migrations/0002_alter_field.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.db import migrations
 

--- a/tests/testapp/sizedbinaryfield_migrations/__init__.py
+++ b/tests/testapp/sizedbinaryfield_migrations/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/testapp/sizedtextfield_migrations/0001_initial.py
+++ b/tests/testapp/sizedtextfield_migrations/0001_initial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.db import migrations, models
 

--- a/tests/testapp/sizedtextfield_migrations/0002_alter_field.py
+++ b/tests/testapp/sizedtextfield_migrations/0002_alter_field.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.db import migrations
 

--- a/tests/testapp/sizedtextfield_migrations/__init__.py
+++ b/tests/testapp/sizedtextfield_migrations/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/testapp/test_aggregates.py
+++ b/tests/testapp/test_aggregates.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 import pytest
 from django.db.models import F
 from django.test import TestCase

--- a/tests/testapp/test_bit1_field.py
+++ b/tests/testapp/test_bit1_field.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 import json
 
 from django.core import serializers

--- a/tests/testapp/test_cache.py
+++ b/tests/testapp/test_cache.py
@@ -1,5 +1,5 @@
 # -*- coding:utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import imp
 import os

--- a/tests/testapp/test_checks.py
+++ b/tests/testapp/test_checks.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 from django.core.management import call_command
 from django.test import TestCase, TransactionTestCase
 

--- a/tests/testapp/test_dynamicfield.py
+++ b/tests/testapp/test_dynamicfield.py
@@ -1,5 +1,5 @@
 # -*- coding:utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import json
 import mock

--- a/tests/testapp/test_forms.py
+++ b/tests/testapp/test_forms.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 import pytest
 from django import forms
 from django.core import exceptions

--- a/tests/testapp/test_functions.py
+++ b/tests/testapp/test_functions.py
@@ -1,5 +1,5 @@
 # -*- coding:utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import hashlib
 from unittest import SkipTest

--- a/tests/testapp/test_handler.py
+++ b/tests/testapp/test_handler.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 import pytest
 from django.db import connection
 from django.db.models import F

--- a/tests/testapp/test_jsonfield.py
+++ b/tests/testapp/test_jsonfield.py
@@ -1,5 +1,5 @@
 # -*- coding:utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import mock
 from unittest import SkipTest

--- a/tests/testapp/test_listcharfield.py
+++ b/tests/testapp/test_listcharfield.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 import json
 import re
 

--- a/tests/testapp/test_listtextfield.py
+++ b/tests/testapp/test_listtextfield.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 import json
 import re
 

--- a/tests/testapp/test_locks.py
+++ b/tests/testapp/test_locks.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 from threading import Thread
 
 import pytest

--- a/tests/testapp/test_lookups.py
+++ b/tests/testapp/test_lookups.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 from django.test import TestCase
 
 from testapp.models import Author

--- a/tests/testapp/test_models.py
+++ b/tests/testapp/test_models.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 import mock
 import pickle
 import re

--- a/tests/testapp/test_monkey_patches.py
+++ b/tests/testapp/test_monkey_patches.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 from django.db import connections
 from django.test import TestCase
 

--- a/tests/testapp/test_operations.py
+++ b/tests/testapp/test_operations.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from unittest import SkipTest
 
 import pytest

--- a/tests/testapp/test_rewrite_query.py
+++ b/tests/testapp/test_rewrite_query.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 from django.db import connection
 from django.test import TestCase
 from django.test.utils import override_settings

--- a/tests/testapp/test_setcharfield.py
+++ b/tests/testapp/test_setcharfield.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 import json
 import re
 

--- a/tests/testapp/test_settextfield.py
+++ b/tests/testapp/test_settextfield.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 import json
 
 import pytest

--- a/tests/testapp/test_size_fields.py
+++ b/tests/testapp/test_size_fields.py
@@ -1,5 +1,5 @@
 # -*- coding:utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import pytest
 from django.core.management import call_command

--- a/tests/testapp/test_status.py
+++ b/tests/testapp/test_status.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
+
 import pytest
 from django.test import TestCase
 

--- a/tests/testapp/test_test_utils.py
+++ b/tests/testapp/test_test_utils.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import pytest
 from django.db import connections
 from django.test import TestCase

--- a/tests/testapp/test_utils.py
+++ b/tests/testapp/test_utils.py
@@ -1,5 +1,5 @@
 # -*- coding:utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from time import sleep
 from unittest import skipUnless

--- a/tests/testapp/utils.py
+++ b/tests/testapp/utils.py
@@ -1,5 +1,5 @@
 # -*- encoding:utf-8 -*-
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 import sys
 from contextlib import contextmanager

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,1 +1,3 @@
+from __future__ import absolute_import
+
 urlpatterns = []


### PR DESCRIPTION
This makes the code more Python 3 compatible on Python 2. Ref #319.