### PR TITLE
Docs - fix links

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -188,4 +188,4 @@ arguments after the ``--`` separator, for example:
     $ tox -- tests/testapp/test_some_feature.py
 
 There are lots of other useful features, most of which you can check out in the
-`pytest docs <http://pytest.org/latest/>`_!
+`pytest docs <http://docs.pytest.org/en/latest/>`_!

--- a/django_mysql/management/commands/dbparams.py
+++ b/django_mysql/management/commands/dbparams.py
@@ -93,7 +93,7 @@ class Command(BaseCommand):
             self.stderr.write(
                 "Warning: SSL params can't be passed in the DSN syntax; you "
                 "must pass them in your my.cnf. See: "
-                "http://www.percona.com/blog/2014/10/16/percona-toolkit-for-"
+                "https://www.percona.com/blog/2014/10/16/percona-toolkit-for-"
                 "mysql-with-mysql-ssl-connections/"
             )
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -24,6 +24,7 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  html       to make standalone HTML files"
+	@echo "  linkcheck  to check links"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
 	@echo "  pickle     to make pickle files"
@@ -53,6 +54,11 @@ html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
+linkcheck:
+	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
+	@echo
+	@echo "Build finished."
 
 livehtml:
 	sphinx-autobuild -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/aggregates.rst
+++ b/docs/aggregates.rst
@@ -21,7 +21,7 @@ The following can be imported from ``django_mysql.models``.
 
     Docs:
     `MySQL
-    <http://dev.mysql.com/doc/refman/en/group-by-functions.html#function_bit-and>`_ /
+    <https://dev.mysql.com/doc/refman/en/group-by-functions.html#function_bit-and>`_ /
     `MariaDB <https://mariadb.com/kb/en/mariadb/bit_and/>`_.
 
     Example usage:
@@ -41,7 +41,7 @@ The following can be imported from ``django_mysql.models``.
 
     Docs:
     `MySQL
-    <http://dev.mysql.com/doc/refman/en/group-by-functions.html#function_bit-or>`_ /
+    <https://dev.mysql.com/doc/refman/en/group-by-functions.html#function_bit-or>`_ /
     `MariaDB <https://mariadb.com/kb/en/mariadb/bit_or/>`_.
 
     Example usage:
@@ -61,7 +61,7 @@ The following can be imported from ``django_mysql.models``.
 
     Docs:
     `MySQL
-    <http://dev.mysql.com/doc/refman/en/group-by-functions.html#function_bit-xor>`_ /
+    <https://dev.mysql.com/doc/refman/en/group-by-functions.html#function_bit-xor>`_ /
     `MariaDB <https://mariadb.com/kb/en/mariadb/bit_xor/>`_.
 
     Example usage:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -288,6 +288,6 @@ texinfo_documents = [
 
 
 intersphinx_mapping = {
-    'django': ('http://docs.djangoproject.com/en/dev/',
-               'http://docs.djangoproject.com/en/dev/_objects/'),
+    'django': ('https://docs.djangoproject.com/en/dev/',
+               'https://docs.djangoproject.com/en/dev/_objects/'),
 }

--- a/docs/field_lookups.rst
+++ b/docs/field_lookups.rst
@@ -7,8 +7,8 @@ Field Lookups
 ORM extensions for filtering. These are all automatically added for the
 appropriate field types when ``django_mysql`` is in your ``INSTALLED_APPS``.
 Note that lookups specific to included
-:doc:`model fields <model_fields>` are documented with the field, rather than
-here.
+:doc:`model fields <model_fields/index>` are documented with the field, rather
+than here.
 
 
 --------------------------------
@@ -42,7 +42,7 @@ Soundex
 -------
 
 MySQL implements the `Soundex algorithm
-<http://en.wikipedia.org/wiki/Soundex>`_ with its ``SOUNDEX`` function,
+<https://en.wikipedia.org/wiki/Soundex>`_ with its ``SOUNDEX`` function,
 allowing you to find words sounding similar to each other (in
 English only, regrettably). These lookups allow you to use that function in the
 ORM and are added for :class:`~django.db.fields.CharField` and

--- a/docs/locks.rst
+++ b/docs/locks.rst
@@ -36,7 +36,7 @@ The following can be imported from ``django_mysql.locks``.
 
     For more information on user locks refer to the ``GET_LOCK`` documentation
     on `MySQL
-    <http://dev.mysql.com/doc/refman/5.6/en/miscellaneous-functions.html#function_get-lock>`_
+    <https://dev.mysql.com/doc/refman/5.6/en/miscellaneous-functions.html#function_get-lock>`_
     or `MariaDB <https://mariadb.com/kb/en/mariadb/get_lock/>`_.
 
     .. warning::

--- a/docs/management_commands/dbparams.rst
+++ b/docs/management_commands/dbparams.rst
@@ -57,4 +57,4 @@ take, e.g.:
     configuration being given in their DSN format; you must pass them via a
     MySQL configuration file instead.  ``dbparams`` will output a warning
     on stderr if this is the case. For more info see the `percona blog
-    <http://www.percona.com/blog/2014/10/16/percona-toolkit-for-mysql-with-mysql-ssl-connections/>`_.
+    <https://www.percona.com/blog/2014/10/16/percona-toolkit-for-mysql-with-mysql-ssl-connections/>`_.

--- a/docs/model_fields/list_fields.rst
+++ b/docs/model_fields/list_fields.rst
@@ -112,7 +112,7 @@ The ``contains`` lookup is overridden on ``ListCharField`` and
 ``ListTextField`` to match where the set field contains the given element,
 using MySQL's ``FIND_IN_SET`` function (docs:
 `MariaDB <https://mariadb.com/kb/en/mariadb/find_in_set/>`_ /
-`MySQL <http://dev.mysql.com/doc/refman/en/string-functions.html#function_find-in-set>`_ docs).
+`MySQL <https://dev.mysql.com/doc/refman/en/string-functions.html#function_find-in-set>`_ docs).
 
 For example:
 

--- a/docs/model_fields/set_fields.rst
+++ b/docs/model_fields/set_fields.rst
@@ -108,7 +108,7 @@ The ``contains`` lookup is overridden on ``SetCharField`` and ``SetTextField``
 to match where the set field contains the given element, using MySQL's
 ``FIND_IN_SET`` (docs:
 `MariaDB <https://mariadb.com/kb/en/mariadb/find_in_set/>`_ /
-`MySQL <http://dev.mysql.com/doc/refman/en/string-functions.html#function_find-in-set>`_).
+`MySQL <https://dev.mysql.com/doc/refman/en/string-functions.html#function_find-in-set>`_).
 
 For example:
 

--- a/docs/queryset_extensions.rst
+++ b/docs/queryset_extensions.rst
@@ -22,7 +22,7 @@ Approximate Counting
     full table scan to produce a consistent number, due to MVCC keeping several
     copies of rows when under transaction. If you have lots of rows, you will
     notice this as a slow query - `Percona have some more details
-    <http://www.percona.com/blog/2006/12/01/count-for-innodb-tables/>`_.
+    <https://www.percona.com/blog/2006/12/01/count-for-innodb-tables/>`_.
 
     This method returns the approximate count found by running ``EXPLAIN SELECT
     COUNT(*) ...``. It can be out by 30-50% in the worst case, but in many
@@ -182,9 +182,10 @@ Once you’ve done this, the following methods will work.
     `MySQL <https://dev.mysql.com/doc/refman/en/select.html>`_ /
     `MariaDB <https://mariadb.com/kb/en/mariadb/select/#straight_join>`_.
 
-    The MariaDB docs also have a good page `“How to Force Query Plans”
-    <https://mariadb.com/kb/en/mariadb/how-to-force-query-plans/>`_ which
-    covers some cases when you might want to use ``STRAIGHT_JOIN``.
+    The MariaDB docs also have a good page `Index Hints: How to Force Query
+    Plans”
+    <https://mariadb.com/kb/en/mariadb/index-hints-how-to-force-query-plans/>`_
+    which covers some cases when you might want to use ``STRAIGHT_JOIN``.
 
 .. method:: sql_small_result()
 
@@ -358,7 +359,7 @@ Once you’ve done this, the following methods will work.
     Docs:
     `MySQL <https://dev.mysql.com/doc/refman/en/index-hints.html>`_ /
     `MariaDB
-    <https://mariadb.com/kb/en/mariadb/how-to-force-query-plans/>`_.
+    <https://mariadb.com/kb/en/mariadb/index-hints-how-to-force-query-plans/>`_.
 
 
 .. method:: force_index(*index_names, for_=None)
@@ -505,7 +506,7 @@ can be thought of in one of these two methods.
         dynamically adjusted to try and match this time, via a weighted average
         of the past and current speed of processing. The default and algorithm
         is taken from the analogous ``pt-online-schema-change`` flag
-        `--chunk-time <http://www.percona.com/doc/percona-toolkit/2.1/pt-online-schema-change.html#cmdoption-pt-online-schema-change--chunk-time>`_.
+        `--chunk-time <https://www.percona.com/doc/percona-toolkit/2.1/pt-online-schema-change.html#cmdoption-pt-online-schema-change--chunk-time>`_.
 
     .. attribute:: chunk_size=2
 
@@ -630,10 +631,10 @@ Integration with pt-visual-explain
 ----------------------------------
 
 How does MySQL *really* execute a query? The ``EXPLAIN`` statement
-(docs: `MySQL <http://dev.mysql.com/doc/refman/5.6/en/explain.html>`_ /
+(docs: `MySQL <https://dev.mysql.com/doc/refman/5.6/en/explain.html>`_ /
 `MariaDB <https://mariadb.com/kb/en/mariadb/explain/>`_),
 gives a description of the execution plan, and the ``pt-visual-explain``
-`tool <http://www.percona.com/doc/percona-toolkit/2.2/pt-visual-explain.html>`_
+`tool <https://www.percona.com/doc/percona-toolkit/2.2/pt-visual-explain.html>`_
 can format this in an understandable tree.
 
 This function is a shortcut to turn a ``QuerySet`` into its visual explanation,
@@ -682,7 +683,7 @@ Handler
 MySQL's ``HANDLER`` commands give you simple NoSQL-style read access, faster
 than full SQL queries, with the ability to perform index lookups or paginated
 scans (docs:
-`MySQL <http://dev.mysql.com/doc/refman/5.6/en/handler.html>`_ /
+`MySQL <https://dev.mysql.com/doc/refman/5.6/en/handler.html>`_ /
 `MariaDB <https://mariadb.com/kb/en/mariadb/handler-commands/>`_).
 
 This extension adds an ORM-based API for handlers. You can instantiate them

--- a/docs/status.rst
+++ b/docs/status.rst
@@ -43,7 +43,7 @@ The following can all be imported from ``django_mysql.status``.
         47
 
     To see the names of all the available variables, refer to the documentation:
-    `MySQL <http://dev.mysql.com/doc/refman/5.6/en/show-status.html>`_ /
+    `MySQL <https://dev.mysql.com/doc/refman/5.6/en/show-status.html>`_ /
     `MariaDB <https://mariadb.com/kb/en/mariadb/show-status/>`_. They vary
     based upon server version, plugins installed, etc.
 
@@ -82,7 +82,7 @@ The following can all be imported from ``django_mysql.status``.
                                     timeout=60.0, sleep=0.1)
 
         A helper method similar to the logic in ``pt-online-schema-change`` for
-        waiting with `--max-load <http://www.percona.com/doc/percona-toolkit/2.1/pt-online-schema-change.html#cmdoption-pt-online-schema-change--max-load>`_.
+        waiting with `--max-load <https://www.percona.com/doc/percona-toolkit/2.1/pt-online-schema-change.html#cmdoption-pt-online-schema-change--max-load>`_.
 
         Polls global status every ``sleep`` seconds until every variable named
         in ``thresholds`` is at or below its specified threshold, or raises a
@@ -106,7 +106,7 @@ The following can all be imported from ``django_mysql.status``.
     STATUS``, so *some* variables are restricted to the current connection
     only, rather than the whole server. For which, you should refer to the
     documentation:
-    `MySQL <http://dev.mysql.com/doc/refman/5.6/en/show-status.html>`_ /
+    `MySQL <https://dev.mysql.com/doc/refman/5.6/en/show-status.html>`_ /
     `MariaDB <https://mariadb.com/kb/en/mariadb/show-status/>`_.
 
     Also it doesn't have the ``wait_until_load_low`` method, which only makes

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -13,7 +13,7 @@ The following can be imported from ``django_mysql.utils``.
 
     Given a string ``query`` containing a MySQL query, returns a 'fingerprint'
     of the query from the Percona ``pt-fingerprint`` tool
-    (`docs <http://www.percona.com/doc/percona-toolkit/2.2/pt-fingerprint.html>`_).
+    (`docs <https://www.percona.com/doc/percona-toolkit/2.2/pt-fingerprint.html>`_).
     You must therefore have ``pt-fingerprint`` installed.
 
     Example usage:


### PR DESCRIPTION
Add a sphinx `linkcheck` build which checks all the links it finds,
and fix said link problems.

There was one broken internal link, to `model_fields`. The rest are
mostly dealing with HTTPS permanent redirects.