### PR TITLE
Fix JSONField to work with Django's serializer framework

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,8 @@ Pending
   standalone package.
 * Added ``JSONSet`` database function that wraps the ``JSON_SET`` function from
   MySQL 5.7.
+* Fixed ``JSONField`` to work with Django's serializer framework, as used in
+  e.g. ``dumpdata``.
 
 1.1.1 (2017-03-28)
 ------------------

--- a/django_mysql/models/fields/json.py
+++ b/django_mysql/models/fields/json.py
@@ -120,6 +120,9 @@ class JSONField(Field):
             )
         return super(JSONField, self).get_lookup(lookup_name)
 
+    def value_to_string(self, obj):
+        return self.value_from_object(obj)
+
     def formfield(self, **kwargs):
         defaults = {'form_class': forms.JSONField}
         defaults.update(kwargs)


### PR DESCRIPTION
Summary: Fixes #353. Use the same approach that `django.contrib.postgres`'s `JSONField` uses.

Checklist:

- [x] Line added to HISTORY.rst, or N/A
- [x] All commits squashed into one.

Test Plan: Added tests adapted from the `django.contrib.postgres` ones.