### PR TITLE
Disallow NaN in JSONField because MySQL doesn't support it

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ Pending
 -------
 
 * New release notes here
+* Don't allow NaN in JSONField because MySQL doesn't support it
 
 1.1.0 (2016-07-22)
 ------------------

--- a/django_mysql/models/fields/json.py
+++ b/django_mysql/models/fields/json.py
@@ -103,7 +103,10 @@ class JSONField(Field):
         if value is not None and not isinstance(value, six.string_types):
             # For some reason this value gets string quoted in Django's SQL
             # compiler...
-            return json.dumps(value)
+
+            # Although json.dumps could serialize NaN, MySQL doesn't.
+            return json.dumps(value, allow_nan=False)
+
         return value
 
     def get_lookup(self, lookup_name):

--- a/tests/testapp/test_jsonfield.py
+++ b/tests/testapp/test_jsonfield.py
@@ -66,6 +66,15 @@ class TestSaveLoad(JSONFieldTestCase):
         m = JSONModel.objects.get()
         assert m.attrs == [chars]
 
+    def test_nan_raises_valueerror(self):
+        m = JSONModel(attrs=float('nan'))
+        try:
+            m.save()
+        except ValueError:
+            pass
+        else:
+            assert False
+
 
 class QueryTests(JSONFieldTestCase):
 

--- a/tests/testapp/test_jsonfield.py
+++ b/tests/testapp/test_jsonfield.py
@@ -68,12 +68,8 @@ class TestSaveLoad(JSONFieldTestCase):
 
     def test_nan_raises_valueerror(self):
         m = JSONModel(attrs=float('nan'))
-        try:
+        with pytest.raises(ValueError):
             m.save()
-        except ValueError:
-            pass
-        else:
-            assert False
 
 
 class QueryTests(JSONFieldTestCase):


### PR DESCRIPTION
Summary: Call json.dumps with allow_nan=False, to get a ValueError instead of a misleading DB error, in case of 'value' containing NaN.

Issue: #345

Test Plan: Test added. All tests pass.
