### PR TITLE
Fix build for Django 1.10 changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Requirements
 Tested with all combinations of:
 
 * Python: 2.7, 3.4, 3.5
-* Django: 1.7, 1.8, 1.9, master
+* Django: 1.7, 1.8, 1.9, 1.10 branch
 * MySQL: 5.5, 5.6, 5.7 / MariaDB: 5.5, 10.0, 10.1
 * mysqlclient: 1.3.7 (Python 3 compatible version of ``MySQL-python``)
 

--- a/django_mysql/models/fields/sets.py
+++ b/django_mysql/models/fields/sets.py
@@ -1,6 +1,7 @@
 # -*- coding:utf-8 -*-
 from __future__ import absolute_import
 
+import django
 from django.core import checks
 from django.db.models import CharField, IntegerField, TextField
 from django.utils import six
@@ -125,23 +126,24 @@ class SetFieldMixin(object):
             return ','.join(value)
         return value
 
-    def get_db_prep_lookup(self, lookup_type, value, connection,
-                           prepared=False):
-        if lookup_type in ('contains', 'icontains'):
-            # Avoid the default behaviour of adding wildcards on either side of
-            # what we're searching for, because FIND_IN_SET is doing that
-            # implicitly
-            if isinstance(value, set):
-                # Can't do multiple contains without massive ORM hackery
-                # (ANDing all the FIND_IN_SET calls), so just reject them
-                raise ValueError(
-                    "Can't do contains with a set and {klass}, you should "
-                    "pass them as separate filters."
-                    .format(klass=self.__class__.__name__)
-                )
-            return [six.text_type(self.base_field.get_prep_value(value))]
-        return super(SetFieldMixin, self).get_db_prep_lookup(
-            lookup_type, value, connection, prepared)
+    if django.VERSION[:2] <= (1, 7):
+        def get_db_prep_lookup(self, lookup_type, value, connection,
+                               prepared=False):
+            if lookup_type in ('contains', 'icontains'):
+                # Avoid the default behaviour of adding wildcards on either
+                # side of what we're searching for, because FIND_IN_SET is
+                # doing that implicitly
+                if isinstance(value, set):
+                    # Can't do multiple contains without massive ORM hackery
+                    # (ANDing all the FIND_IN_SET calls), so just reject them
+                    raise ValueError(
+                        "Can't do contains with a set and {klass}, you should "
+                        "pass them as separate filters."
+                        .format(klass=self.__class__.__name__)
+                    )
+                return [six.text_type(self.base_field.get_prep_value(value))]
+            return super(SetFieldMixin, self).get_db_prep_lookup(
+                lookup_type, value, connection, prepared)
 
     def value_to_string(self, obj):
         vals = self._get_val_from_obj(obj)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,7 +8,7 @@ Requirements
 Tested with all combinations of:
 
 * Python: 2.7, 3.4, 3.5
-* Django: 1.7, 1.8, 1.9, master
+* Django: 1.7, 1.8, 1.9, 1.10 branch
 * MySQL: 5.5, 5.6, 5.7 / MariaDB: 5.5, 10.0, 10.1
 * mysqlclient: 1.3.7 (Python 3 compatible version of ``MySQL-python``)
 

--- a/tests/testapp/test_enumfield.py
+++ b/tests/testapp/test_enumfield.py
@@ -129,12 +129,12 @@ class TestMigrations(TransactionTestCase):
             assert table_name not in table_names(cursor)
 
         call_command('migrate', 'testapp',
-                     verbosity=0, skip_checks=True)
+                     verbosity=0, skip_checks=True, interactive=False)
         with connection.cursor() as cursor:
             assert table_name in table_names(cursor)
 
         call_command('migrate', 'testapp', 'zero',
-                     verbosity=0, skip_checks=True)
+                     verbosity=0, skip_checks=True, interactive=False)
         with connection.cursor() as cursor:
             assert table_name not in table_names(cursor)
 

--- a/tests/testapp/test_jsonfield.py
+++ b/tests/testapp/test_jsonfield.py
@@ -13,6 +13,7 @@ from django.test import TestCase
 from django_mysql import forms
 from django_mysql.models import JSONField
 from testapp.models import JSONModel, TemporaryModel
+from testapp.utils import print_all_queries
 
 
 class JSONFieldTestCase(TestCase):
@@ -268,10 +269,11 @@ class ExtraLookupsQueryTests(JSONFieldTestCase):
         assert "only works with Sequences" in str(excinfo.value)
 
     def test_has_keys(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__has_keys=['a', 'c'])) ==
-            [self.objs[1], self.objs[2]]
-        )
+        with print_all_queries():
+            assert (
+                list(JSONModel.objects.filter(attrs__has_keys=['a', 'c'])) ==
+                [self.objs[1], self.objs[2]]
+            )
 
     def test_has_keys_2(self):
         assert (

--- a/tests/testapp/test_listcharfield.py
+++ b/tests/testapp/test_listcharfield.py
@@ -528,12 +528,12 @@ class TestMigrations(TransactionTestCase):
             assert table_name not in table_names(cursor)
 
         call_command('migrate', 'testapp',
-                     verbosity=0, skip_checks=True)
+                     verbosity=0, skip_checks=True, interactive=False)
         with connection.cursor() as cursor:
             assert table_name in table_names(cursor)
 
         call_command('migrate', 'testapp', 'zero',
-                     verbosity=0, skip_checks=True)
+                     verbosity=0, skip_checks=True, interactive=False)
         with connection.cursor() as cursor:
             assert table_name not in table_names(cursor)
 

--- a/tests/testapp/test_setcharfield.py
+++ b/tests/testapp/test_setcharfield.py
@@ -494,12 +494,12 @@ class TestMigrations(TransactionTestCase):
             assert table_name not in table_names(cursor)
 
         call_command('migrate', 'testapp',
-                     verbosity=0, skip_checks=True)
+                     verbosity=0, skip_checks=True, interactive=False)
         with connection.cursor() as cursor:
             assert table_name in table_names(cursor)
 
         call_command('migrate', 'testapp', 'zero',
-                     verbosity=0, skip_checks=True)
+                     verbosity=0, skip_checks=True, interactive=False)
         with connection.cursor() as cursor:
             assert table_name not in table_names(cursor)
 

--- a/tests/testapp/test_size_fields.py
+++ b/tests/testapp/test_size_fields.py
@@ -22,7 +22,7 @@ forceDataError = override_mysql_variables(SQL_MODE='STRICT_TRANS_TABLES')
 
 def migrate(name):
     call_command('migrate', 'testapp', name,
-                 verbosity=0, skip_checks=True)
+                 verbosity=0, skip_checks=True, interactive=False)
 
 
 class SubSizedBinaryField(SizedBinaryField):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{27,35}-codestyle,
-    py{27,34,35}-django{18,19,master},py{27,34}-django17
+    py{27,34,35}-django{18,19,110},py{27,34}-django17
 
 [testenv]
 setenv =
@@ -11,7 +11,7 @@ deps =
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
-    djangomaster: https://github.com/django/django/archive/master.tar.gz
+    django110: https://github.com/django/django/archive/stable/1.10.x.tar.gz
     -rrequirements/requirements-testing.txt
 commands = coverage run -p --source=django_mysql ./runtests.py --nolint {posargs}
 


### PR DESCRIPTION
- [x] Stop building Django master, fix on the 1.10 branch since it's alpha now
- [x] Fix for `get_prep_lookup` / `get_db_prep_lookup` obsoletion in django/django#6499
- [x] Fix `call_command('migrate')` requiring `interactive=False`