### PR TITLE
Fix coverage

### DIFF
--- a/django_mysql/models/fields/bit.py
+++ b/django_mysql/models/fields/bit.py
@@ -11,15 +11,6 @@ class Bit1Mixin(object):
     def db_type(self, connection):
         return 'bit(1)'
 
-    def to_python(self, value):
-        # Meant to be binary/bytes but can come back as unicode strings
-        if isinstance(value, six.binary_type):
-            value = (value == b'\x01')
-        elif isinstance(value, six.text_type):
-            # Only on older versions of mysqlclient and Py 2.7
-            value = (value == '\x01')  # pragma: no cover
-        return value
-
     def from_db_value(self, value, expression, connection, context):
         # Meant to be binary/bytes but can come back as unicode strings
         if isinstance(value, six.binary_type):

--- a/django_mysql/models/fields/dynamic.py
+++ b/django_mysql/models/fields/dynamic.py
@@ -324,7 +324,7 @@ class KeyTransform(Transform):
             params + [self.key_name]
         )
 
-    if django.VERSION[:3] <= (1, 8, 2):
+    if django.VERSION[:3] <= (1, 8, 2):  # pragma: no cover
         # Backport of bugfix for transforms with arguments, taken from:
         # https://code.djangoproject.com/ticket/24744
         def copy(self):

--- a/django_mysql/operations.py
+++ b/django_mysql/operations.py
@@ -85,21 +85,11 @@ class AlterStorageEngine(Operation):
         if engine is None:
             engine = self.engine
 
-        if hasattr(to_state, 'render'):
-            apps = to_state.render()  # Django 1.7
-        else:
-            apps = to_state.apps  # Django 1.8+
-
-        new_model = apps.get_model(app_label, self.name)
-
-        if hasattr(self, 'allowed_to_migrate'):
-            allowed = self.allowed_to_migrate  # Django 1.7
-        else:
-            allowed = self.allow_migrate_model  # Django 1.8+
+        new_model = to_state.apps.get_model(app_label, self.name)
 
         qn = schema_editor.connection.ops.quote_name
 
-        if allowed(schema_editor.connection.alias, new_model):
+        if self.allow_migrate_model(schema_editor.connection.alias, new_model):
             with schema_editor.connection.cursor() as cursor:
                 cursor.execute(
                     """SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES

--- a/tests/testapp/test_dynamicfield.py
+++ b/tests/testapp/test_dynamicfield.py
@@ -20,6 +20,11 @@ from django_mysql.utils import connection_is_mariadb
 from testapp.models import DynamicModel, TemporaryModel
 from testapp.utils import requiresPython2
 
+try:
+    import mariadb_dyncol
+except ImportError:  # pragma: no cover
+    mariadb_dyncol = None
+
 
 class DynColTestCase(TestCase):
 
@@ -436,6 +441,23 @@ class TestCheck(DynColTestCase):
             "date, datetime" in
             errors[0].hint
         )
+
+
+class TestToPython(TestCase):
+    def test_mariadb_dyncol_value(self):
+        value = mariadb_dyncol.pack({'foo': 'bar'})
+        result = DynamicField().to_python(value)
+        assert result == {'foo': 'bar'}
+
+    def test_json(self):
+        value = six.text_type(json.dumps({'foo': 'bar'}))
+        result = DynamicField().to_python(value)
+        assert result == {'foo': 'bar'}
+
+    def test_pass_through(self):
+        value = {'foo': 'bar'}
+        result = DynamicField().to_python(value)
+        assert result == {'foo': 'bar'}
 
 
 class SubDynamicField(DynamicField):

--- a/tests/testapp/test_listtextfield.py
+++ b/tests/testapp/test_listtextfield.py
@@ -372,6 +372,13 @@ class TestSerialization(SimpleTestCase):
         instance = objs[0].object
         assert instance.field == ["big", "leather", "comfy"]
 
+    def test_dumping_loading_empty(self):
+        instance = BigCharListModel(field=[])
+        data = serializers.serialize('json', [instance])
+        objs = list(serializers.deserialize('json', data))
+        instance = objs[0].object
+        assert instance.field == []
+
 
 class TestDescription(SimpleTestCase):
 

--- a/tests/testapp/test_settextfield.py
+++ b/tests/testapp/test_settextfield.py
@@ -331,6 +331,13 @@ class TestSerialization(SimpleTestCase):
         instance = objs[0].object
         assert instance.field == {"big", "leather", "comfy"}
 
+    def test_empty(self):
+        instance = BigCharSetModel(field=set())
+        data = serializers.serialize('json', [instance])
+        objs = list(serializers.deserialize('json', data))
+        instance = objs[0].object
+        assert instance.field == set()
+
 
 class TestDescription(SimpleTestCase):
 


### PR DESCRIPTION
* Bit field `to_python` no longer needed since Django 1.8
* 'nocover' the django <1.8.2 block
* Remove some migration logic for Django 1.7 that was missed when dropping its support
* Fully test `to_python` of `DynamicField`
* Test empty case of `to_python` for List and Set fields
