### PR TITLE
Storing strings in JSONField.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,8 @@ Pending
 -------
 
 * (Insert new release notes below this line)
+* Fixed ``JSONField`` to allow storing strings as top-level json objects.
+* Fixed ``JSONField`` so that it doesn't overquote inputs when redisplaying the form due to invalid user input.
 
 1.1.1 (2017-03-28)
 ------------------

--- a/django_mysql/forms.py
+++ b/django_mysql/forms.py
@@ -240,8 +240,6 @@ class JSONField(forms.CharField):
     widget = forms.Textarea
 
     def to_python(self, value):
-        if self.disabled:
-            return value
         if value in self.empty_values:
             return None
         elif isinstance(value, (list, dict, int, float, JSONString)):
@@ -260,8 +258,6 @@ class JSONField(forms.CharField):
             return converted
 
     def bound_data(self, data, initial):
-        if self.disabled:
-            return initial
         try:
             return json.loads(data)
         except ValueError:

--- a/django_mysql/forms.py
+++ b/django_mysql/forms.py
@@ -225,26 +225,49 @@ class SimpleSetField(forms.CharField):
             raise ValidationError(errors)
 
 
+class InvalidJSONInput(six.text_type):
+    pass
+
+
+class JSONString(six.text_type):
+    pass
+
+
 class JSONField(forms.CharField):
     default_error_messages = {
         'invalid': _("'%(value)s' value must be valid JSON."),
     }
-
-    def __init__(self, **kwargs):
-        kwargs.setdefault('widget', forms.Textarea)
-        super(JSONField, self).__init__(**kwargs)
+    widget = forms.Textarea
 
     def to_python(self, value):
+        if self.disabled:
+            return value
         if value in self.empty_values:
             return None
+        elif isinstance(value, (list, dict, int, float, JSONString)):
+            return value
         try:
-            return json.loads(value)
+            converted = json.loads(value)
         except ValueError:
             raise forms.ValidationError(
                 self.error_messages['invalid'],
                 code='invalid',
                 params={'value': value},
             )
+        if isinstance(converted, six.text_type):
+            return JSONString(converted)
+        else:
+            return converted
+
+    def bound_data(self, data, initial):
+        if self.disabled:
+            return initial
+        try:
+            return json.loads(data)
+        except ValueError:
+            return InvalidJSONInput(data)
 
     def prepare_value(self, value):
+        if isinstance(value, InvalidJSONInput):
+            return value
         return json.dumps(value)

--- a/django_mysql/models/fields/json.py
+++ b/django_mysql/models/fields/json.py
@@ -109,6 +109,11 @@ class JSONField(Field):
 
         return value
 
+    def get_db_prep_value(self, value, connection, prepared=False):
+        if not prepared and value is not None:
+            return json.dumps(value, allow_nan=False)
+        return value
+
     def get_lookup(self, lookup_name):
         # Have to 'unregister' some incompatible lookups
         if lookup_name in {

--- a/tests/testapp/test_forms.py
+++ b/tests/testapp/test_forms.py
@@ -7,6 +7,7 @@ import pytest
 from django import forms
 from django.core import exceptions
 from django.test import SimpleTestCase
+from django.utils.html import escape
 
 from django_mysql.forms import JSONField, SimpleListField, SimpleSetField
 
@@ -306,4 +307,37 @@ class TestJSONField(SimpleTestCase):
     def test_prepare_value(self):
         field = JSONField()
         assert field.prepare_value({'a': 'b'}) == '{"a": "b"}'
+        assert field.prepare_value(['a', 'b']) == '["a", "b"]'
+        assert field.prepare_value(True) == 'true'
+        assert field.prepare_value(False) == 'false'
+        assert field.prepare_value(3.14) == '3.14'
         assert field.prepare_value(None) == 'null'
+        assert field.prepare_value('foo') == '"foo"'
+
+    def test_redisplay_wrong_input(self):
+        """
+        When displaying a bound form (typically due to invalid input), the form
+        should not overquote JSONField inputs.
+        """
+        class JsonForm(forms.Form):
+            name = forms.CharField(max_length=2)
+            jfield = JSONField()
+
+        # JSONField input is fine, name is too long
+        form = JsonForm({'name': 'xyz', 'jfield': '["foo"]'})
+        self.assertIn('[&quot;foo&quot;]</textarea>', form.as_p())
+
+        # This time, the JSONField input is wrong
+        form = JsonForm({'name': 'xy', 'jfield': '{"foo"}'})
+        # Appears once in the textarea and once in the error message
+        self.assertEqual(form.as_p().count(escape('{"foo"}')), 2)
+
+    def test_already_converted_value(self):
+        field = JSONField(required=False)
+        tests = [
+            '["a", "b", "c"]', '{"a": 1, "b": 2}', '1', '1.5', '"foo"',
+            'true', 'false', 'null',
+        ]
+        for json_string in tests:
+            val = field.clean(json_string)
+            self.assertEqual(field.clean(val), val)

--- a/tests/testapp/test_jsonfield.py
+++ b/tests/testapp/test_jsonfield.py
@@ -44,12 +44,47 @@ class TestSaveLoad(JSONFieldTestCase):
         m = JSONModel.objects.get()
         assert m.attrs == {'key': 'value'}
 
+    def test_string(self):
+        m = JSONModel(attrs='value')
+        assert m.attrs == 'value'
+        m.save()
+        m = JSONModel.objects.get()
+        assert m.attrs == 'value'
+
+    def test_awkward_1(self):
+        m = JSONModel(attrs='"')
+        assert m.attrs == '"'
+        m.save()
+        m = JSONModel.objects.get()
+        assert m.attrs == '"'
+
+    def test_awkward_2(self):
+        m = JSONModel(attrs='\\')
+        assert m.attrs == '\\'
+        m.save()
+        m = JSONModel.objects.get()
+        assert m.attrs == '\\'
+
     def test_list(self):
         m = JSONModel(attrs=[1, 2, 4])
         assert m.attrs == [1, 2, 4]
         m.save()
         m = JSONModel.objects.get()
         assert m.attrs == [1, 2, 4]
+
+    def test_true(self):
+        m = JSONModel(attrs=True)
+        assert m.attrs is True
+        m.save()
+        m = JSONModel.objects.get()
+        assert m.attrs is True
+
+    def test_false(self):
+        m = JSONModel(attrs=False)
+        assert m.attrs is False
+        m.save()
+        m = JSONModel.objects.get()
+        assert m.attrs is False
 
     def test_null(self):
         m = JSONModel(attrs=None)
@@ -81,6 +116,7 @@ class QueryTests(JSONFieldTestCase):
             JSONModel(attrs=1337),
             JSONModel(attrs=['an', 'array']),
             JSONModel(attrs=None),
+            JSONModel(attrs='foo'),
         ])
         self.objs = list(JSONModel.objects.all().order_by('id'))
 
@@ -94,6 +130,12 @@ class QueryTests(JSONFieldTestCase):
         assert (
             list(JSONModel.objects.filter(attrs=1337)) ==
             [self.objs[1]]
+        )
+
+    def test_equal_string(self):
+        assert (
+            list(JSONModel.objects.filter(attrs='foo')) ==
+            [self.objs[4]]
         )
 
     def test_equal_array(self):
@@ -111,7 +153,7 @@ class QueryTests(JSONFieldTestCase):
     def test_equal_F_attrs(self):
         assert (
             list(JSONModel.objects.filter(attrs=F('attrs'))) ==
-            [self.objs[0], self.objs[1], self.objs[2]]
+            [self.objs[0], self.objs[1], self.objs[2], self.objs[4]]
         )
 
     def test_isnull_True(self):
@@ -123,7 +165,7 @@ class QueryTests(JSONFieldTestCase):
     def test_isnull_False(self):
         assert (
             list(JSONModel.objects.filter(attrs__isnull=False)) ==
-            [self.objs[0], self.objs[1], self.objs[2]]
+            [self.objs[0], self.objs[1], self.objs[2], self.objs[4]]
         )
 
     def test_range_broken(self):


### PR DESCRIPTION
Be able to store strings in JSONField (this feature was broken).

Also copy code from 'django.contrib.postgres.forms.jsonb.JSONField' in order to fix some issues related with redisplaying wrong user input.

This PR is motivated by: #349 (which now it is not longer necessary).

Checklist:

- [x] Line added to HISTORY.rst, or N/A

Test Plan:
- Create some test about serializing strings.
- Copy two tests from ' django.tests.postgres_tests.test_json.py'.
- All current and new tests pass.

