### PR TITLE
Don't dump value if its already a string in JSONField.prepare_value.

### DIFF
--- a/django_mysql/forms.py
+++ b/django_mysql/forms.py
@@ -247,4 +247,6 @@ class JSONField(forms.CharField):
             )
 
     def prepare_value(self, value):
-        return json.dumps(value)
+        if not isinstance(value, six.string_types):
+            return json.dumps(value)
+        return value

--- a/tests/testapp/test_forms.py
+++ b/tests/testapp/test_forms.py
@@ -307,3 +307,8 @@ class TestJSONField(SimpleTestCase):
         field = JSONField()
         assert field.prepare_value({'a': 'b'}) == '{"a": "b"}'
         assert field.prepare_value(None) == 'null'
+
+    def test_prepare_already_string_value(self):
+        field = JSONField()
+        assert field.prepare_value('{"a": "b"}') == '{"a": "b"}'
+        assert field.prepare_value('null') == 'null'


### PR DESCRIPTION
Make that `prepare_value` function of JSONField form doesn't dumb value if it's already a string.
It happens when submitting an invalid JSON into a form, that results into a "more invalid" json.

Example in #348.


Checklist:

- [ ] Docs updated, or N/A
- [ ] Line added to HISTORY.rst, or N/A
- [ ] Added extra items to checklist as applicable
- [ ] All commits squashed into one.

Test Plan: All current tests pass, and extra test added.
