### PR TITLE
Index hint for nested queries (bound to alias)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,3 +13,4 @@ Contributors
 * Łukasz Więcek <https://github.com/lwiecek>
 * Marco Santamaria <https://github.com/marco-santamaria>
 * Michael Aquilina <https://github.com/MichaelAquilina>
+* Vladimir Kuzmin <https://github.com/VladimirKuzmin>

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Pending
 
 * New release notes here
 * Fixed some features to work when there are non-MySQL databases configured
+* Fixed syntax error when index hint used on an aliased table
+* Index hints apply to the correct table entry in nested queries
 
 1.0.8 (2016-04-08)
 ------------------


### PR DESCRIPTION
Summary:

Index hint should remember which table it was applied.
Solution:
- on each aliases changing in query also change alias in index hint
- at rewriting stage modify SQL according the alias

Checklist:
- [x] Docs updated, or N/A
- [x] Line added to HISTORY.rst, or N/A
- [x] Added extra items to checklist as applicable
- [x] All commits squashed into one.

Test Plan:
- added tests for nested queries up to 3 level generated by Django ORM
- added test for raw SQL query

Known issue:
For nested queries like this (without any `JOIN`): 

``` python
SomeModel.objects.filter(pk__in=SomeModel.objects.all())
```

Django will not assign alias to any table, so index hint will be always applied to outer query.
But it looks like queries like this are useless.
