### PR TITLE
Fix crashes for DynamicField instances without spec

### DIFF
--- a/django_mysql/models/fields/dynamic.py
+++ b/django_mysql/models/fields/dynamic.py
@@ -35,7 +35,7 @@ class DynamicField(Field):
             kwargs['default'] = dict
         if 'blank' not in kwargs:
             kwargs['blank'] = True
-        self.spec = kwargs.pop('spec', None)
+        self.spec = kwargs.pop('spec', {})
         super(DynamicField, self).__init__(*args, **kwargs)
 
     def check(self, **kwargs):


### PR DESCRIPTION
Changed None to empty dict for empty constructor parameter in dynamic field

Summary: 
"None" isn't a good choice for spec, on my opinions, because during migrations on several projects I have always get Attribute error in validators and other functions that work with "spec" as with dictionary and doesn't check if it dictionary or not.

Checklist:

- [ ] Docs updated, or N/A
- [ ] Line added to HISTORY.rst, or N/A
- [ ] Added extra items to checklist as applicable
- [ ] All commits squashed into one.

Test Plan: Manually 