### PR TITLE
Remove '-v' from pytest args

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,4 +27,4 @@ paths = django_mysql
         tests
 
 [tool:pytest]
-addopts = -p no:doctest -v
+addopts = -p no:doctest


### PR DESCRIPTION
Accidentally left in #278.
