### PR TITLE
Add multilint config, move isort config into setup.py

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,12 +10,6 @@ insert_final_newline = true
 charset = utf-8
 end_of_line = lf
 
-[*.py]
-multi_line_output=5
-known_standard_library=mock
-known_third_party=pytest,django
-known_first_party=django_mysql
-
 [*.bat]
 indent_style = tab
 end_of_line = crlf

--- a/django_mysql/models/__init__.py
+++ b/django_mysql/models/__init__.py
@@ -1,3 +1,6 @@
+"""
+isort:skip_file
+"""
 from django_mysql.models.base import Model  # noqa
 from django_mysql.models.aggregates import (  # noqa
     BitAnd, BitOr, BitXor, GroupConcat

--- a/django_mysql/models/fields/__init__.py
+++ b/django_mysql/models/fields/__init__.py
@@ -7,9 +7,7 @@ from django_mysql.models.fields.json import JSONField  # noqa
 from django_mysql.models.fields.lists import (  # noqa
     ListCharField, ListTextField
 )
-from django_mysql.models.fields.sets import (  # noqa
-    SetCharField, SetTextField
-)
+from django_mysql.models.fields.sets import SetCharField, SetTextField  # noqa
 from django_mysql.models.fields.sizes import (  # noqa
     SizedBinaryField, SizedTextField
 )

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,5 +4,18 @@ universal = 1
 [flake8]
 select = E,F,W
 
+[isort]
+known_first_party = django_mysql
+known_standard_library = mock
+known_third_party = pytest,django
+multi_line_output = 5
+not_skip = __init__.py
+
+[multilint]
+paths = django_mysql
+        runtests.py
+        setup.py
+        tests
+
 [pytest]
 addopts = -p no:doctest


### PR DESCRIPTION
`multilint` paths config was missing when added, plus `isort` config should be in `setup.cfg` rather than `.editorconfig` because it's cleaner there.