### PR TITLE
Use flake8-coding to ensure all files have the utf-8 encoding header

### DIFF
--- a/django_mysql/management/__init__.py
+++ b/django_mysql/management/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )

--- a/django_mysql/management/commands/__init__.py
+++ b/django_mysql/management/commands/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )

--- a/django_mysql/models/__init__.py
+++ b/django_mysql/models/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 """
 isort:skip_file
 """

--- a/django_mysql/models/aggregates.py
+++ b/django_mysql/models/aggregates.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )

--- a/django_mysql/models/fields/__init__.py
+++ b/django_mysql/models/fields/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )

--- a/django_mysql/models/fields/sizes.py
+++ b/django_mysql/models/fields/sizes.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )

--- a/django_mysql/models/functions.py
+++ b/django_mysql/models/functions.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )

--- a/django_mysql/operations.py
+++ b/django_mysql/operations.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )

--- a/django_mysql/test/__init__.py
+++ b/django_mysql/test/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )

--- a/django_mysql/test/utils.py
+++ b/django_mysql/test/utils.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )

--- a/requirements/requirements-codestyle.txt
+++ b/requirements/requirements-codestyle.txt
@@ -1,3 +1,4 @@
+flake8-coding==1.3.0
 isort==4.2.5
 mccabe==0.5.2
 multilint==2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 universal = 1
 
 [flake8]
+accept-encodings = utf-8
 ignore = X99999
 
 [isort]

--- a/tests/testapp/enum_default_migrations/__init__.py
+++ b/tests/testapp/enum_default_migrations/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )

--- a/tests/testapp/list_default_migrations/__init__.py
+++ b/tests/testapp/list_default_migrations/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )

--- a/tests/testapp/management/__init__.py
+++ b/tests/testapp/management/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )

--- a/tests/testapp/management/commands/__init__.py
+++ b/tests/testapp/management/commands/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )

--- a/tests/testapp/set_default_migrations/__init__.py
+++ b/tests/testapp/set_default_migrations/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )

--- a/tests/testapp/sizedbinaryfield_migrations/__init__.py
+++ b/tests/testapp/sizedbinaryfield_migrations/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )

--- a/tests/testapp/sizedtextfield_migrations/__init__.py
+++ b/tests/testapp/sizedtextfield_migrations/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )

--- a/tests/testapp/test_operations.py
+++ b/tests/testapp/test_operations.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )

--- a/tests/testapp/test_test_utils.py
+++ b/tests/testapp/test_test_utils.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )


### PR DESCRIPTION
Fixes #319. Last step to ensuring compatibility from Python 2 to 3.