### PR TITLE
Json search

### DIFF
--- a/django_mysql/models/functions.py
+++ b/django_mysql/models/functions.py
@@ -271,6 +271,17 @@ class JSONValue(Func):
         super(JSONValue, self).__init__(Value(json_string))
 
 
+class CharValue(Func):
+    function = 'CAST'
+    template = '%(function)s(%(expressions)s AS CHAR)'
+    def __init__(self, expression):
+        try:
+            expression = unicode(expression, "utf-8")
+        except:
+            super(CharValue, self).__init__(Value('%{}%'.format(expression)))
+        super(CharValue, self).__init__(Value('%{}%'.format(expression)))
+
+
 class BaseJSONModifyFunc(Func):
     def __init__(self, expression, data):
         from django_mysql.models.fields import JSONField


### PR DESCRIPTION
Summary:  
Added the ability to search by the key of the object, if the key is a number. Before a number it is necessary to put any letter. Example: json = {'1': '2'},  queryset = Model.objects.filter(json_field__k1='2')
Added MySQL function JSON_SEACR to find the value inside the object. Example:
json = {'key1': 'value1', 'obj': {'key2': 'value2'}, 'key3': 'value3'} 
queryset = Model.objects.filter(json_field__search='value') 
https://dev.mysql.com/doc/refman/5.7/en/json-search-functions.html#function_json-search

Checklist:

- [ ] Docs updated, or N/A
- [ ] Line added to HISTORY.rst, or N/A
- [ ] Added extra items to checklist as applicable
- [ ] All commits squashed into one.

Test Plan: Works with the current CRM project
