### PR TITLE
Fixed problem with control characters in JSONField

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Pending
 
 * New release notes here
 * Fixed some features to work when there are non-MySQL databases configured
+* Allowed control characters in JSONField
 
 1.0.8 (2016-04-08)
 ------------------

--- a/django_mysql/models/fields/json.py
+++ b/django_mysql/models/fields/json.py
@@ -110,7 +110,7 @@ class JSONField(field_class(Field)):
     def from_db_value(self, value, expression, connection, context):
         # Similar to to_python, for Django 1.8+
         if isinstance(value, six.string_types):
-            return json.loads(value)
+            return json.loads(value, strict=False)
         return value
 
     def get_prep_value(self, value):

--- a/tests/testapp/test_jsonfield.py
+++ b/tests/testapp/test_jsonfield.py
@@ -58,6 +58,14 @@ class TestSaveLoad(JSONFieldTestCase):
         m = JSONModel.objects.get()
         assert m.attrs is None
 
+    def test_control_characters(self):
+        chars = ''.join(chr(i) for i in range(32))
+        m = JSONModel(attrs=[chars])
+        assert m.attrs == [chars]
+        m.save()
+        m = JSONModel.objects.get()
+        assert m.attrs == [chars]
+
 
 class QueryTests(JSONFieldTestCase):
 


### PR DESCRIPTION
Summary: Added option `strict=False` to the `json.loads` call in the `from_db_value` method of the `JSONField` class to allow control characters. Fixes #287.

Checklist:

- [x] Docs updated - N/A
- [x] Line added to HISTORY.rst
- [x] All commits squashed into one.

Test Plan: Added test