### PR TITLE
AttributeError: 'DatabaseWrapper'

### DIFF
--- a/django_mysql/models/fields/json.py
+++ b/django_mysql/models/fields/json.py
@@ -63,7 +63,7 @@ class JSONField(Field):
         for db in conn_names:
             conn = connections[db]
             if (
-                hasattr(conn, 'mysql_version') and
+                hasattr(conn, 'mysql_version') and hasattr(conn, 'is_mariadb') and
                 (conn.is_mariadb or conn.mysql_version < (5, 7))
             ):
                 any_conn_works = False


### PR DESCRIPTION
AttributeError: 'DatabaseWrapper' object has no attribute 'is_mariadb'.

Put an additional check for is_mariadb

Summary: *please summarize what this PR fixes/adds*

Checklist:

- [ ] Docs updated, or N/A
- [ ] Line added to HISTORY.rst, or N/A
- [ ] Added extra items to checklist as applicable
- [ ] All commits squashed into one.

Test Plan: <summarize how you tested your fix/addition here>
