### PR TITLE
Use temporary database connection during system check

### DIFF
--- a/django_mysql/checks.py
+++ b/django_mysql/checks.py
@@ -17,7 +17,7 @@ def check_variables(app_configs, **kwargs):
     errors = []
 
     for alias, connection in mysql_connections():
-        with connection.cursor() as cursor:
+        with connection.temporary_connection() as cursor:
             cursor.execute("""SELECT @@sql_mode,
                                      @@innodb_strict_mode,
                                      @@character_set_connection""")


### PR DESCRIPTION
Fixes #485.

Summary: Use temporary database connection during system check. This prevents a dangling connection is leaked to application code. In some cases, the dangling connection may become unusable, thus database access in application code gets blocked.

Checklist:

- [x] Docs updated, or N/A
- [x] Line added to HISTORY.rst, or N/A
- [x] All commits squashed into one.

Test Plan: I have tested the changes in my project. Here is how I tested it: I put the following connection checking code in celery task definition body before running any database-related operation:

```python
@shared_task
def task():
    from django.db import connection
    print(connection.connection)
    # ...
```

By starting a fresh celery worker instance and dispatching a task: `task.delay()`, I
can see the following in celery worker log:

```
celery-periodic_1  | [2018-06-19 14:38:59,453: INFO/MainProcess] celery@106f1e5cd0eb ready.
celery-periodic_1  | [2018-06-19 14:39:08,722: INFO/MainProcess] Received task: test.tasks.task[fc05571c-05fd-409d-8b36-489da6e44914]  
celery-periodic_1  | [2018-06-19 14:39:08,726: WARNING/ForkPoolWorker-8] None
celery-periodic_1  | [2018-06-19 14:39:08,757: INFO/ForkPoolWorker-8] Task test.tasks.task[fc05571c-05fd-409d-8b36-489da6e44914] succeeded in 0.03256514499662444s: None
```

The third line of logging indicates no dangling connection was leaked from system check phase.