### PR TITLE
Fix JSONField.deconstruct for subclasses

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Pending
 
 .. Insert new release notes below this line
 
+* Fixed ``JSONField.deconstruct()`` to not break the path for subclasses.
+
 2.2.0 (2017-12-04)
 ------------------
 

--- a/django_mysql/models/fields/dynamic.py
+++ b/django_mysql/models/fields/dynamic.py
@@ -247,11 +247,11 @@ class DynamicField(Field):
         name, path, args, kwargs = super(DynamicField, self).deconstruct()
 
         bad_paths = (
-            'django_mysql.models.fields.dynamic.' + self.__class__.__name__,
-            'django_mysql.models.fields.' + self.__class__.__name__
+            'django_mysql.models.fields.dynamic.DynamicField',
+            'django_mysql.models.fields.DynamicField',
         )
         if path in bad_paths:
-            path = 'django_mysql.models.' + self.__class__.__name__
+            path = 'django_mysql.models.DynamicField'
 
         # Remove defaults
         if 'default' in kwargs and kwargs['default'] is dict:

--- a/django_mysql/models/fields/enum.py
+++ b/django_mysql/models/fields/enum.py
@@ -45,12 +45,13 @@ class EnumField(CharField):
 
     def deconstruct(self):
         name, path, args, kwargs = super(EnumField, self).deconstruct()
+
         bad_paths = (
-            'django_mysql.models.fields.enum.' + self.__class__.__name__,
-            'django_mysql.models.fields.' + self.__class__.__name__
+            'django_mysql.models.fields.enum.EnumField',
+            'django_mysql.models.fields.EnumField',
         )
         if path in bad_paths:
-            path = 'django_mysql.models.' + self.__class__.__name__
+            path = 'django_mysql.models.EnumField'
 
         kwargs['choices'] = self.choices
         del kwargs['max_length']

--- a/django_mysql/models/fields/json.py
+++ b/django_mysql/models/fields/json.py
@@ -81,7 +81,14 @@ class JSONField(Field):
 
     def deconstruct(self):
         name, path, args, kwargs = super(JSONField, self).deconstruct()
-        path = 'django_mysql.models.%s' % self.__class__.__name__
+
+        bad_paths = (
+            'django_mysql.models.fields.json.JSONField',
+            'django_mysql.models.fields.JSONField',
+        )
+        if path in bad_paths:
+            path = 'django_mysql.models.JSONField'
+
         return name, path, args, kwargs
 
     def db_type(self, connection):

--- a/django_mysql/models/fields/sizes.py
+++ b/django_mysql/models/fields/sizes.py
@@ -29,11 +29,11 @@ class SizedBinaryField(BinaryField):
         name, path, args, kwargs = super(SizedBinaryField, self).deconstruct()
 
         bad_paths = (
-            'django_mysql.models.fields.sizes.' + self.__class__.__name__,
-            'django_mysql.models.fields.' + self.__class__.__name__
+            'django_mysql.models.fields.sizes.SizedBinaryField',
+            'django_mysql.models.fields.SizedBinaryField',
         )
         if path in bad_paths:
-            path = 'django_mysql.models.' + self.__class__.__name__
+            path = 'django_mysql.models.SizedBinaryField'
 
         kwargs['size_class'] = self.size_class
         return name, path, args, kwargs
@@ -71,11 +71,11 @@ class SizedTextField(TextField):
         name, path, args, kwargs = super(SizedTextField, self).deconstruct()
 
         bad_paths = (
-            'django_mysql.models.fields.sizes.' + self.__class__.__name__,
-            'django_mysql.models.fields.' + self.__class__.__name__
+            'django_mysql.models.fields.sizes.SizedTextField',
+            'django_mysql.models.fields.SizedTextField',
         )
         if path in bad_paths:
-            path = 'django_mysql.models.' + self.__class__.__name__
+            path = 'django_mysql.models.SizedTextField'
 
         kwargs['size_class'] = self.size_class
         return name, path, args, kwargs

--- a/tests/testapp/test_jsonfield.py
+++ b/tests/testapp/test_jsonfield.py
@@ -530,6 +530,27 @@ class TestFormField(JSONFieldTestCase):
         assert isinstance(form_field, forms.JSONField)
 
 
+class JSONFieldSubclass(JSONField):
+    pass
+
+
+class TestDeconstruct(JSONFieldTestCase):
+
+    def test_deconstruct(self):
+        field = JSONField()
+        name, path, args, kwargs = field.deconstruct()
+
+        new = JSONField(*args, **kwargs)
+
+        assert path == 'django_mysql.models.JSONField'
+        assert new.default == field.default
+
+    def test_deconstruct_subclass(self):
+        field = JSONFieldSubclass()
+        name, path, args, kwargs = field.deconstruct()
+        assert path == 'tests.testapp.test_jsonfield.JSONFieldSubclass'
+
+
 class TestSerialization(JSONFieldTestCase):
     test_data = '''[
         {


### PR DESCRIPTION
Fixes #436. Also hardcode the names in other field classes to be stricter and reduce the chance of error.