### PR TITLE
Fix index hint for nested queries

### DIFF
--- a/django_mysql/rewrite_query.py
+++ b/django_mysql/rewrite_query.py
@@ -167,7 +167,7 @@ def modify_sql(sql, add_comments, add_hints, add_index_hints):
 table_spec_re_template = r'''
     \b(?P<operator>FROM|JOIN)
     \s+
-    {table_name}
+    {table_name}(?!\s+[A-Z]+\d+)
     \s+
 '''
 

--- a/tests/testapp/test_rewrite_query.py
+++ b/tests/testapp/test_rewrite_query.py
@@ -310,6 +310,26 @@ class RewriteQueryTests(TestCase):
             "WHERE (1) ORDER BY col_a"
         )
 
+    def test_index_hint_not_applied_to_nested(self):
+        assert (
+            rewrite_query(
+                "SELECT COUNT(*) FROM `sometable` "
+                "WHERE id IN ("
+                "  SELECT DISTINCT U1.id FROM `sometable` U0"
+                "  INNER JOIN `tag` U1 ON U1.fk_id=U0.id"
+                "  WHERE U1.name in ('a', 'b', 'c')"
+                ")"
+                "AND (/*QueryRewrite':index=`tag` USE `myindex` */1)"
+            ) ==
+            "SELECT COUNT(*) FROM `sometable` "
+            "WHERE id IN ("
+            "  SELECT DISTINCT U1.id FROM `sometable` U0"
+            "  INNER JOIN `tag` U1 ON U1.fk_id=U0.id"
+            "  WHERE U1.name in ('a', 'b', 'c')"
+            ")"
+            "AND (1)"
+        )
+
     def test_it_is_monkey_patched(self):
         with CaptureLastQuery() as cap, connection.cursor() as cursor:
             cursor.execute("SELECT 1 FROM DUAL "


### PR DESCRIPTION
Summary:
Using index hint on a query where indexed table represented only in subquery (e.g. if you use Paginator, some tables might be ommited in count() query) causes syntax error (the hint added before table alias).

```python
class Post(Model):
    author = ForeignKey('User')
    text = TextField()
    published = DateTimeField()

class TaggedPost(Post):
    tags = ManyToManyField('Tag')

# use subquery instead of distinct() for optimization purposes; distinct() causes filesort
post_ids = TaggedPost.objects.filter(tags__in=tags_list).values('pk')
posts = TaggedPost.objects.filter(pk__in=post_ids).use_index('published_idx', table_name='post')
# next line generate invalid query
count = posts.count()
```

Fix rely on weak assumption that django uses aliases for tables in nested queries and these aliases match `[A-Z]+\d+`. From now on `use_index()` doesn't apply hint to any aliased tables.

Checklist:
- [ ] Line added to HISTORY.rst
- [x] All commits squashed into one.
- [ ] Self added to AUTHORS.rst (or you can opt out)

Test Plan:
Tested in my project with and without nested queries. Added test case.

