### PR TITLE
Make EnumField escape its arguments in a pymysql-friendly fashion.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Pending
 
 .. Insert new release notes below this line
 
+* Made ``EnumField`` escape its arguments in a ``pymysql``-friendly fashion.
+
 2.3.0 (2018-06-19)
 ------------------
 


### PR DESCRIPTION
Turns out pymysql 'fixes' the types returned by escape functions, so we need to work with both `bytes` and `str` here. Also `escape_string()` is accessible on the connection so a direct import from the kind-of private `_mysql` isn't needed.
