### PR TITLE
Improve JSONSet, JSONReplace, JSONInsert by allowing dicts and lists.

### DIFF
--- a/django_mysql/models/functions.py
+++ b/django_mysql/models/functions.py
@@ -260,6 +260,17 @@ class JSONLength(Func):
         super(JSONLength, self).__init__(*exprs, output_field=output_field)
 
 
+class JSONValue(Func):
+    function = 'CAST'
+    template = '%(function)s(%(expressions)s as json)'
+    arity = 1
+
+    def __init__(self, expression):
+        import json
+        value = json.dumps(expression, allow_nan=False)
+        super(JSONValue, self).__init__(Value(value))
+
+
 class BaseJSONModifyFunc(Func):
     def __init__(self, expression, data):
         from django_mysql.models.fields import JSONField
@@ -276,7 +287,7 @@ class BaseJSONModifyFunc(Func):
             exprs.append(path)
 
             if not hasattr(value, 'resolve_expression'):
-                value = Value(value)
+                value = JSONValue(value)
 
             exprs.append(value)
 


### PR DESCRIPTION
Current `JSONSet` function only allows to set values like `ints`, `floats` and `str`.

This PR improves/fixes this function by also allowing to set `dicts` and `lists`.

For example:
```
obj = JSONModel.objects.create(attrs={})
obj.attrs = JSONSet('attrs', {'$.data': {'foo': 'bar', 'nums': [11, 38, 42]}})
obj.save()
```
Which will result in:

```
obj.refresh_from_db()
assert obj.attrs['data'] == {'foo': 'bar', 'nums': [11, 38, 42]}
```

The same for `JSONInsert` and `JSONReplace`.


Checklist:

- [x] Docs updated, or N/A
- [x] All commits squashed into one.

Test Plan:
- For each class ( `JSONSet`, `JSONInsert` and `JSONReplace`) add one test for `dicts` and one for `lists`.
- Add a more complex test (multi-level nested dicts and lists) just for `JSONSet`. I assume that it also works for the other classes as all of them inherits from `BaseJSONModifyFunc`.
- All current and new tests pass.
