### PR TITLE
Fix warnings about models being reloaded

### DIFF
--- a/tests/testapp/test_dynamicfield.py
+++ b/tests/testapp/test_dynamicfield.py
@@ -325,10 +325,10 @@ class TestCheck(DynColTestCase):
     def test_db_not_mariadb(self, is_mariadb):
         is_mariadb.return_value = False
 
-        class ValidDynamicModel(TemporaryModel):
+        class ValidDynamicModel1(TemporaryModel):
             field = DynamicField()
 
-        errors = ValidDynamicModel.check(actually_check=True)
+        errors = ValidDynamicModel1.check(actually_check=True)
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.E013'
         assert "MariaDB 10.0.1+ is required" in errors[0].msg
@@ -342,10 +342,10 @@ class TestCheck(DynColTestCase):
             if 'mysql_version' in connections[db].__dict__:
                 del connections[db].__dict__['mysql_version']
 
-        class ValidDynamicModel(TemporaryModel):
+        class ValidDynamicModel2(TemporaryModel):
             field = DynamicField()
 
-        errors = ValidDynamicModel.check(actually_check=True)
+        errors = ValidDynamicModel2.check(actually_check=True)
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.E013'
         assert "MariaDB 10.0.1+ is required" in errors[0].msg
@@ -372,22 +372,22 @@ class TestCheck(DynColTestCase):
         assert "The MySQL charset must be 'utf8'" in errors[0].msg
 
     def test_spec_not_dict(self):
-        class InvalidDynamicModel(TemporaryModel):
+        class InvalidDynamicModel1(TemporaryModel):
             field = DynamicField(spec=['woops', 'a', 'list'])
 
-        errors = InvalidDynamicModel.check(actually_check=True)
+        errors = InvalidDynamicModel1.check(actually_check=True)
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.E009'
         assert "'spec' must be a dict" in errors[0].msg
         assert "The value passed is of type list" in errors[0].hint
 
     def test_spec_key_not_valid(self):
-        class InvalidDynamicModel(TemporaryModel):
+        class InvalidDynamicModel2(TemporaryModel):
             field = DynamicField(spec={
                 2.0: six.text_type
             })
 
-        errors = InvalidDynamicModel.check(actually_check=True)
+        errors = InvalidDynamicModel2.check(actually_check=True)
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.E010'
         assert "The key '2.0' in 'spec' is not a string" in errors[0].msg
@@ -395,10 +395,10 @@ class TestCheck(DynColTestCase):
         assert "'2.0' is of type float" in errors[0].hint
 
     def test_spec_value_not_valid(self):
-        class InvalidDynamicModel(TemporaryModel):
+        class InvalidDynamicModel3(TemporaryModel):
             field = DynamicField(spec={'bad': list})
 
-        errors = InvalidDynamicModel.check(actually_check=True)
+        errors = InvalidDynamicModel3.check(actually_check=True)
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.E011'
         assert (
@@ -412,14 +412,14 @@ class TestCheck(DynColTestCase):
         )
 
     def test_spec_nested_value_not_valid(self):
-        class InvalidDynamicModel(TemporaryModel):
+        class InvalidDynamicModel4(TemporaryModel):
             field = DynamicField(spec={
                 'l1': {
                     'bad': tuple
                 }
             })
 
-        errors = InvalidDynamicModel.check(actually_check=True)
+        errors = InvalidDynamicModel4.check(actually_check=True)
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.E011'
         assert (

--- a/tests/testapp/test_jsonfield.py
+++ b/tests/testapp/test_jsonfield.py
@@ -472,19 +472,19 @@ class ExtraLookupsQueryTests(JSONFieldTestCase):
 class TestCheck(JSONFieldTestCase):
 
     def test_mutable_default_list(self):
-        class InvalidJSONModel(TemporaryModel):
+        class InvalidJSONModel1(TemporaryModel):
             field = JSONField(default=[])
 
-        errors = InvalidJSONModel.check(actually_check=True)
+        errors = InvalidJSONModel1.check(actually_check=True)
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.E017'
         assert 'Do not use mutable defaults for JSONField' in errors[0].msg
 
     def test_mutable_default_dict(self):
-        class InvalidJSONModel(TemporaryModel):
+        class InvalidJSONModel2(TemporaryModel):
             field = JSONField(default=[])
 
-        errors = InvalidJSONModel.check(actually_check=True)
+        errors = InvalidJSONModel2.check(actually_check=True)
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.E017'
         assert 'Do not use mutable defaults for JSONField' in errors[0].msg
@@ -493,10 +493,10 @@ class TestCheck(JSONFieldTestCase):
     def test_db_not_mysql(self, is_mariadb):
         is_mariadb.return_value = True
 
-        class InvalidJSONModel(TemporaryModel):
+        class InvalidJSONModel3(TemporaryModel):
             field = JSONField()
 
-        errors = InvalidJSONModel.check(actually_check=True)
+        errors = InvalidJSONModel3.check(actually_check=True)
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.E016'
         assert "MySQL 5.7+ is required" in errors[0].msg
@@ -510,10 +510,10 @@ class TestCheck(JSONFieldTestCase):
             if 'mysql_version' in connections[db].__dict__:
                 del connections[db].__dict__['mysql_version']
 
-        class InvalidJSONModel(TemporaryModel):
+        class InvalidJSONModel4(TemporaryModel):
             field = JSONField()
 
-        errors = InvalidJSONModel.check(actually_check=True)
+        errors = InvalidJSONModel4.check(actually_check=True)
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.E016'
         assert "MySQL 5.7+ is required" in errors[0].msg

--- a/tests/testapp/test_listcharfield.py
+++ b/tests/testapp/test_listcharfield.py
@@ -419,34 +419,34 @@ class TestValidation(SimpleTestCase):
 class TestCheck(SimpleTestCase):
 
     def test_field_checks(self):
-        class InvalidListCharModel(TemporaryModel):
+        class InvalidListCharModel1(TemporaryModel):
             field = ListCharField(models.CharField(), max_length=32)
 
-        errors = InvalidListCharModel.check(actually_check=True)
+        errors = InvalidListCharModel1.check(actually_check=True)
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.E004'
         assert 'Base field for list has errors' in errors[0].msg
         assert 'max_length' in errors[0].msg
 
     def test_invalid_base_fields(self):
-        class InvalidListCharModel(TemporaryModel):
+        class InvalidListCharModel2(TemporaryModel):
             field = ListCharField(
                 models.ForeignKey('testapp.Author'),
                 max_length=32
             )
 
-        errors = InvalidListCharModel.check(actually_check=True)
+        errors = InvalidListCharModel2.check(actually_check=True)
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.E005'
         assert 'Base field for list must be' in errors[0].msg
 
     def test_max_length_including_base(self):
-        class InvalidListCharModel(TemporaryModel):
+        class InvalidListCharModel3(TemporaryModel):
             field = ListCharField(
                 models.CharField(max_length=32),
                 size=2, max_length=32)
 
-        errors = InvalidListCharModel.check(actually_check=True)
+        errors = InvalidListCharModel3.check(actually_check=True)
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.E006'
         assert 'Field can overrun' in errors[0].msg

--- a/tests/testapp/test_listtextfield.py
+++ b/tests/testapp/test_listtextfield.py
@@ -246,23 +246,23 @@ class TestValidation(SimpleTestCase):
 class TestCheck(SimpleTestCase):
 
     def test_field_checks(self):
-        class InvalidListTextModel(TemporaryModel):
+        class InvalidListTextModel1(TemporaryModel):
             field = ListTextField(models.CharField(), max_length=32)
 
-        errors = InvalidListTextModel.check(actually_check=True)
+        errors = InvalidListTextModel1.check(actually_check=True)
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.E004'
         assert 'Base field for list has errors' in errors[0].msg
         assert 'max_length' in errors[0].msg
 
     def test_invalid_base_fields(self):
-        class InvalidListTextModel(TemporaryModel):
+        class InvalidListTextModel2(TemporaryModel):
             field = ListTextField(
                 models.ForeignKey('testapp.Author'),
                 max_length=32
             )
 
-        errors = InvalidListTextModel.check(actually_check=True)
+        errors = InvalidListTextModel2.check(actually_check=True)
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.E005'
         assert 'Base field for list must be' in errors[0].msg

--- a/tests/testapp/test_setcharfield.py
+++ b/tests/testapp/test_setcharfield.py
@@ -376,34 +376,34 @@ class TestCheck(SimpleTestCase):
         assert field.base_field.model.__name__ == 'IntSetModel'
 
     def test_base_field_checks(self):
-        class InvalidSetCharFieldModel(TemporaryModel):
+        class InvalidSetCharFieldModel1(TemporaryModel):
             field = SetCharField(models.CharField(), max_length=32)
 
-        errors = InvalidSetCharFieldModel.check(actually_check=True)
+        errors = InvalidSetCharFieldModel1.check(actually_check=True)
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.E001'
         assert 'Base field for set has errors' in errors[0].msg
         assert 'max_length' in errors[0].msg
 
     def test_invalid_base_fields(self):
-        class InvalidSetCharFieldModel(TemporaryModel):
+        class InvalidSetCharFieldModel2(TemporaryModel):
             field = SetCharField(
                 models.ForeignKey('testapp.Author'),
                 max_length=32
             )
 
-        errors = InvalidSetCharFieldModel.check(actually_check=True)
+        errors = InvalidSetCharFieldModel2.check(actually_check=True)
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.E002'
         assert 'Base field for set must be' in errors[0].msg
 
     def test_max_length_including_base(self):
-        class InvalidSetCharFieldModel(TemporaryModel):
+        class InvalidSetCharFieldModel3(TemporaryModel):
             field = SetCharField(
                 models.CharField(max_length=32),
                 size=2, max_length=32)
 
-        errors = InvalidSetCharFieldModel.check(actually_check=True)
+        errors = InvalidSetCharFieldModel3.check(actually_check=True)
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.E003'
         assert 'Field can overrun' in errors[0].msg

--- a/tests/testapp/test_settextfield.py
+++ b/tests/testapp/test_settextfield.py
@@ -221,22 +221,22 @@ class TestCheck(SimpleTestCase):
         assert field.base_field.model.__name__ == 'BigIntSetModel'
 
     def test_base_field_checks(self):
-        class InvalidSetTextModel(TemporaryModel):
+        class InvalidSetTextModel1(TemporaryModel):
             field = SetTextField(models.CharField())
 
-        errors = InvalidSetTextModel.check(actually_check=True)
+        errors = InvalidSetTextModel1.check(actually_check=True)
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.E001'
         assert 'Base field for set has errors' in errors[0].msg
         assert 'max_length' in errors[0].msg
 
     def test_invalid_base_fields(self):
-        class InvalidSetTextModel(TemporaryModel):
+        class InvalidSetTextModel2(TemporaryModel):
             field = SetTextField(
                 models.ForeignKey('testapp.Author')
             )
 
-        errors = InvalidSetTextModel.check(actually_check=True)
+        errors = InvalidSetTextModel2.check(actually_check=True)
         assert len(errors) == 1
         assert errors[0].id == 'django_mysql.E002'
         assert 'Base field for set must be' in errors[0].msg


### PR DESCRIPTION
Rename all the temporary model classes created in test functions so they don't throw warnings about re-registering.
