### PR TITLE
Use custom version of six included with Django

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,8 @@ Pending
 -------
 
 * (Insert new release notes below this line)
-* Use django.utils.six everywhere
+* Use django.utils.six everywhere, fixes usage of ``EnumField`` and field
+  lookups when ``six`` is not installed (from PyPI)
 
 1.1.1 (2017-03-28)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ Pending
 -------
 
 * (Insert new release notes below this line)
+* Use django.utils.six everywhere
 
 1.1.1 (2017-03-28)
 ------------------

--- a/django_mysql/models/fields/enum.py
+++ b/django_mysql/models/fields/enum.py
@@ -3,8 +3,8 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )
 
-import six
 from django.db.models import CharField
+from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 
 from _mysql import escape_string  # isort:skip

--- a/django_mysql/models/lookups.py
+++ b/django_mysql/models/lookups.py
@@ -6,12 +6,12 @@ from __future__ import (
 import collections
 import json
 
-import six
 from django.db.models import CharField, Lookup, Transform
 from django.db.models.lookups import (
     BuiltinLookup, Exact, GreaterThan, GreaterThanOrEqual, LessThan,
     LessThanOrEqual
 )
+from django.utils import six
 
 
 class CaseSensitiveExact(BuiltinLookup):


### PR DESCRIPTION
Use django.utils.six everywhere instead of the version from PyPi. Ie, changed `import six` to `from django.utils import six`. Most imports for `six` used the django version already, but two did not. `six` is not listed in the pip install requirements (though they are in the test environment requirements), so trying to use, say, EnumField fails if `six` is not installed.


Checklist:

- [x] Docs updated, or N/A
- [x] Line added to HISTORY.rst, or N/A
- [x] Added extra items to checklist as applicable
- [x] All commits squashed into one.

Test Plan: tox passed for python 3.6 and django 1.8, 1.1.9, 1.10. (tox didn't run for other python versions due to unrelated local python installation peculiarities.)