### PR TITLE
Fix Pytest warning for pytest.raises change

### DIFF
--- a/tests/testapp/test_cache.py
+++ b/tests/testapp/test_cache.py
@@ -772,13 +772,15 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
         assert cache.get_or_set('mykey', my_callable) == 'value'
 
     def test_get_or_set_version(self):
-        msg = "get_or_set() missing 1 required positional argument: 'default'"
+        msg_re = (
+            r"get_or_set\(\) missing 1 required positional argument: 'default'"
+        )
         cache.get_or_set('brian', 1979, version=2)
 
-        with pytest.raises(TypeError, message=msg):
+        with pytest.raises(TypeError, match=msg_re):
             cache.get_or_set('brian')
 
-        with pytest.raises(TypeError, message=msg):
+        with pytest.raises(TypeError, match=msg_re):
             cache.get_or_set('brian', version=1)
 
         assert cache.get('brian', version=1) is None

--- a/tests/testapp/test_models.py
+++ b/tests/testapp/test_models.py
@@ -356,7 +356,8 @@ class FoundRowsTests(TestCase):
 
     def test_it_doesnt_work_with_iterator(self):
         authors = Author.objects.sql_calc_found_rows()[:5]
-        with pytest.raises(ValueError, message="doesn't work with iterator()"):
+        match_re = r"doesn't work with iterator\(\)"
+        with pytest.raises(ValueError, match=match_re):
             authors.iterator()
 
     def test_iterator_without_it_works(self):


### PR DESCRIPTION
Fix these warnings seen on a test run since upgrading Pytest:

```
tests/testapp/test_cache.py::MySQLCacheTests::test_get_or_set_version
  /Users/chainz/Documents/Projects/django-mysql/tests/testapp/test_cache.py:783: PytestDeprecationWarning: The 'message' parameter is deprecated.
  (did you mean to use `match='some regex'` to check the exception message?)
  Please comment on https://github.com/pytest-dev/pytest/issues/3974 if you have concerns about removal of this parameter.
    with pytest.raises(TypeError, message=msg):
  /Users/chainz/Documents/Projects/django-mysql/tests/testapp/test_cache.py:786: PytestDeprecationWarning: The 'message' parameter is deprecated.
  (did you mean to use `match='some regex'` to check the exception message?)
  Please comment on https://github.com/pytest-dev/pytest/issues/3974 if you have concerns about removal of this parameter.
    with pytest.raises(TypeError, message=msg):

tests/testapp/test_models.py::FoundRowsTests::test_it_doesnt_work_with_iterator
  /Users/chainz/Documents/Projects/django-mysql/tests/testapp/test_models.py:365: PytestDeprecationWarning: The 'message' parameter is deprecated.
  (did you mean to use `match='some regex'` to check the exception message?)
  Please comment on https://github.com/pytest-dev/pytest/issues/3974 if you have concerns about removal of this parameter.
    with pytest.raises(ValueError, message="doesn't work with iterator()"):
```

Fixing as per https://github.com/pytest-dev/pytest/issues/3974 .