### PR TITLE
Fix subprocess import on Google App Engine

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 Pending
 -------
 
+-* (Insert new release notes below this line)
 * Changed subprocess imports for compatibility with Google App Engine.
 
 2.1.0 (2017-06-11)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 Pending
 -------
 
-* (Insert new release notes below this line)
+* Changed subprocess imports for compatibility with Google App Engine.
 
 2.1.0 (2017-06-11)
 ------------------

--- a/django_mysql/models/query.py
+++ b/django_mysql/models/query.py
@@ -4,11 +4,11 @@ from __future__ import (
 )
 
 import operator
+import subprocess
 import sys
 import time
 from copy import copy
 from functools import wraps
-from subprocess import PIPE, Popen
 
 import django
 from django.conf import settings
@@ -638,11 +638,11 @@ def pt_visual_explain(queryset, display=True):
         settings_to_cmd_args(connection.settings_dict) +
         ['-e', explain_query]
     )
-    mysql = Popen(mysql_command, stdout=PIPE)
-    visual_explain = Popen(
+    mysql = subprocess.Popen(mysql_command, stdout=subprocess.PIPE)
+    visual_explain = subprocess.Popen(
         ['pt-visual-explain', '-'],
         stdin=mysql.stdout,
-        stdout=PIPE
+        stdout=subprocess.PIPE
     )
     mysql.stdout.close()
     explanation = visual_explain.communicate()[0].decode(encoding="utf-8")

--- a/django_mysql/utils.py
+++ b/django_mysql/utils.py
@@ -4,10 +4,10 @@ from __future__ import (
 )
 
 import os
+import subprocess
 import time
 from collections import defaultdict
 from contextlib import contextmanager
-from subprocess import PIPE, Popen, call
 from threading import Lock, Thread
 from weakref import WeakKeyDictionary
 
@@ -157,7 +157,8 @@ programs_memo = {}
 def have_program(program_name):
     global programs_memo
     if program_name not in programs_memo:
-        status = call(['which', program_name], stdout=PIPE)
+        status = subprocess.call(['which', program_name],
+                                 stdout=subprocess.PIPE)
         programs_memo[program_name] = (status == 0)
 
     return programs_memo[program_name]
@@ -223,9 +224,9 @@ class PTFingerprintThread(Thread):
 
         global fingerprint_thread
         master, slave = pty.openpty()
-        proc = Popen(
+        proc = subprocess.Popen(
             ['pt-fingerprint'],
-            stdin=PIPE,
+            stdin=subprocess.PIPE,
             stdout=slave,
             close_fds=True
         )


### PR DESCRIPTION
Summary: Fixes #396. Change subprocess to a module level import because of some oddities on Google App Engine.

Checklist:

- [x] Docs updated, or N/A
- [x] Line added to HISTORY.rst, or N/A
- [x] Added extra items to checklist as applicable
- [x] All commits squashed into one.

Test Plan: ran tox and runtests.py for my local install without issue. 
