### PR TITLE
Remove local_settings pattern from settings file

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -87,11 +87,6 @@ USE_I18N = True
 USE_L10N = True
 STATIC_URL = '/static/'
 
-try:
-    from local_settings import *  # noqa
-except ImportError:
-    pass
-
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',


### PR DESCRIPTION
I'm not using it, I don't think anyone is, and it's kinda bad as seen in https://www.pydanny.com/using-executable-code-outside-version-control.html
