### PR TITLE
Include latest stable Python into the test run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ notifications:
   webhooks: https://coveralls.io/webhook?repo_token=7l8yKtg4su0M31T0eGIaM0tnjvH0Rd5PM
 
 language: python
-python: '3.6'
+python: 
+  - '3.6'
+  - '3.7'
 cache: pip
 
 env:


### PR DESCRIPTION
It's a draft pull request. I open it to check if tests will run on Python 3.7 fine.