### PR TITLE
Update mentions of readthedocs.org to readthedocs.io

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -148,7 +148,7 @@ Pending
 * Extra ORM aggregates added - ``BitAnd``, ``BitOr``, and ``BitXor``
 * ``MySQLCache`` is now case-sensitive. If you are already using it, an upgrade
   ``ALTER TABLE`` and migration is provided at `the end of the cache docs
-  <http://django-mysql.readthedocs.org/en/latest/cache.html>`_.
+  <https://django-mysql.readthedocs.io/en/latest/cache.html>`_.
 * (MariaDB only) The ``Lock`` class gained a class method ``held_with_prefix``
   to query held locks matching a given prefix
 * ``SmartIterator`` bugfix for chunks with 0 objects slowing iteration; they

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Django-MySQL
         :target: https://pypi.python.org/pypi/django-mysql
 
 .. image:: https://readthedocs.org/projects/django-mysql/badge/?version=latest
-        :target: http://django-mysql.readthedocs.org/en/latest/
+        :target: https://django-mysql.readthedocs.io/en/latest/
 
 
 .. figure:: https://raw.github.com/adamchainz/django-mysql/master/docs/images/dolphin-pony.png
@@ -59,7 +59,7 @@ Includes:
 * Table lock manager for hard to pull off data migrations
 
 To see them all, check out the exposition at
-http://django-mysql.readthedocs.org/en/latest/exposition.html .
+https://django-mysql.readthedocs.io/en/latest/exposition.html .
 
 
 Requirements
@@ -85,4 +85,4 @@ Documentation
 -------------
 
 Every detail documented on
-`Read The Docs <https://django-mysql.readthedocs.org/en/latest/>`_.
+`Read The Docs <https://django-mysql.readthedocs.io/en/latest/>`_.

--- a/django_mysql/checks.py
+++ b/django_mysql/checks.py
@@ -44,7 +44,7 @@ def strict_mode_warning(alias):
         MySQL's Strict Mode fixes many data integrity problems in MySQL, such
         as data truncation upon insertion, by escalating warnings into errors.
         It is strongly recommended you activate it. See:
-        http://django-mysql.readthedocs.org/en/latest/checks.html#django-mysql-w001-strict-mode
+        https://django-mysql.readthedocs.io/en/latest/checks.html#django-mysql-w001-strict-mode
     """)
     return Warning(
         message.format(alias),
@@ -59,7 +59,7 @@ def innodb_strict_mode_warning(alias):
         InnoDB Strict Mode escalates several warnings around InnoDB-specific
         statements into errors. It's recommended you activate this, but it's
         not very likely to affect you if you don't. See:
-        http://django-mysql.readthedocs.org/en/latest/checks.html#django-mysql-w002-innodb-strict-mode
+        https://django-mysql.readthedocs.io/en/latest/checks.html#django-mysql-w002-innodb-strict-mode
     """)
 
     return Warning(
@@ -75,7 +75,7 @@ def utf8mb4_warning(alias):
         The default 'utf8' character set does not include support for all
         Unicode characters. It's strongly recommended you move to use
         'utf8mb4'. See:
-        http://django-mysql.readthedocs.org/en/latest/checks.html#django-mysql-w003-utf8mb4
+        https://django-mysql.readthedocs.io/en/latest/checks.html#django-mysql-w003-utf8mb4
     """)
 
     return Warning(


### PR DESCRIPTION
They changed domain for hosted projects for security reasons.