### PR TITLE
Stop testing with Python 3.4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ Requirements
 
 Tested with all combinations of:
 
-* Python: 2.7, 3.4, 3.5
+* Python: 2.7, 3.5
 * Django: 1.8, 1.9, 1.10 branch
 * MySQL: 5.5, 5.6, 5.7 / MariaDB: 5.5, 10.0, 10.1
 * mysqlclient: 1.3.7 (Python 3 compatible version of ``MySQL-python``)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,7 +7,7 @@ Requirements
 
 Tested with all combinations of:
 
-* Python: 2.7, 3.4, 3.5
+* Python: 2.7, 3.5
 * Django: 1.8, 1.9, 1.10 branch
 * MySQL: 5.5, 5.6, 5.7 / MariaDB: 5.5, 10.0, 10.1
 * mysqlclient: 1.3.7 (Python 3 compatible version of ``MySQL-python``)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{27,35}-codestyle,
-    py{27,34,35}-django{18,19,110}
+    py{27,35}-django{18,19,110}
 
 [testenv]
 setenv =


### PR DESCRIPTION
It has never found anything that 3.5 didn't, so it's just slowing down the build unnecessarily.