### PR TITLE
Fix some typos in JSONField docs

### DIFF
--- a/docs/model_fields/json_field.rst
+++ b/docs/model_fields/json_field.rst
@@ -82,13 +82,13 @@ We'll use the following example model:
 
 .. code-block:: python
 
-    from django_mysql.models import DynamicField, Model
+    from django_mysql.models import JSONField, Model
 
     class ShopItem(Model):
         name = models.CharField(max_length=200)
         attrs = JSONField()
 
-        def __str__(self):  # __unicode__ on Python 3
+        def __str__(self):  # __unicode__ on Python 2
             return self.name
 
 Exact Lookups


### PR DESCRIPTION
Summary:  Fix typos in code snippet.

Checklist:

- [N/A] Docs updated, or N/A
- [N/A] Line added to HISTORY.rst, or N/A
- [x] Added extra items to checklist as applicable
- [N/A] All commits squashed into one.

Test Plan: N/A

Pretty sure these are both mistakes, right? Sorry if I'm reading the Python 2/3 one wrong.