### PR TITLE
ensure_ascii=False param for json.dumps

### DIFF
--- a/django_mysql/forms.py
+++ b/django_mysql/forms.py
@@ -271,4 +271,4 @@ class JSONField(forms.CharField):
     def prepare_value(self, value):
         if isinstance(value, InvalidJSONInput):
             return value
-        return json.dumps(value)
+        return json.dumps(value, ensure_ascii=False)


### PR DESCRIPTION
JSON may contain non-ASCII characters, and, if we edit it in django admin, in form these characters will appear in non-readable form, for example:
["\u0442\u0435\u0441\u0442"]
Adding "ensure_ascii=False" param will fix this.

Checklist:

- [ ] Docs updated, or N/A
- [ ] Line added to HISTORY.rst, or N/A

Test Plan: tested only on my project
