### PR TITLE
Hide deprecation warnings from MySQL 5.7

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )
 
+import warnings
+
 import django
 from django.db import connection
 from pytest_django.plugin import _blocking_manager
@@ -19,3 +21,17 @@ def pytest_report_header(config):
         header += "\nMySQL version: {}".format(version)
 
     return header
+
+
+# MySQL 5.7 warns about some sql mode changes
+warnings.filterwarnings('ignore', r'.*Changing sql mode.*')
+warnings.filterwarnings(
+    'ignore',
+    r'.*sql modes should be used with strict mode.*',
+)
+# MySQL 5.7 turned 'explain' into 'explain extended' so it always warns the
+# optimized query
+warnings.filterwarnings('ignore', r'.*/\* select#\d+ \*/')
+# MySQL 5.7 deprecated some query hints
+warnings.filterwarnings('ignore', r".*'SQL_CACHE' is deprecated.*")
+warnings.filterwarnings('ignore', r".*'SQL_NO_CACHE' is deprecated.*")

--- a/tests/testapp/utils.py
+++ b/tests/testapp/utils.py
@@ -4,15 +4,12 @@ from __future__ import (
 )
 
 import sys
-import warnings
 from contextlib import contextmanager
 from unittest import skipUnless
 
 from django.db import DEFAULT_DB_ALIAS, connection, connections
 from django.test.utils import CaptureQueriesContext
 from django.utils import six
-
-from django_mysql.utils import connection_is_mariadb
 
 requiresPython2 = skipUnless(six.PY2, "Python 2 only")
 
@@ -99,19 +96,7 @@ def used_indexes(query, using=DEFAULT_DB_ALIAS):
     """
     connection = connections[using]
     with connection.cursor() as cursor:
-        with warnings.catch_warnings(record=True) as warn_list:
-            cursor.execute("EXPLAIN " + query)
-
-        # Jump through hoops to suppress the forced full query from MySQL 5.7+
-        if (
-            not connection_is_mariadb(connection) and
-            connection.mysql_version >= (5, 7)
-        ):
-            expected_warnings = 1
-        else:
-            expected_warnings = 0
-        assert len(warn_list) == expected_warnings
-        assert all('1003' in str(w) for w in warn_list)
+        cursor.execute("EXPLAIN " + query)
 
         return {row['key'] for row in fetchall_dicts(cursor)
                 if row['key'] is not None}


### PR DESCRIPTION
MySQL 5.7 emits warnings for some deprecated stuff, which pollute our test output. This stops them warning.