### PR TITLE
Improved JSONField and DynamicField DB version checks

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,8 @@ Pending
 .. Insert new release notes below this line
 
 * Add ``output_field`` argument to ``JSONExtract`` function.
+* Improved DB version checks for ``JSONField`` and ``DynamicField`` so you can
+  have just one connection that supports them.
 
 2.1.1 (2017-10-10)
 ------------------

--- a/django_mysql/models/fields/dynamic.py
+++ b/django_mysql/models/fields/dynamic.py
@@ -64,22 +64,23 @@ class DynamicField(Field):
     def _check_mariadb_version(self):
         errors = []
 
-        any_conn_works = True
+        any_conn_works = False
         conn_names = ['default'] + list(set(connections) - {'default'})
         for db in conn_names:
             conn = connections[db]
             if (
                 hasattr(conn, 'mysql_version') and
-                (not connection_is_mariadb(conn) or
-                 conn.mysql_version < (10, 0, 1))
+                connection_is_mariadb(conn) and
+                conn.mysql_version >= (10, 0, 1)
             ):
-                any_conn_works = False
+                any_conn_works = True
 
         if not any_conn_works:
             errors.append(
                 checks.Error(
-                    "MariaDB 10.0.1+ is required to use DynamicField",
-                    hint=None,
+                    'MariaDB 10.0.1+ is required to use DynamicField',
+                    hint='At least one of your DB connections should be to '
+                         'MariaDB 10.0.1+',
                     obj=self,
                     id='django_mysql.E013'
                 )

--- a/django_mysql/models/fields/json.py
+++ b/django_mysql/models/fields/json.py
@@ -58,21 +58,23 @@ class JSONField(Field):
     def _check_mysql_version(self):
         errors = []
 
-        any_conn_works = True
+        any_conn_works = False
         conn_names = ['default'] + list(set(connections) - {'default'})
         for db in conn_names:
             conn = connections[db]
             if (
                 hasattr(conn, 'mysql_version') and
-                (connection_is_mariadb(conn) or conn.mysql_version < (5, 7))
+                not connection_is_mariadb(conn) and
+                conn.mysql_version >= (5, 7)
             ):
-                any_conn_works = False
+                any_conn_works = True
 
         if not any_conn_works:
             errors.append(
                 checks.Error(
-                    "MySQL 5.7+ is required to use JSONField",
-                    hint=None,
+                    'MySQL 5.7+ is required to use JSONField',
+                    hint='At least one of your DB connections should be to '
+                         'MySQL 5.7+',
                     obj=self,
                     id='django_mysql.E016'
                 )


### PR DESCRIPTION
They now pass as long as one connection will be good, which was the original intention. Previously they checked *all connections* were good.

Fixes #411.

Checklist:

- [x] Docs updated
- [x] Line added to HISTORY.rst, or N/A
- [x] All commits squashed into one.

Test Plan: Added tests for this behaviour.