### PR TITLE
Fix mariadb-dyncol import in tests

### DIFF
--- a/tests/testapp/test_dynamicfield.py
+++ b/tests/testapp/test_dynamicfield.py
@@ -3,6 +3,7 @@ from datetime import date, datetime, time
 from unittest import SkipTest, mock
 
 import django
+import mariadb_dyncol
 import pytest
 from django.core import serializers
 from django.db import connection, connections
@@ -13,11 +14,6 @@ from django.test import TestCase
 from django_mysql.models import DynamicField
 from django_mysql.utils import connection_is_mariadb
 from tests.testapp.models import DynamicModel, SpeclessDynamicModel, TemporaryModel
-
-try:
-    import mariadb_dyncol
-except ImportError:  # pragma: no cover
-    mariadb_dyncol = None
 
 
 class DynColTestCase(TestCase):


### PR DESCRIPTION
It's always available in the test environment so no need to try/except around its import.