### PR TITLE
Add JSONArrayAppend database function.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,9 @@ Pending
 
 .. Insert new release notes below this line
 
+* Added ``JSONArrayAppend`` database function that wraps the respective
+  JSON-modifying function from MySQL 5.7.
+
 2.3.1 (2018-07-22)
 ------------------
 

--- a/django_mysql/models/functions.py
+++ b/django_mysql/models/functions.py
@@ -324,6 +324,10 @@ class JSONSet(BaseJSONModifyFunc):
     function = 'JSON_SET'
 
 
+class JSONArrayAppend(BaseJSONModifyFunc):
+    function = 'JSON_ARRAY_APPEND'
+
+
 # MariaDB Regexp Functions
 
 class RegexpInstr(Func):

--- a/docs/database_functions.rst
+++ b/docs/database_functions.rst
@@ -678,6 +678,7 @@ more information on their syntax, refer to the MySQL documentation.
         ...     attrs=JSONReplace('attrs', {'$.monthly_sales': 0})
         ... )
 
+
 .. class:: JSONSet(expression, data)
 
     Given ``expression`` that resolves to some JSON data, updates it using the
@@ -700,6 +701,33 @@ more information on their syntax, refer to the MySQL documentation.
         >>> shop_item = ShopItem.objects.latest()
         >>> shop_item.attrs = JSONSet('attrs', {'$.size': '10m'})
         >>> shop_item.save()
+
+
+.. class:: JSONArrayAppend(expression, data)
+
+    Given ``expression`` that resolves to some JSON data, adds to it using the
+    dictionary ``data`` of JSON paths to new values. If a path selects an
+    array, the new value will be appended to it. On the other hand, if a path
+    selects a scalar or object value, that value is autowrapped within an array
+    and the new value is added to that array. If any of the JSON paths within
+    the data dictionary does not match, or if ``expression`` is ``NULL``, it
+    returns ``NULL``.
+
+    Note that if ``expression`` is a string, it will refer to a field, whereas
+    keys and values within the ``data`` dictionary will be wrapped with
+    ``Value`` automatically and thus interpreted as the given string. If you
+    want a key or value to refer to a field, use Django's ``F()`` class.
+
+    Docs:
+    `MySQL <https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html#function_json-array-append>`_.
+
+    .. code-block:: pycon
+
+        >>> # Append the string '10m' to the array 'sizes' directly in MySQL
+        >>> shop_item = ShopItem.objects.latest()
+        >>> shop_item.attrs = JSONArrayAppend('attrs', {'$.sizes': '10m'})
+        >>> shop_item.save()
+
 
 Dynamic Columns Functions
 -------------------------

--- a/tests/testapp/test_functions.py
+++ b/tests/testapp/test_functions.py
@@ -15,10 +15,10 @@ from django.utils import six
 
 from django_mysql.models.functions import (
     CRC32, ELT, MD5, SHA1, SHA2, Abs, AsType, Ceiling, ColumnAdd, ColumnDelete,
-    ColumnGet, ConcatWS, Field, Floor, Greatest, If, JSONExtract, JSONInsert,
-    JSONKeys, JSONLength, JSONReplace, JSONSet, LastInsertId, Least,
-    RegexpInstr, RegexpReplace, RegexpSubstr, Round, Sign, UpdateXML,
-    XMLExtractValue,
+    ColumnGet, ConcatWS, Field, Floor, Greatest, If, JSONArrayAppend,
+    JSONExtract, JSONInsert, JSONKeys, JSONLength, JSONReplace, JSONSet,
+    LastInsertId, Least, RegexpInstr, RegexpReplace, RegexpSubstr, Round, Sign,
+    UpdateXML, XMLExtractValue,
 )
 from django_mysql.utils import connection_is_mariadb
 from testapp.models import Alphabet, Author, DynamicModel, JSONModel
@@ -568,6 +568,16 @@ class JSONFunctionTests(JSONFieldTestCase):
         with pytest.raises(ValueError) as excinfo:
             JSONSet('attrs', {})
         assert '"data" cannot be empty' in str(excinfo.value)
+
+    def test_json_array_append(self):
+        self.obj.attrs = JSONArrayAppend(
+            'attrs',
+            {'$.arr': 'max', '$.arr[0]': 1.1, '$.sub.document': 3},
+        )
+        self.obj.save()
+        self.obj.refresh_from_db()
+        assert self.obj.attrs['arr'] == [['dee', 1.1], 'arr', 'arr', 'max']
+        assert self.obj.attrs['sub']['document'] == ['store', 3]
 
 
 class RegexpFunctionTests(TestCase):


### PR DESCRIPTION
Summary:
`JSONArrayAppend` is a DB function that appends values to the end of the indicated arrays within a JSON document.
(https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html#function_json-array-append)

Checklist:

- [x] Line added to HISTORY.rst
- [x] Test added to `test_functions:JSONFunctionTests`
