### PR TITLE
Made MySQLCache.set_many return a list

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,8 @@ Pending
 ------------------
 
 * Changed subprocess imports for compatibility with Google App Engine.
+* (Insert new release notes below this line)
+* Made ``MySQLCache.set_many`` return a list as per Django 2.0.
 
 2.1.0 (2017-06-11)
 ------------------

--- a/django_mysql/cache.py
+++ b/django_mysql/cache.py
@@ -289,6 +289,7 @@ class MySQLCache(BaseDatabaseCache):
 
         with connections[db].cursor() as cursor:
             cursor.execute(query, params)
+        return []
 
     def delete(self, key, version=None):
         key = self.make_key(key, version=version)

--- a/tests/testapp/test_cache.py
+++ b/tests/testapp/test_cache.py
@@ -846,11 +846,16 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
         caches['no_cull'].get('nonexistent')
 
         with self.assertNumQueries(1):
-            caches['no_cull'].set_many({"key1": "spam"})
+            result = caches['no_cull'].set_many({"key1": "spam"})
+        assert result == []
 
         # Multiple keys can be set using set_many
         with self.assertNumQueries(1):
-            caches['no_cull'].set_many({"key1": "spam", "key2": "eggs"})
+            result = caches['no_cull'].set_many({
+                'key1': 'spam',
+                'key2': 'eggs',
+            })
+        assert result == []
         assert cache.get("key1") == "spam"
         assert cache.get("key2") == "eggs"
 


### PR DESCRIPTION
Summary: Fixes #389. New feature in Django 2.0 as per django/django#7520.

Checklist:

- [x] Docs updated
- [x] Line added to HISTORY.rst
- [x] All commits squashed into one.

Test Plan: Updated test
