### PR TITLE
Format code with Black

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,8 @@ Django-MySQL
 .. image:: https://readthedocs.org/projects/django-mysql/badge/?version=latest
         :target: https://django-mysql.readthedocs.io/en/latest/
 
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :target: https://github.com/python/black
 
 .. figure:: https://raw.github.com/adamchainz/django-mysql/master/docs/images/dolphin-pony.png
    :alt: The dolphin-pony - proof that cute + cute = double cute.

--- a/django_mysql/__init__.py
+++ b/django_mysql/__init__.py
@@ -1,6 +1,6 @@
-__author__ = 'Adam Johnson'
-__email__ = 'me@adamj.eu'
-__version__ = '3.2.0'
+__author__ = "Adam Johnson"
+__email__ = "me@adamj.eu"
+__version__ = "3.2.0"
 
 
-default_app_config = 'django_mysql.apps.MySQLConfig'
+default_app_config = "django_mysql.apps.MySQLConfig"

--- a/django_mysql/apps.py
+++ b/django_mysql/apps.py
@@ -5,8 +5,8 @@ from .checks import register_checks
 
 
 class MySQLConfig(AppConfig):
-    name = 'django_mysql'
-    verbose_name = _('MySQL extensions')
+    name = "django_mysql"
+    verbose_name = _("MySQL extensions")
 
     def ready(self):
         self.perform_monkey_patches()
@@ -15,13 +15,12 @@ class MySQLConfig(AppConfig):
 
     def perform_monkey_patches(self):
         from django_mysql import monkey_patches
+
         monkey_patches.patch()
 
     def add_lookups(self):
         from django.db.models import CharField, TextField
-        from django_mysql.models.lookups import (
-            CaseSensitiveExact, Soundex, SoundsLike,
-        )
+        from django_mysql.models.lookups import CaseSensitiveExact, Soundex, SoundsLike
 
         CharField.register_lookup(CaseSensitiveExact)
         CharField.register_lookup(SoundsLike)

--- a/django_mysql/checks.py
+++ b/django_mysql/checks.py
@@ -1,8 +1,6 @@
 from django.core.checks import Tags, Warning, register
 from django.db import DEFAULT_DB_ALIAS, connections
 
-from django_mysql.utils import collapse_spaces
-
 
 def register_checks():
     register(Tags.compatibility)(check_variables)
@@ -13,79 +11,72 @@ def check_variables(app_configs, **kwargs):
 
     for alias, connection in mysql_connections():
         with connection.temporary_connection() as cursor:
-            cursor.execute("""SELECT @@sql_mode,
+            cursor.execute(
+                """SELECT @@sql_mode,
                                      @@innodb_strict_mode,
-                                     @@character_set_connection""")
+                                     @@character_set_connection"""
+            )
             variables = cursor.fetchone()
             sql_mode, innodb_strict_mode, character_set_connection = variables
 
-        modes = set(sql_mode.split(','))
-        if not (modes & {'STRICT_TRANS_TABLES', 'STRICT_ALL_TABLES'}):
+        modes = set(sql_mode.split(","))
+        if not (modes & {"STRICT_TRANS_TABLES", "STRICT_ALL_TABLES"}):
             errors.append(strict_mode_warning(alias))
 
         if not innodb_strict_mode:
             errors.append(innodb_strict_mode_warning(alias))
 
-        if character_set_connection != 'utf8mb4':
+        if character_set_connection != "utf8mb4":
             errors.append(utf8mb4_warning(alias))
 
     return errors
 
 
 def strict_mode_warning(alias):
-    message = "MySQL Strict Mode is not set for database connection '{}'"
-    hint = collapse_spaces("""
-        MySQL's Strict Mode fixes many data integrity problems in MySQL, such
-        as data truncation upon insertion, by escalating warnings into errors.
-        It is strongly recommended you activate it. See:
-        https://django-mysql.readthedocs.io/en/latest/checks.html#django-mysql-w001-strict-mode
-    """)
     return Warning(
-        message.format(alias),
-        hint=hint,
-        id='django_mysql.W001',
+        "MySQL Strict Mode is not set for database connection '{}'".format(alias),
+        hint=(
+            "MySQL's Strict Mode fixes many data integrity problems in MySQL, "
+            + "such as data truncation upon insertion, by escalating warnings "
+            + "into errors. It is strongly recommended you activate it. See: "
+            + "https://django-mysql.readthedocs.io/en/latest/checks.html#django-mysql-w001-strict-mode"  # noqa: B950
+        ),
+        id="django_mysql.W001",
     )
 
 
 def innodb_strict_mode_warning(alias):
-    message = "InnoDB Strict Mode is not set for database connection '{}'"
-    hint = collapse_spaces("""
-        InnoDB Strict Mode escalates several warnings around InnoDB-specific
-        statements into errors. It's recommended you activate this, but it's
-        not very likely to affect you if you don't. See:
-        https://django-mysql.readthedocs.io/en/latest/checks.html#django-mysql-w002-innodb-strict-mode
-    """)
-
     return Warning(
-        message.format(alias),
-        hint=hint,
-        id='django_mysql.W002',
+        "InnoDB Strict Mode is not set for database connection '{}'".format(alias),
+        hint=(
+            "InnoDB Strict Mode escalates several warnings around "
+            + "InnoDB-specific statements into errors. It's recommended you "
+            + "activate this, but it's not very likely to affect you if you "
+            + "don't. See: "
+            + "https://django-mysql.readthedocs.io/en/latest/checks.html#django-mysql-w002-innodb-strict-mode"  # noqa: B950
+        ),
+        id="django_mysql.W002",
     )
 
 
 def utf8mb4_warning(alias):
-    message = "The character set is not utf8mb4 for database connection '{}'"
-    hint = collapse_spaces("""
-        The default 'utf8' character set does not include support for all
-        Unicode characters. It's strongly recommended you move to use
-        'utf8mb4'. See:
-        https://django-mysql.readthedocs.io/en/latest/checks.html#django-mysql-w003-utf8mb4
-    """)
-
     return Warning(
-        message.format(alias),
-        hint=hint,
-        id='django_mysql.W003',
+        "The character set is not utf8mb4 for database connection '{}'".format(alias),
+        hint=(
+            "The default 'utf8' character set does not include support for "
+            + "all Unicode characters. It's strongly recommended you move to "
+            + "use 'utf8mb4'. See: "
+            + "https://django-mysql.readthedocs.io/en/latest/checks.html#django-mysql-w003-utf8mb4"  # noqa: B950
+        ),
+        id="django_mysql.W003",
     )
 
 
 def mysql_connections():
-    conn_names = [DEFAULT_DB_ALIAS] + list(
-        set(connections) - {DEFAULT_DB_ALIAS},
-    )
+    conn_names = [DEFAULT_DB_ALIAS] + list(set(connections) - {DEFAULT_DB_ALIAS})
     for alias in conn_names:
         connection = connections[alias]
-        if not hasattr(connection, 'mysql_version'):
+        if not hasattr(connection, "mysql_version"):
             continue  # pragma: no cover
 
         yield alias, connection

--- a/django_mysql/exceptions.py
+++ b/django_mysql/exceptions.py
@@ -2,4 +2,5 @@ class TimeoutError(Exception):
     """
     Indicates a database operation timed out in some way.
     """
+
     pass

--- a/django_mysql/forms.py
+++ b/django_mysql/forms.py
@@ -7,19 +7,21 @@ from django.utils.text import format_lazy
 from django.utils.translation import ugettext_lazy as _
 
 from django_mysql.validators import (
-    ListMaxLengthValidator, ListMinLengthValidator, SetMaxLengthValidator, SetMinLengthValidator,
+    ListMaxLengthValidator,
+    ListMinLengthValidator,
+    SetMaxLengthValidator,
+    SetMinLengthValidator,
 )
 
 
 class SimpleListField(forms.CharField):
 
     default_error_messages = {
-        'item_n_invalid': _('Item %(nth)s in the list did not validate: '),
-        'no_double_commas': _('No leading, trailing, or double commas.'),
+        "item_n_invalid": _("Item %(nth)s in the list did not validate: "),
+        "no_double_commas": _("No leading, trailing, or double commas."),
     }
 
-    def __init__(self, base_field, max_length=None, min_length=None,
-                 *args, **kwargs):
+    def __init__(self, base_field, max_length=None, min_length=None, *args, **kwargs):
         self.base_field = base_field
         super(SimpleListField, self).__init__(*args, **kwargs)
         if max_length is not None:
@@ -31,10 +33,7 @@ class SimpleListField(forms.CharField):
 
     def prepare_value(self, value):
         if isinstance(value, list):
-            return ",".join(
-                str(self.base_field.prepare_value(v))
-                for v in value
-            )
+            return ",".join(str(self.base_field.prepare_value(v)) for v in value)
         return value
 
     def to_python(self, value):
@@ -47,25 +46,28 @@ class SimpleListField(forms.CharField):
         values = []
         for i, item in enumerate(items, start=1):
             if not len(item):
-                errors.append(ValidationError(
-                    self.error_messages['no_double_commas'],
-                    code='no_double_commas',
-                ))
+                errors.append(
+                    ValidationError(
+                        self.error_messages["no_double_commas"], code="no_double_commas"
+                    )
+                )
                 continue
 
             try:
                 value = self.base_field.to_python(item)
             except ValidationError as e:
                 for error in e.error_list:
-                    errors.append(ValidationError(
-                        format_lazy(
-                            '{}{}',
-                            self.error_messages['item_n_invalid'],
-                            error.message,
-                        ),
-                        code='item_n_invalid',
-                        params={'nth': i},
-                    ))
+                    errors.append(
+                        ValidationError(
+                            format_lazy(
+                                "{}{}",
+                                self.error_messages["item_n_invalid"],
+                                error.message,
+                            ),
+                            code="item_n_invalid",
+                            params={"nth": i},
+                        )
+                    )
 
             values.append(value)
 
@@ -83,15 +85,17 @@ class SimpleListField(forms.CharField):
             except ValidationError as e:
                 for error in e.error_list:
                     for message in error.messages:
-                        errors.append(ValidationError(
-                            format_lazy(
-                                '{}{}',
-                                self.error_messages['item_n_invalid'],
-                                message,
-                            ),
-                            code='item_invalid',
-                            params={'nth': i},
-                        ))
+                        errors.append(
+                            ValidationError(
+                                format_lazy(
+                                    "{}{}",
+                                    self.error_messages["item_n_invalid"],
+                                    message,
+                                ),
+                                code="item_invalid",
+                                params={"nth": i},
+                            )
+                        )
         if errors:
             raise ValidationError(errors)
 
@@ -104,15 +108,17 @@ class SimpleListField(forms.CharField):
             except ValidationError as e:
                 for error in e.error_list:
                     for message in error.messages:
-                        errors.append(ValidationError(
-                            format_lazy(
-                                '{}{}',
-                                self.error_messages['item_n_invalid'],
-                                message,
-                            ),
-                            code='item_n_invalid',
-                            params={'nth': i},
-                        ))
+                        errors.append(
+                            ValidationError(
+                                format_lazy(
+                                    "{}{}",
+                                    self.error_messages["item_n_invalid"],
+                                    message,
+                                ),
+                                code="item_n_invalid",
+                                params={"nth": i},
+                            )
+                        )
         if errors:
             raise ValidationError(errors)
 
@@ -121,15 +127,15 @@ class SimpleSetField(forms.CharField):
     empty_values = list(validators.EMPTY_VALUES) + [set()]
 
     default_error_messages = {
-        'item_invalid': _('Item "%(item)s" in the set did not validate: '),
-        'item_n_invalid': _('Item %(nth)s in the set did not validate: '),
-        'no_double_commas': _('No leading, trailing, or double commas.'),
-        'no_duplicates': _("Duplicates are not supported. "
-                           "'%(item)s' appears twice or more."),
+        "item_invalid": _('Item "%(item)s" in the set did not validate: '),
+        "item_n_invalid": _("Item %(nth)s in the set did not validate: "),
+        "no_double_commas": _("No leading, trailing, or double commas."),
+        "no_duplicates": _(
+            "Duplicates are not supported. " "'%(item)s' appears twice or more."
+        ),
     }
 
-    def __init__(self, base_field, max_length=None, min_length=None,
-                 *args, **kwargs):
+    def __init__(self, base_field, max_length=None, min_length=None, *args, **kwargs):
         self.base_field = base_field
         super(SimpleSetField, self).__init__(*args, **kwargs)
         if max_length is not None:
@@ -141,10 +147,7 @@ class SimpleSetField(forms.CharField):
 
     def prepare_value(self, value):
         if isinstance(value, set):
-            return ",".join(
-                str(self.base_field.prepare_value(v))
-                for v in value
-            )
+            return ",".join(str(self.base_field.prepare_value(v)) for v in value)
         return value
 
     def to_python(self, value):
@@ -157,32 +160,37 @@ class SimpleSetField(forms.CharField):
         values = set()
         for i, item in enumerate(items, start=1):
             if not len(item):
-                errors.append(ValidationError(
-                    self.error_messages['no_double_commas'],
-                    code='no_double_commas',
-                ))
+                errors.append(
+                    ValidationError(
+                        self.error_messages["no_double_commas"], code="no_double_commas"
+                    )
+                )
                 continue
 
             try:
                 value = self.base_field.to_python(item)
             except ValidationError as e:
                 for error in e.error_list:
-                    errors.append(ValidationError(
-                        format_lazy(
-                            '{}{}',
-                            self.error_messages['item_n_invalid'],
-                            error.message,
-                        ),
-                        code='item_n_invalid',
-                        params={'nth': i},
-                    ))
+                    errors.append(
+                        ValidationError(
+                            format_lazy(
+                                "{}{}",
+                                self.error_messages["item_n_invalid"],
+                                error.message,
+                            ),
+                            code="item_n_invalid",
+                            params={"nth": i},
+                        )
+                    )
 
             if value in values:
-                errors.append(ValidationError(
-                    self.error_messages['no_duplicates'],
-                    code='no_duplicates',
-                    params={'item': item},
-                ))
+                errors.append(
+                    ValidationError(
+                        self.error_messages["no_duplicates"],
+                        code="no_duplicates",
+                        params={"item": item},
+                    )
+                )
             else:
                 values.add(value)
 
@@ -200,15 +208,15 @@ class SimpleSetField(forms.CharField):
             except ValidationError as e:
                 for error in e.error_list:
                     for message in error.messages:
-                        errors.append(ValidationError(
-                            format_lazy(
-                                '{}{}',
-                                self.error_messages['item_invalid'],
-                                message,
-                            ),
-                            code='item_invalid',
-                            params={'item': item},
-                        ))
+                        errors.append(
+                            ValidationError(
+                                format_lazy(
+                                    "{}{}", self.error_messages["item_invalid"], message
+                                ),
+                                code="item_invalid",
+                                params={"item": item},
+                            )
+                        )
         if errors:
             raise ValidationError(errors)
 
@@ -221,15 +229,15 @@ class SimpleSetField(forms.CharField):
             except ValidationError as e:
                 for error in e.error_list:
                     for message in error.messages:
-                        errors.append(ValidationError(
-                            format_lazy(
-                                '{}{}',
-                                self.error_messages['item_invalid'],
-                                message,
-                            ),
-                            code='item_invalid',
-                            params={'item': item},
-                        ))
+                        errors.append(
+                            ValidationError(
+                                format_lazy(
+                                    "{}{}", self.error_messages["item_invalid"], message
+                                ),
+                                code="item_invalid",
+                                params={"item": item},
+                            )
+                        )
         if errors:
             raise ValidationError(errors)
 
@@ -243,9 +251,7 @@ class JSONString(str):
 
 
 class JSONField(forms.CharField):
-    default_error_messages = {
-        'invalid': _("'%(value)s' value must be valid JSON."),
-    }
+    default_error_messages = {"invalid": _("'%(value)s' value must be valid JSON.")}
     widget = forms.Textarea
 
     def to_python(self, value):
@@ -259,9 +265,7 @@ class JSONField(forms.CharField):
             converted = json.loads(value)
         except ValueError:
             raise forms.ValidationError(
-                self.error_messages['invalid'],
-                code='invalid',
-                params={'value': value},
+                self.error_messages["invalid"], code="invalid", params={"value": value}
             )
         if isinstance(converted, str):
             return JSONString(converted)

--- a/django_mysql/management/commands/cull_mysql_caches.py
+++ b/django_mysql/management/commands/cull_mysql_caches.py
@@ -9,21 +9,25 @@ from django_mysql.utils import collapse_spaces
 class Command(BaseCommand):
     args = "<optional cache aliases>"
 
-    help = collapse_spaces("""
+    help = collapse_spaces(
+        """
         Runs cache.cull() on all your MySQLCache caches, or only those
         specified aliases.
-    """)
+    """
+    )
 
     def add_arguments(self, parser):
         parser.add_argument(
-            'aliases', metavar='aliases', nargs='*',
-            help='Specify the cache alias(es) to cull.',
+            "aliases",
+            metavar="aliases",
+            nargs="*",
+            help="Specify the cache alias(es) to cull.",
         )
 
     def handle(self, *args, **options):
-        verbosity = options.get('verbosity')
+        verbosity = options.get("verbosity")
 
-        aliases = set(options['aliases'])
+        aliases = set(options["aliases"])
 
         if not aliases:
             aliases = settings.CACHES
@@ -39,8 +43,7 @@ class Command(BaseCommand):
 
             if verbosity >= 1:
                 self.stdout.write(
-                    "Deleting from cache '{}'... ".format(alias),
-                    ending='',
+                    "Deleting from cache '{}'... ".format(alias), ending=""
                 )
             num_deleted = cache.cull()
             if verbosity >= 1:

--- a/django_mysql/management/commands/dbparams.py
+++ b/django_mysql/management/commands/dbparams.py
@@ -8,41 +8,44 @@ from django_mysql.utils import settings_to_cmd_args
 class Command(BaseCommand):
     args = "<optional connection alias>"
 
-    help = ("Outputs shell parameters representing database connection "
-            "suitable for inclusion in various tools' commandlines. The "
-            "connection alias should be a name from DATABASES - defaults to "
-            "'{default}'.").format(default=DEFAULT_DB_ALIAS)
+    help = (
+        "Outputs shell parameters representing database connection "
+        "suitable for inclusion in various tools' commandlines. The "
+        "connection alias should be a name from DATABASES - defaults to "
+        "'{default}'."
+    ).format(default=DEFAULT_DB_ALIAS)
 
     requires_system_checks = False
 
     def add_arguments(self, parser):
         parser.add_argument(
-            'alias', metavar='alias', nargs='?',
+            "alias",
+            metavar="alias",
+            nargs="?",
             default=DEFAULT_DB_ALIAS,
-            help='Specify the database connection alias to output '
-                 'parameters for.',
+            help="Specify the database connection alias to output " "parameters for.",
         )
 
         parser.add_argument(
-            '--mysql',
-            action='store_true',
-            dest='mysql',
+            "--mysql",
+            action="store_true",
+            dest="mysql",
             default=False,
-            help='Outputs flags for tools that take parameters in the '
-                 'same format as the mysql client, e.g. mysql '
-                 '$(./manage.py dbparams --mysql)',
+            help="Outputs flags for tools that take parameters in the "
+            "same format as the mysql client, e.g. mysql "
+            "$(./manage.py dbparams --mysql)",
         )
         parser.add_argument(
-            '--dsn',
-            action='store_true',
-            dest='dsn',
+            "--dsn",
+            action="store_true",
+            dest="dsn",
             default=False,
-            help='Output a DSN for e.g. percona tools, e.g. '
-                 'pt-online-schema-change $(./manage.py dbparams --dsn)',
+            help="Output a DSN for e.g. percona tools, e.g. "
+            "pt-online-schema-change $(./manage.py dbparams --dsn)",
         )
 
     def handle(self, *args, **options):
-        alias = options['alias']
+        alias = options["alias"]
 
         try:
             settings_dict = connections[alias].settings_dict
@@ -50,12 +53,11 @@ class Command(BaseCommand):
             raise CommandError("Connection '{}' does not exist".format(alias))
 
         connection = connections[alias]
-        if connection.vendor != 'mysql':
-            raise CommandError("{} is not a MySQL database connection"
-                               .format(alias))
+        if connection.vendor != "mysql":
+            raise CommandError("{} is not a MySQL database connection".format(alias))
 
-        show_mysql = options['mysql']
-        show_dsn = options['dsn']
+        show_mysql = options["mysql"]
+        show_dsn = options["dsn"]
         if show_mysql and show_dsn:
             raise CommandError("Pass only one of --mysql and --dsn")
         elif not show_mysql and not show_dsn:
@@ -72,39 +74,38 @@ class Command(BaseCommand):
         self.stdout.write(" ".join(args), ending="")
 
     def output_for_dsn(self, settings_dict):
-        cert = settings_dict['OPTIONS'].get('ssl', {}).get('ca')
+        cert = settings_dict["OPTIONS"].get("ssl", {}).get("ca")
         if cert:
             self.stderr.write(
                 "Warning: SSL params can't be passed in the DSN syntax; you "
                 "must pass them in your my.cnf. See: "
                 "https://www.percona.com/blog/2014/10/16/percona-toolkit-for-"
-                "mysql-with-mysql-ssl-connections/",
+                "mysql-with-mysql-ssl-connections/"
             )
 
-        db = settings_dict['OPTIONS'].get('db', settings_dict['NAME'])
-        user = settings_dict['OPTIONS'].get('user', settings_dict['USER'])
-        passwd = settings_dict['OPTIONS'].get('passwd',
-                                              settings_dict['PASSWORD'])
-        host = settings_dict['OPTIONS'].get('host', settings_dict['HOST'])
-        port = settings_dict['OPTIONS'].get('port', settings_dict['PORT'])
-        defaults_file = settings_dict['OPTIONS'].get('read_default_file')
+        db = settings_dict["OPTIONS"].get("db", settings_dict["NAME"])
+        user = settings_dict["OPTIONS"].get("user", settings_dict["USER"])
+        passwd = settings_dict["OPTIONS"].get("passwd", settings_dict["PASSWORD"])
+        host = settings_dict["OPTIONS"].get("host", settings_dict["HOST"])
+        port = settings_dict["OPTIONS"].get("port", settings_dict["PORT"])
+        defaults_file = settings_dict["OPTIONS"].get("read_default_file")
 
         args = []
         if defaults_file:
-            args.append('F={}'.format(defaults_file))
+            args.append("F={}".format(defaults_file))
         if user:
-            args.append('u={}'.format(user))
+            args.append("u={}".format(user))
         if passwd:
-            args.append('p={}'.format(passwd))
+            args.append("p={}".format(passwd))
         if host:
-            if '/' in host:
-                args.append('S={}'.format(host))
+            if "/" in host:
+                args.append("S={}".format(host))
             else:
-                args.append('h={}'.format(host))
+                args.append("h={}".format(host))
         if port:
-            args.append('P={}'.format(port))
+            args.append("P={}".format(port))
         if db:
-            args.append('D={}'.format(db))
+            args.append("D={}".format(db))
 
         dsn = ",".join(args)
         self.stdout.write(dsn, ending="")

--- a/django_mysql/management/commands/fix_datetime_columns.py
+++ b/django_mysql/management/commands/fix_datetime_columns.py
@@ -9,30 +9,32 @@ from django_mysql.utils import collapse_spaces
 class Command(BaseCommand):
     args = "<optional connection alias>"
 
-    help = collapse_spaces("""
+    help = collapse_spaces(
+        """
         Detects DateTimeFields with column type 'datetime' instead of
         'datetime(6)' and outputs the SQL to fix them.
-    """)
+    """
+    )
 
     def add_arguments(self, parser):
         parser.add_argument(
-            'alias', metavar='alias', nargs='?',
+            "alias",
+            metavar="alias",
+            nargs="?",
             default=DEFAULT_DB_ALIAS,
-            help='Specify the database connection alias to output '
-                 'parameters for.',
+            help="Specify the database connection alias to output " "parameters for.",
         )
 
     def handle(self, *args, **options):
-        alias = options['alias']
+        alias = options["alias"]
 
         try:
             connection = connections[alias]
         except ConnectionDoesNotExist:
             raise CommandError("Connection '{}' does not exist".format(alias))
 
-        if connection.vendor != 'mysql':
-            raise CommandError("{} is not a MySQL database connection"
-                               .format(alias))
+        if connection.vendor != "mysql":
+            raise CommandError("{} is not a MySQL database connection".format(alias))
 
         sqls = []
         with connection.cursor() as cursor:
@@ -79,14 +81,13 @@ class Command(BaseCommand):
         for column_name in bad_column_names:
             column_spec = column_specs[column_name]
 
-            new_column_spec = column_spec.replace('datetime', 'datetime(6)', 1)
+            new_column_spec = column_spec.replace("datetime", "datetime(6)", 1)
             modify_columns.append(
-                'MODIFY COLUMN {} {}'.format(qn(column_name), new_column_spec),
+                "MODIFY COLUMN {} {}".format(qn(column_name), new_column_spec)
             )
 
-        return 'ALTER TABLE {table_name}\n    {columns};'.format(
-            table_name=qn(table_name),
-            columns=',\n    '.join(modify_columns),
+        return "ALTER TABLE {table_name}\n    {columns};".format(
+            table_name=qn(table_name), columns=",\n    ".join(modify_columns)
         )
 
 
@@ -98,14 +99,14 @@ def parse_create_table(sql):
     for line in sql.splitlines()[1:]:  # first line = CREATE TABLE
         sline = line.strip()
 
-        if not sline.startswith('`'):
+        if not sline.startswith("`"):
             # We've finished parsing the columns
             break
 
-        bits = sline.split('`')
+        bits = sline.split("`")
         assert len(bits) == 3
         column_name = bits[1]
-        column_spec = bits[2].lstrip().rstrip(',')
+        column_spec = bits[2].lstrip().rstrip(",")
 
         column_types[column_name] = column_spec
     return column_types

--- a/django_mysql/management/commands/mysql_cache_migration.py
+++ b/django_mysql/management/commands/mysql_cache_migration.py
@@ -9,18 +9,22 @@ from django_mysql.utils import collapse_spaces
 class Command(BaseCommand):
     args = "<app_name>"
 
-    help = collapse_spaces("""
+    help = collapse_spaces(
+        """
         Outputs a migration that will create a table.
-    """)
+    """
+    )
 
     def add_arguments(self, parser):
         parser.add_argument(
-            'aliases', metavar='aliases', nargs='*',
-            help='Specify the cache alias(es) to create migrations for.',
+            "aliases",
+            metavar="aliases",
+            nargs="*",
+            help="Specify the cache alias(es) to create migrations for.",
         )
 
     def handle(self, *args, **options):
-        aliases = set(options['aliases'])
+        aliases = set(options["aliases"])
 
         if not aliases:
             aliases = settings.CACHES
@@ -50,14 +54,12 @@ class Command(BaseCommand):
         # defined in TEMPLATES
         out = [header]
         for table in tables:
-            out.append(
-                table_operation.replace('{{ table }}', table),
-            )
+            out.append(table_operation.replace("{{ table }}", table))
         out.append(footer)
-        return ''.join(out)
+        return "".join(out)
 
 
-header = '''
+header = """
 from django.db import migrations
 
 
@@ -70,24 +72,27 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-'''.strip()
+""".strip()
 
-create_table_sql = '\n'.join(
-    '    ' * 3 + line
-    for line in MySQLCache.create_table_sql.splitlines()
-).format(table_name='{{ table }}')
+create_table_sql = "\n".join(
+    "    " * 3 + line for line in MySQLCache.create_table_sql.splitlines()
+).format(table_name="{{ table }}")
 
 
-table_operation = '''
+table_operation = (
+    '''
         migrations.RunSQL(
             """
-''' + create_table_sql + '''
+'''
+    + create_table_sql
+    + '''
             """,
             "DROP TABLE `{{ table }}`",
         ),
 '''.rstrip()
+)
 
 
-footer = '''
+footer = """
     ]
-'''
+"""

--- a/django_mysql/models/__init__.py
+++ b/django_mysql/models/__init__.py
@@ -2,16 +2,27 @@
 isort:skip_file
 """
 from django_mysql.models.base import Model  # noqa
-from django_mysql.models.aggregates import (  # noqa
-    BitAnd, BitOr, BitXor, GroupConcat,
-)
+from django_mysql.models.aggregates import BitAnd, BitOr, BitXor, GroupConcat  # noqa
 from django_mysql.models.expressions import ListF, SetF  # noqa
 from django_mysql.models.query import (  # noqa
-    add_QuerySetMixin, ApproximateInt, SmartChunkedIterator, SmartIterator,
-    pt_visual_explain, QuerySet, QuerySetMixin,
+    add_QuerySetMixin,
+    ApproximateInt,
+    SmartChunkedIterator,
+    SmartIterator,
+    pt_visual_explain,
+    QuerySet,
+    QuerySetMixin,
 )
 from django_mysql.models.fields import (  # noqa
-    Bit1BooleanField, DynamicField, EnumField, JSONField, ListCharField,
-    ListTextField, NullBit1BooleanField, SetCharField, SetTextField,
-    SizedBinaryField, SizedTextField,
+    Bit1BooleanField,
+    DynamicField,
+    EnumField,
+    JSONField,
+    ListCharField,
+    ListTextField,
+    NullBit1BooleanField,
+    SetCharField,
+    SetTextField,
+    SizedBinaryField,
+    SizedTextField,
 )

--- a/django_mysql/models/aggregates.py
+++ b/django_mysql/models/aggregates.py
@@ -2,38 +2,38 @@ from django.db.models import Aggregate, CharField
 
 
 class BitAnd(Aggregate):
-    function = 'BIT_AND'
-    name = 'bitand'
+    function = "BIT_AND"
+    name = "bitand"
 
 
 class BitOr(Aggregate):
-    function = 'BIT_OR'
-    name = 'bitor'
+    function = "BIT_OR"
+    name = "bitor"
 
 
 class BitXor(Aggregate):
-    function = 'BIT_XOR'
-    name = 'bitxor'
+    function = "BIT_XOR"
+    name = "bitxor"
 
 
 class GroupConcat(Aggregate):
-    function = 'GROUP_CONCAT'
+    function = "GROUP_CONCAT"
 
-    def __init__(self, expression, distinct=False, separator=None,
-                 ordering=None, **extra):
+    def __init__(
+        self, expression, distinct=False, separator=None, ordering=None, **extra
+    ):
 
-        if 'output_field' not in extra:
+        if "output_field" not in extra:
             # This can/will be improved to SetTextField or ListTextField
-            extra['output_field'] = CharField()
+            extra["output_field"] = CharField()
 
         super(GroupConcat, self).__init__(expression, **extra)
 
         self.distinct = distinct
         self.separator = separator
 
-        if ordering not in ('asc', 'desc', None):
-            raise ValueError(
-                "'ordering' must be one of 'asc', 'desc', or None")
+        if ordering not in ("asc", "desc", None):
+            raise ValueError("'ordering' must be one of 'asc', 'desc', or None")
         self.ordering = ordering
 
     def as_sql(self, compiler, connection, function=None, template=None):

--- a/django_mysql/models/expressions.py
+++ b/django_mysql/models/expressions.py
@@ -5,7 +5,6 @@ from django_mysql.utils import collapse_spaces
 
 
 class TwoSidedExpression(BaseExpression):
-
     def __init__(self, lhs, rhs):
         super(TwoSidedExpression, self).__init__()
         self.lhs = lhs
@@ -24,12 +23,12 @@ class ListF(object):
         self.field = F(field_name)
 
     def append(self, value):
-        if not hasattr(value, 'as_sql'):
+        if not hasattr(value, "as_sql"):
             value = Value(value)
         return AppendListF(self.field, value)
 
     def appendleft(self, value):
-        if not hasattr(value, 'as_sql'):
+        if not hasattr(value, "as_sql"):
             value = Value(value)
         return AppendLeftListF(self.field, value)
 
@@ -47,7 +46,8 @@ class AppendListF(TwoSidedExpression):
     # comma and 'value'
     # N.B. using MySQL side variables to avoid repeat calculation of
     # expression[s]
-    sql_expression = collapse_spaces("""
+    sql_expression = collapse_spaces(
+        """
         CONCAT_WS(
             ',',
             IF(
@@ -57,7 +57,8 @@ class AppendListF(TwoSidedExpression):
             ),
             %s
         )
-    """)
+    """
+    )
 
     def as_sql(self, compiler, connection):
         field, field_params = compiler.compile(self.lhs)
@@ -76,7 +77,8 @@ class AppendLeftListF(TwoSidedExpression):
     # comma and 'value'
     # N.B. using MySQL side variables to avoid repeat calculation of
     # expression[s]
-    sql_expression = collapse_spaces("""
+    sql_expression = collapse_spaces(
+        """
         CONCAT_WS(
             ',',
             %s,
@@ -86,7 +88,8 @@ class AppendLeftListF(TwoSidedExpression):
                 NULL
             )
         )
-    """)
+    """
+    )
 
     def as_sql(self, compiler, connection):
         field, field_params = compiler.compile(self.lhs)
@@ -100,7 +103,8 @@ class AppendLeftListF(TwoSidedExpression):
 
 class PopListF(BaseExpression):
 
-    sql_expression = collapse_spaces("""
+    sql_expression = collapse_spaces(
+        """
         SUBSTRING(
             @tmp_f:=%s,
             1,
@@ -114,7 +118,8 @@ class PopListF(BaseExpression):
                 0
             )
         )
-    """)
+    """
+    )
 
     def __init__(self, lhs):
         super(PopListF, self).__init__()
@@ -135,13 +140,15 @@ class PopListF(BaseExpression):
 
 class PopLeftListF(BaseExpression):
 
-    sql_expression = collapse_spaces("""
+    sql_expression = collapse_spaces(
+        """
         IF(
             (@tmp_c:=LOCATE(',', @tmp_f:=%s)) > 0,
             SUBSTRING(@tmp_f, @tmp_c + 1),
             ''
         )
-    """)
+    """
+    )
 
     def __init__(self, lhs):
         super(PopLeftListF, self).__init__()
@@ -161,17 +168,16 @@ class PopLeftListF(BaseExpression):
 
 
 class SetF(object):
-
     def __init__(self, field_name):
         self.field = F(field_name)
 
     def add(self, value):
-        if not hasattr(value, 'as_sql'):
+        if not hasattr(value, "as_sql"):
             value = Value(value)
         return AddSetF(self.field, value)
 
     def remove(self, value):
-        if not hasattr(value, 'as_sql'):
+        if not hasattr(value, "as_sql"):
             value = Value(value)
         return RemoveSetF(self.field, value)
 
@@ -183,7 +189,8 @@ class AddSetF(TwoSidedExpression):
     # comma and 'value'
     # N.B. using MySQL side variables to avoid repeat calculation of
     # expression[s]
-    sql_expression = collapse_spaces("""
+    sql_expression = collapse_spaces(
+        """
         IF(
             FIND_IN_SET(@tmp_val:=%s, @tmp_f:=%s),
             @tmp_f,
@@ -193,7 +200,8 @@ class AddSetF(TwoSidedExpression):
                 @tmp_val
             )
         )
-    """)
+    """
+    )
 
     def as_sql(self, compiler, connection):
         field, field_params = compiler.compile(self.lhs)
@@ -212,7 +220,8 @@ class RemoveSetF(TwoSidedExpression):
     # that element.
     # There are some tricks going on - e.g. LEAST to evaluate a sub expression
     # but not use it in the output of CONCAT_WS
-    sql_expression = collapse_spaces("""
+    sql_expression = collapse_spaces(
+        """
         IF(
             @tmp_pos:=FIND_IN_SET(%s, @tmp_f:=%s),
             CONCAT_WS(
@@ -241,7 +250,8 @@ class RemoveSetF(TwoSidedExpression):
             ),
             @tmp_f
         )
-    """)
+    """
+    )
 
     def as_sql(self, compiler, connection):
         field, field_params = compiler.compile(self.lhs)

--- a/django_mysql/models/fields/__init__.py
+++ b/django_mysql/models/fields/__init__.py
@@ -1,7 +1,21 @@
-from django_mysql.models.fields.bit import Bit1BooleanField, NullBit1BooleanField  # noqa
-from django_mysql.models.fields.dynamic import DynamicField  # noqa
-from django_mysql.models.fields.enum import EnumField  # noqa
-from django_mysql.models.fields.json import JSONField  # noqa
-from django_mysql.models.fields.lists import ListCharField, ListTextField  # noqa
-from django_mysql.models.fields.sets import SetCharField, SetTextField  # noqa
-from django_mysql.models.fields.sizes import SizedBinaryField, SizedTextField  # noqa
+from django_mysql.models.fields.bit import Bit1BooleanField, NullBit1BooleanField
+from django_mysql.models.fields.dynamic import DynamicField
+from django_mysql.models.fields.enum import EnumField
+from django_mysql.models.fields.json import JSONField
+from django_mysql.models.fields.lists import ListCharField, ListTextField
+from django_mysql.models.fields.sets import SetCharField, SetTextField
+from django_mysql.models.fields.sizes import SizedBinaryField, SizedTextField
+
+__all__ = [
+    "Bit1BooleanField",
+    "DynamicField",
+    "EnumField",
+    "JSONField",
+    "ListCharField",
+    "ListTextField",
+    "NullBit1BooleanField",
+    "SetCharField",
+    "SetTextField",
+    "SizedBinaryField",
+    "SizedTextField",
+]

--- a/django_mysql/models/fields/bit.py
+++ b/django_mysql/models/fields/bit.py
@@ -4,25 +4,28 @@ from django.db.models import BooleanField, NullBooleanField
 
 class Bit1Mixin(object):
     def db_type(self, connection):
-        return 'bit(1)'
+        return "bit(1)"
 
     if django.VERSION >= (2, 0):
+
         def from_db_value(self, value, expression, connection):
             # Meant to be binary/bytes but can come back as unicode strings
             if isinstance(value, bytes):
-                value = (value == b'\x01')
+                value = value == b"\x01"
             elif isinstance(value, str):
                 # Only on older versions of mysqlclient and Py 2.7
-                value = (value == '\x01')  # pragma: no cover
+                value = value == "\x01"  # pragma: no cover
             return value
+
     else:
+
         def from_db_value(self, value, expression, connection, context):
             # Meant to be binary/bytes but can come back as unicode strings
             if isinstance(value, bytes):
-                value = (value == b'\x01')
+                value = value == b"\x01"
             elif isinstance(value, str):
                 # Only on older versions of mysqlclient and Py 2.7
-                value = (value == '\x01')  # pragma: no cover
+                value = value == "\x01"  # pragma: no cover
             return value
 
     def get_prep_value(self, value):

--- a/django_mysql/models/fields/enum.py
+++ b/django_mysql/models/fields/enum.py
@@ -7,13 +7,11 @@ class EnumField(CharField):
     description = _("Enumeration")
 
     def __init__(self, *args, **kwargs):
-        if 'choices' not in kwargs or len(kwargs['choices']) == 0:
-            raise ValueError(
-                '"choices" argument must be be a non-empty list',
-            )
+        if "choices" not in kwargs or len(kwargs["choices"]) == 0:
+            raise ValueError('"choices" argument must be be a non-empty list')
 
         choices = []
-        for choice in kwargs['choices']:
+        for choice in kwargs["choices"]:
             if isinstance(choice, tuple):
                 choices.append(choice)
             elif isinstance(choice, str):
@@ -21,18 +19,18 @@ class EnumField(CharField):
             else:
                 raise TypeError(
                     'Invalid choice "{choice}". '
-                    'Expected string or tuple as elements in choices'.format(
-                        choice=choice,
-                    ),
+                    "Expected string or tuple as elements in choices".format(
+                        choice=choice
+                    )
                 )
 
-        kwargs['choices'] = choices
+        kwargs["choices"] = choices
 
-        if 'max_length' in kwargs:
+        if "max_length" in kwargs:
             raise TypeError('"max_length" is not a valid argument')
         # Massive to avoid problems with validation - let MySQL handle the
         # maximum string length
-        kwargs['max_length'] = int(2 ** 32)
+        kwargs["max_length"] = int(2 ** 32)
 
         super(EnumField, self).__init__(*args, **kwargs)
 
@@ -40,26 +38,20 @@ class EnumField(CharField):
         name, path, args, kwargs = super(EnumField, self).deconstruct()
 
         bad_paths = (
-            'django_mysql.models.fields.enum.EnumField',
-            'django_mysql.models.fields.EnumField',
+            "django_mysql.models.fields.enum.EnumField",
+            "django_mysql.models.fields.EnumField",
         )
         if path in bad_paths:
-            path = 'django_mysql.models.EnumField'
+            path = "django_mysql.models.EnumField"
 
-        kwargs['choices'] = self.choices
-        del kwargs['max_length']
+        kwargs["choices"] = self.choices
+        del kwargs["max_length"]
 
         return name, path, args, kwargs
 
     def db_type(self, connection):
         connection.ensure_connection()
-        values = [
-            connection.connection.escape_string(c)
-            for c, _ in self.flatchoices
-        ]
+        values = [connection.connection.escape_string(c) for c, _ in self.flatchoices]
         # Use force_text because MySQLdb escape_string() returns bytes, but
         # pymysql returns str
-        return 'enum(%s)' % ','.join(
-            "'%s'" % force_text(v)
-            for v in values
-        )
+        return "enum(%s)" % ",".join("'%s'" % force_text(v) for v in values)

--- a/django_mysql/models/fields/lists.py
+++ b/django_mysql/models/fields/lists.py
@@ -10,7 +10,6 @@ from django_mysql.validators import ListMaxLengthValidator
 
 
 class ListFieldMixin(object):
-
     def __init__(self, base_field, size=None, **kwargs):
         self.base_field = base_field
         self.size = size
@@ -22,7 +21,7 @@ class ListFieldMixin(object):
 
     def get_default(self):
         default = super(ListFieldMixin, self).get_default()
-        if default == '':
+        if default == "":
             return []
         else:
             return default
@@ -32,35 +31,34 @@ class ListFieldMixin(object):
         if not isinstance(self.base_field, (CharField, IntegerField)):
             errors.append(
                 checks.Error(
-                    'Base field for list must be a CharField or IntegerField.',
+                    "Base field for list must be a CharField or IntegerField.",
                     hint=None,
                     obj=self,
-                    id='django_mysql.E005',
-                ),
+                    id="django_mysql.E005",
+                )
             )
             return errors
 
         # Remove the field name checks as they are not needed here.
         base_errors = self.base_field.check()
         if base_errors:
-            messages = '\n    '.join(
-                '%s (%s)' % (error.msg, error.id)
-                for error in base_errors
+            messages = "\n    ".join(
+                "%s (%s)" % (error.msg, error.id) for error in base_errors
             )
             errors.append(
                 checks.Error(
-                    'Base field for list has errors:\n    %s' % messages,
+                    "Base field for list has errors:\n    %s" % messages,
                     hint=None,
                     obj=self,
-                    id='django_mysql.E004',
-                ),
+                    id="django_mysql.E004",
+                )
             )
         return errors
 
     @property
     def description(self):
-        return _('List of %(base_description)s') % {
-            'base_description': self.base_field.description,
+        return _("List of %(base_description)s") % {
+            "base_description": self.base_field.description
         }
 
     def set_attributes_from_name(self, name):
@@ -71,14 +69,14 @@ class ListFieldMixin(object):
         name, path, args, kwargs = super(ListFieldMixin, self).deconstruct()
 
         bad_paths = (
-            'django_mysql.models.fields.lists.' + self.__class__.__name__,
-            'django_mysql.models.fields.' + self.__class__.__name__,
+            "django_mysql.models.fields.lists." + self.__class__.__name__,
+            "django_mysql.models.fields." + self.__class__.__name__,
         )
         if path in bad_paths:
-            path = 'django_mysql.models.' + self.__class__.__name__
+            path = "django_mysql.models." + self.__class__.__name__
 
         args.insert(0, self.base_field)
-        kwargs['size'] = self.size
+        kwargs["size"] = self.size
         return name, path, args, kwargs
 
     def to_python(self, value):
@@ -86,51 +84,48 @@ class ListFieldMixin(object):
             if not len(value):
                 value = []
             else:
-                value = [self.base_field.to_python(v) for
-                         v in value.split(',')]
+                value = [self.base_field.to_python(v) for v in value.split(",")]
         return value
 
     if django.VERSION >= (2, 0):
+
         def from_db_value(self, value, expression, connection):
             # Similar to to_python, for Django 1.8+
             if isinstance(value, str):
                 if not len(value):
                     value = []
                 else:
-                    value = [self.base_field.to_python(v) for
-                             v in value.split(',')]
+                    value = [self.base_field.to_python(v) for v in value.split(",")]
             return value
+
     else:
+
         def from_db_value(self, value, expression, connection, context):
             # Similar to to_python, for Django 1.8+
             if isinstance(value, str):
                 if not len(value):
                     value = []
                 else:
-                    value = [self.base_field.to_python(v) for
-                             v in value.split(',')]
+                    value = [self.base_field.to_python(v) for v in value.split(",")]
             return value
 
     def get_prep_value(self, value):
         if isinstance(value, list):
-            value = [
-                str(self.base_field.get_prep_value(v))
-                for v in value
-            ]
+            value = [str(self.base_field.get_prep_value(v)) for v in value]
             for v in value:
-                if ',' in v:
+                if "," in v:
                     raise ValueError(
-                        "List members in {klass} {name} cannot contain commas"
-                        .format(klass=self.__class__.__name__,
-                                name=self.name),
+                        "List members in {klass} {name} cannot contain commas".format(
+                            klass=self.__class__.__name__, name=self.name
+                        )
                     )
                 elif not len(v):
                     raise ValueError(
-                        "The empty string cannot be stored in {klass} {name}"
-                        .format(klass=self.__class__.__name__,
-                                name=self.name),
+                        "The empty string cannot be stored in {klass} {name}".format(
+                            klass=self.__class__.__name__, name=self.name
+                        )
                     )
-            return ','.join(value)
+            return ",".join(value)
         return value
 
     def get_lookup(self, lookup_name):
@@ -154,9 +149,9 @@ class ListFieldMixin(object):
 
     def formfield(self, **kwargs):
         defaults = {
-            'form_class': SimpleListField,
-            'base_field': self.base_field.formfield(),
-            'max_length': self.size,
+            "form_class": SimpleListField,
+            "base_field": self.base_field.formfield(),
+            "max_length": self.size,
         }
         defaults.update(kwargs)
         return super(ListFieldMixin, self).formfield(**defaults)
@@ -170,12 +165,13 @@ class ListCharField(ListFieldMixin, CharField):
     """
     A subclass of CharField for using MySQL's handy FIND_IN_SET function with.
     """
+
     def check(self, **kwargs):
         errors = super(ListCharField, self).check(**kwargs)
 
         # Unfortunately this check can't really be done for IntegerFields since
         # they have boundless length
-        has_base_error = any(e.id == 'django_mysql.E004' for e in errors)
+        has_base_error = any(e.id == "django_mysql.E004" for e in errors)
         if (
             not has_base_error
             and self.max_length is not None
@@ -186,21 +182,21 @@ class ListCharField(ListFieldMixin, CharField):
                 # The chars used
                 (self.size * (self.base_field.max_length))
                 # The commas
-                + self.size - 1
+                + self.size
+                - 1
             )
             if max_size > self.max_length:
                 errors.append(
                     checks.Error(
-                        'Field can overrun - set contains CharFields of max '
-                        'length %s, leading to a comma-combined max length of '
-                        '%s, which is greater than the space reserved for the '
-                        'set - %s' %
-                        (self.base_field.max_length, max_size,
-                            self.max_length),
+                        "Field can overrun - set contains CharFields of max "
+                        "length %s, leading to a comma-combined max length of "
+                        "%s, which is greater than the space reserved for the "
+                        "set - %s"
+                        % (self.base_field.max_length, max_size, self.max_length),
                         hint=None,
                         obj=self,
-                        id='django_mysql.E006',
-                    ),
+                        id="django_mysql.E006",
+                    )
                 )
         return errors
 
@@ -220,7 +216,6 @@ ListTextField.register_lookup(SetLength)
 
 
 class IndexLookup(Lookup):
-
     def __init__(self, index, *args, **kwargs):
         super(IndexLookup, self).__init__(*args, **kwargs)
         self.index = index
@@ -230,11 +225,10 @@ class IndexLookup(Lookup):
         rhs, rhs_params = self.process_rhs(qn, connection)
         params = tuple(lhs_params) + tuple(rhs_params)
         # Put rhs on the left since that's the order FIND_IN_SET uses
-        return '(FIND_IN_SET(%s, %s) = %s)' % (rhs, lhs, self.index), params
+        return "(FIND_IN_SET(%s, %s) = %s)" % (rhs, lhs, self.index), params
 
 
 class IndexLookupFactory(object):
-
     def __init__(self, index):
         self.index = index
 

--- a/django_mysql/models/fields/sets.py
+++ b/django_mysql/models/fields/sets.py
@@ -21,7 +21,7 @@ class SetFieldMixin(object):
 
     def get_default(self):
         default = super(SetFieldMixin, self).get_default()
-        if default == '':
+        if default == "":
             return set()
         else:
             return default
@@ -31,35 +31,34 @@ class SetFieldMixin(object):
         if not isinstance(self.base_field, (CharField, IntegerField)):
             errors.append(
                 checks.Error(
-                    'Base field for set must be a CharField or IntegerField.',
+                    "Base field for set must be a CharField or IntegerField.",
                     hint=None,
                     obj=self,
-                    id='django_mysql.E002',
-                ),
+                    id="django_mysql.E002",
+                )
             )
             return errors
 
         # Remove the field name checks as they are not needed here.
         base_errors = self.base_field.check()
         if base_errors:
-            messages = '\n    '.join(
-                '%s (%s)' % (error.msg, error.id)
-                for error in base_errors
+            messages = "\n    ".join(
+                "%s (%s)" % (error.msg, error.id) for error in base_errors
             )
             errors.append(
                 checks.Error(
-                    'Base field for set has errors:\n    %s' % messages,
+                    "Base field for set has errors:\n    %s" % messages,
                     hint=None,
                     obj=self,
-                    id='django_mysql.E001',
-                ),
+                    id="django_mysql.E001",
+                )
             )
         return errors
 
     @property
     def description(self):
-        return _('Set of %(base_description)s') % {
-            'base_description': self.base_field.description,
+        return _("Set of %(base_description)s") % {
+            "base_description": self.base_field.description
         }
 
     def set_attributes_from_name(self, name):
@@ -70,14 +69,14 @@ class SetFieldMixin(object):
         name, path, args, kwargs = super(SetFieldMixin, self).deconstruct()
 
         bad_paths = (
-            'django_mysql.models.fields.sets.' + self.__class__.__name__,
-            'django_mysql.models.fields.' + self.__class__.__name__,
+            "django_mysql.models.fields.sets." + self.__class__.__name__,
+            "django_mysql.models.fields." + self.__class__.__name__,
         )
         if path in bad_paths:
-            path = 'django_mysql.models.' + self.__class__.__name__
+            path = "django_mysql.models." + self.__class__.__name__
 
         args.insert(0, self.base_field)
-        kwargs['size'] = self.size
+        kwargs["size"] = self.size
         return name, path, args, kwargs
 
     def to_python(self, value):
@@ -85,51 +84,48 @@ class SetFieldMixin(object):
             if not len(value):
                 value = set()
             else:
-                value = {self.base_field.to_python(v) for
-                         v in value.split(',')}
+                value = {self.base_field.to_python(v) for v in value.split(",")}
         return value
 
     if django.VERSION >= (2, 0):
+
         def from_db_value(self, value, expression, connection):
             # Similar to to_python, for Django 1.8+
             if isinstance(value, str):
                 if not len(value):
                     value = set()
                 else:
-                    value = {self.base_field.to_python(v) for
-                             v in value.split(',')}
+                    value = {self.base_field.to_python(v) for v in value.split(",")}
             return value
+
     else:
+
         def from_db_value(self, value, expression, connection, context):
             # Similar to to_python, for Django 1.8+
             if isinstance(value, str):
                 if not len(value):
                     value = set()
                 else:
-                    value = {self.base_field.to_python(v) for
-                             v in value.split(',')}
+                    value = {self.base_field.to_python(v) for v in value.split(",")}
             return value
 
     def get_prep_value(self, value):
         if isinstance(value, set):
-            value = {
-                str(self.base_field.get_prep_value(v))
-                for v in value
-            }
+            value = {str(self.base_field.get_prep_value(v)) for v in value}
             for v in value:
-                if ',' in v:
+                if "," in v:
                     raise ValueError(
-                        "Set members in {klass} {name} cannot contain commas"
-                        .format(klass=self.__class__.__name__,
-                                name=self.name),
+                        "Set members in {klass} {name} cannot contain commas".format(
+                            klass=self.__class__.__name__, name=self.name
+                        )
                     )
                 elif not len(v):
                     raise ValueError(
-                        "The empty string cannot be stored in {klass} {name}"
-                        .format(klass=self.__class__.__name__,
-                                name=self.name),
+                        "The empty string cannot be stored in {klass} {name}".format(
+                            klass=self.__class__.__name__, name=self.name
+                        )
                     )
-            return ','.join(value)
+            return ",".join(value)
         return value
 
     def value_to_string(self, obj):
@@ -138,9 +134,9 @@ class SetFieldMixin(object):
 
     def formfield(self, **kwargs):
         defaults = {
-            'form_class': SimpleSetField,
-            'base_field': self.base_field.formfield(),
-            'max_length': self.size,
+            "form_class": SimpleSetField,
+            "base_field": self.base_field.formfield(),
+            "max_length": self.size,
         }
         defaults.update(kwargs)
         return super(SetFieldMixin, self).formfield(**defaults)
@@ -154,12 +150,13 @@ class SetCharField(SetFieldMixin, CharField):
     """
     A subclass of CharField for using MySQL's handy FIND_IN_SET function with.
     """
+
     def check(self, **kwargs):
         errors = super(SetCharField, self).check(**kwargs)
 
         # Unfortunately this check can't really be done for IntegerFields since
         # they have boundless length
-        has_base_error = any(e.id == 'django_mysql.E001' for e in errors)
+        has_base_error = any(e.id == "django_mysql.E001" for e in errors)
         if (
             not has_base_error
             and self.max_length is not None
@@ -170,21 +167,21 @@ class SetCharField(SetFieldMixin, CharField):
                 # The chars used
                 (self.size * (self.base_field.max_length))
                 # The commas
-                + self.size - 1
+                + self.size
+                - 1
             )
             if max_size > self.max_length:
                 errors.append(
                     checks.Error(
-                        'Field can overrun - set contains CharFields of max '
-                        'length %s, leading to a comma-combined max length of '
-                        '%s, which is greater than the space reserved for the '
-                        'set - %s' %
-                        (self.base_field.max_length, max_size,
-                            self.max_length),
+                        "Field can overrun - set contains CharFields of max "
+                        "length %s, leading to a comma-combined max length of "
+                        "%s, which is greater than the space reserved for the "
+                        "set - %s"
+                        % (self.base_field.max_length, max_size, self.max_length),
                         hint=None,
                         obj=self,
-                        id='django_mysql.E003',
-                    ),
+                        id="django_mysql.E003",
+                    )
                 )
         return errors
 

--- a/django_mysql/models/fields/sizes.py
+++ b/django_mysql/models/fields/sizes.py
@@ -4,7 +4,7 @@ from django.db.models import BinaryField, TextField
 
 class SizedBinaryField(BinaryField):
     def __init__(self, *args, **kwargs):
-        self.size_class = kwargs.pop('size_class', 4)
+        self.size_class = kwargs.pop("size_class", 4)
         super(SizedBinaryField, self).__init__(*args, **kwargs)
 
     def check(self, **kwargs):
@@ -12,11 +12,11 @@ class SizedBinaryField(BinaryField):
         if self.size_class not in (1, 2, 3, 4):
             errors.append(
                 checks.Error(
-                    'size_class must be 1, 2, 3, or 4',
+                    "size_class must be 1, 2, 3, or 4",
                     hint=None,
                     obj=self,
-                    id='django_mysql.E007',
-                ),
+                    id="django_mysql.E007",
+                )
             )
         return errors
 
@@ -24,29 +24,29 @@ class SizedBinaryField(BinaryField):
         name, path, args, kwargs = super(SizedBinaryField, self).deconstruct()
 
         bad_paths = (
-            'django_mysql.models.fields.sizes.SizedBinaryField',
-            'django_mysql.models.fields.SizedBinaryField',
+            "django_mysql.models.fields.sizes.SizedBinaryField",
+            "django_mysql.models.fields.SizedBinaryField",
         )
         if path in bad_paths:
-            path = 'django_mysql.models.SizedBinaryField'
+            path = "django_mysql.models.SizedBinaryField"
 
-        kwargs['size_class'] = self.size_class
+        kwargs["size_class"] = self.size_class
         return name, path, args, kwargs
 
     def db_type(self, connection):
         if self.size_class == 1:
-            return 'tinyblob'
+            return "tinyblob"
         elif self.size_class == 2:
-            return 'blob'
+            return "blob"
         elif self.size_class == 3:
-            return 'mediumblob'
+            return "mediumblob"
         else:  # don't check size_class == 4 as a safeguard for invalid values
-            return 'longblob'
+            return "longblob"
 
 
 class SizedTextField(TextField):
     def __init__(self, *args, **kwargs):
-        self.size_class = kwargs.pop('size_class', 4)
+        self.size_class = kwargs.pop("size_class", 4)
         super(SizedTextField, self).__init__(*args, **kwargs)
 
     def check(self, **kwargs):
@@ -54,11 +54,11 @@ class SizedTextField(TextField):
         if self.size_class not in (1, 2, 3, 4):
             errors.append(
                 checks.Error(
-                    'size_class must be 1, 2, 3, or 4',
+                    "size_class must be 1, 2, 3, or 4",
                     hint=None,
                     obj=self,
-                    id='django_mysql.E008',
-                ),
+                    id="django_mysql.E008",
+                )
             )
         return errors
 
@@ -66,21 +66,21 @@ class SizedTextField(TextField):
         name, path, args, kwargs = super(SizedTextField, self).deconstruct()
 
         bad_paths = (
-            'django_mysql.models.fields.sizes.SizedTextField',
-            'django_mysql.models.fields.SizedTextField',
+            "django_mysql.models.fields.sizes.SizedTextField",
+            "django_mysql.models.fields.SizedTextField",
         )
         if path in bad_paths:
-            path = 'django_mysql.models.SizedTextField'
+            path = "django_mysql.models.SizedTextField"
 
-        kwargs['size_class'] = self.size_class
+        kwargs["size_class"] = self.size_class
         return name, path, args, kwargs
 
     def db_type(self, connection):
         if self.size_class == 1:
-            return 'tinytext'
+            return "tinytext"
         elif self.size_class == 2:
-            return 'text'
+            return "text"
         elif self.size_class == 3:
-            return 'mediumtext'
+            return "mediumtext"
         else:  # don't check size_class == 4 as a safeguard for invalid values
-            return 'longtext'
+            return "longtext"

--- a/django_mysql/models/functions.py
+++ b/django_mysql/models/functions.py
@@ -25,53 +25,52 @@ class MultiArgFunc(Func):
 
 
 class Greatest(MultiArgFunc):
-    function = 'GREATEST'
+    function = "GREATEST"
 
 
 class Least(MultiArgFunc):
-    function = 'LEAST'
+    function = "LEAST"
 
 
 # Control Flow Functions
 
 
 class If(Func):
-    function = 'IF'
+    function = "IF"
 
     def __init__(self, condition, true, false=None, output_field=None):
         if output_field is None:
             # Workaround for some ORM weirdness
             output_field = DjangoField()
 
-        super(If, self).__init__(condition, true, false,
-                                 output_field=output_field)
+        super(If, self).__init__(condition, true, false, output_field=output_field)
 
 
 # Numeric Functions
 
 
 class Abs(SingleArgFunc):
-    function = 'ABS'
+    function = "ABS"
     output_field_class = IntegerField
 
 
 class Ceiling(SingleArgFunc):
-    function = 'CEILING'
+    function = "CEILING"
     output_field_class = IntegerField
 
 
 class CRC32(SingleArgFunc):
-    function = 'CRC32'
+    function = "CRC32"
     output_field_class = IntegerField
 
 
 class Floor(SingleArgFunc):
-    function = 'FLOOR'
+    function = "FLOOR"
     output_field_class = IntegerField
 
 
 class Round(Func):
-    function = 'ROUND'
+    function = "ROUND"
     output_field_class = IntegerField
 
     def __init__(self, expression, places=0):
@@ -79,43 +78,49 @@ class Round(Func):
 
 
 class Sign(SingleArgFunc):
-    function = 'SIGN'
+    function = "SIGN"
     output_field_class = IntegerField
 
 
 # String Functions
 
+
 class ConcatWS(Func):
     """
     Stands for CONCAT_With-Separator
     """
-    function = 'CONCAT_WS'
+
+    function = "CONCAT_WS"
 
     def __init__(self, *expressions, **kwargs):
-        separator = kwargs.pop('separator', ',')
+        separator = kwargs.pop("separator", ",")
         if len(kwargs) > 0:
-            raise ValueError("Invalid keyword arguments for ConcatWS: {}"
-                             .format(",".join(kwargs.keys())))
+            raise ValueError(
+                "Invalid keyword arguments for ConcatWS: {}".format(
+                    ",".join(kwargs.keys())
+                )
+            )
 
         if len(expressions) < 2:
-            raise ValueError('ConcatWS must take at least two expressions')
+            raise ValueError("ConcatWS must take at least two expressions")
 
-        if not hasattr(separator, 'resolve_expression'):
+        if not hasattr(separator, "resolve_expression"):
             separator = Value(separator)
 
         # N.B. if separator is "," we could potentially use list field
         output_field = TextField()
-        super(ConcatWS, self).__init__(separator, *expressions,
-                                       output_field=output_field)
+        super(ConcatWS, self).__init__(
+            separator, *expressions, output_field=output_field
+        )
 
 
 class ELT(Func):
-    function = 'ELT'
+    function = "ELT"
 
     def __init__(self, num, expressions):
         value_exprs = []
         for v in expressions:
-            if not hasattr(v, 'resolve_expression'):
+            if not hasattr(v, "resolve_expression"):
                 v = Value(v)
             value_exprs.append(v)
 
@@ -123,12 +128,12 @@ class ELT(Func):
 
 
 class Field(Func):
-    function = 'FIELD'
+    function = "FIELD"
 
     def __init__(self, field, values, **kwargs):
         values_exprs = []
         for v in values:
-            if not hasattr(v, 'resolve_expression'):
+            if not hasattr(v, "resolve_expression"):
                 v = Value(v)
             values_exprs.append(v)
 
@@ -139,59 +144,63 @@ class Field(Func):
 
 
 class UpdateXML(Func):
-    function = 'UPDATEXML'
+    function = "UPDATEXML"
 
     def __init__(self, xml_target, xpath_expr, new_xml):
-        if not hasattr(xpath_expr, 'resolve_expression'):
+        if not hasattr(xpath_expr, "resolve_expression"):
             xpath_expr = Value(xpath_expr)
-        if not hasattr(new_xml, 'resolve_expression'):
+        if not hasattr(new_xml, "resolve_expression"):
             new_xml = Value(new_xml)
 
-        return super(UpdateXML, self).__init__(xml_target, xpath_expr, new_xml,
-                                               output_field=TextField())
+        return super(UpdateXML, self).__init__(
+            xml_target, xpath_expr, new_xml, output_field=TextField()
+        )
 
 
 class XMLExtractValue(Func):
-    function = 'EXTRACTVALUE'
+    function = "EXTRACTVALUE"
 
     def __init__(self, xml_frag, xpath_expr):
-        if not hasattr(xpath_expr, 'resolve_expression'):
+        if not hasattr(xpath_expr, "resolve_expression"):
             xpath_expr = Value(xpath_expr)
 
-        return super(XMLExtractValue, self).__init__(xml_frag, xpath_expr,
-                                                     output_field=TextField())
+        return super(XMLExtractValue, self).__init__(
+            xml_frag, xpath_expr, output_field=TextField()
+        )
 
 
 # Encryption Functions
 
 
 class MD5(SingleArgFunc):
-    function = 'MD5'
+    function = "MD5"
     output_field_class = CharField
 
 
 class SHA1(SingleArgFunc):
-    function = 'SHA1'
+    function = "SHA1"
     output_field_class = CharField
 
 
 class SHA2(Func):
-    function = 'SHA2'
+    function = "SHA2"
     hash_lens = (224, 256, 384, 512)
 
     def __init__(self, expression, hash_len=512):
         if hash_len not in self.hash_lens:
             raise ValueError(
-                "hash_len must be one of {}"
-                .format(",".join(str(x) for x in self.hash_lens)),
+                "hash_len must be one of {}".format(
+                    ",".join(str(x) for x in self.hash_lens)
+                )
             )
         super(SHA2, self).__init__(expression, Value(hash_len))
 
 
 # Information Functions
 
+
 class LastInsertId(Func):
-    function = 'LAST_INSERT_ID'
+    function = "LAST_INSERT_ID"
 
     def __init__(self, expression=None):
         if expression is not None:
@@ -213,15 +222,16 @@ class LastInsertId(Func):
 
 # JSON Functions
 
+
 class JSONExtract(Func):
-    function = 'JSON_EXTRACT'
+    function = "JSON_EXTRACT"
 
     def __init__(self, expression, *paths, output_field=None):
         from django_mysql.models.fields import JSONField
 
         exprs = [expression]
         for path in paths:
-            if not hasattr(path, 'resolve_expression'):
+            if not hasattr(path, "resolve_expression"):
                 path = Value(path)
             exprs.append(path)
 
@@ -229,7 +239,7 @@ class JSONExtract(Func):
             if len(paths) > 1:
                 raise TypeError(
                     "output_field won't work with more than one path, as a "
-                    "JSON Array will be returned",
+                    "JSON Array will be returned"
                 )
         else:
             output_field = JSONField()
@@ -238,14 +248,14 @@ class JSONExtract(Func):
 
 
 class JSONKeys(Func):
-    function = 'JSON_KEYS'
+    function = "JSON_KEYS"
 
     def __init__(self, expression, path=None):
         from django_mysql.models.fields import JSONField
 
         exprs = [expression]
         if path is not None:
-            if not hasattr(path, 'resolve_expression'):
+            if not hasattr(path, "resolve_expression"):
                 path = Value(path)
             exprs.append(path)
 
@@ -253,14 +263,14 @@ class JSONKeys(Func):
 
 
 class JSONLength(Func):
-    function = 'JSON_LENGTH'
+    function = "JSON_LENGTH"
 
     def __init__(self, expression, path=None, **extra):
-        output_field = extra.pop('output_field', IntegerField())
+        output_field = extra.pop("output_field", IntegerField())
 
         exprs = [expression]
         if path is not None:
-            if not hasattr(path, 'resolve_expression'):
+            if not hasattr(path, "resolve_expression"):
                 path = Value(path)
             exprs.append(path)
 
@@ -268,8 +278,8 @@ class JSONLength(Func):
 
 
 class JSONValue(Func):
-    function = 'CAST'
-    template = '%(function)s(%(expressions)s AS JSON)'
+    function = "CAST"
+    template = "%(function)s(%(expressions)s AS JSON)"
 
     def __init__(self, expression):
         json_string = json.dumps(expression, allow_nan=False)
@@ -286,85 +296,88 @@ class BaseJSONModifyFunc(Func):
         exprs = [expression]
 
         for path, value in data.items():
-            if not hasattr(path, 'resolve_expression'):
+            if not hasattr(path, "resolve_expression"):
                 path = Value(path)
 
             exprs.append(path)
 
-            if not hasattr(value, 'resolve_expression'):
+            if not hasattr(value, "resolve_expression"):
                 value = JSONValue(value)
 
             exprs.append(value)
 
-        super(BaseJSONModifyFunc, self).__init__(*exprs,
-                                                 output_field=JSONField())
+        super(BaseJSONModifyFunc, self).__init__(*exprs, output_field=JSONField())
 
 
 class JSONInsert(BaseJSONModifyFunc):
-    function = 'JSON_INSERT'
+    function = "JSON_INSERT"
 
 
 class JSONReplace(BaseJSONModifyFunc):
-    function = 'JSON_REPLACE'
+    function = "JSON_REPLACE"
 
 
 class JSONSet(BaseJSONModifyFunc):
-    function = 'JSON_SET'
+    function = "JSON_SET"
 
 
 class JSONArrayAppend(BaseJSONModifyFunc):
-    function = 'JSON_ARRAY_APPEND'
+    function = "JSON_ARRAY_APPEND"
 
 
 # MariaDB Regexp Functions
 
+
 class RegexpInstr(Func):
-    function = 'REGEXP_INSTR'
+    function = "REGEXP_INSTR"
 
     def __init__(self, expression, regex):
-        if not hasattr(regex, 'resolve_expression'):
+        if not hasattr(regex, "resolve_expression"):
             regex = Value(regex)
 
-        super(RegexpInstr, self).__init__(expression, regex,
-                                          output_field=IntegerField())
+        super(RegexpInstr, self).__init__(
+            expression, regex, output_field=IntegerField()
+        )
 
 
 class RegexpReplace(Func):
-    function = 'REGEXP_REPLACE'
+    function = "REGEXP_REPLACE"
 
     def __init__(self, expression, regex, replace):
-        if not hasattr(regex, 'resolve_expression'):
+        if not hasattr(regex, "resolve_expression"):
             regex = Value(regex)
 
-        if not hasattr(replace, 'resolve_expression'):
+        if not hasattr(replace, "resolve_expression"):
             replace = Value(replace)
 
-        super(RegexpReplace, self).__init__(expression, regex, replace,
-                                            output_field=CharField())
+        super(RegexpReplace, self).__init__(
+            expression, regex, replace, output_field=CharField()
+        )
 
 
 class RegexpSubstr(Func):
-    function = 'REGEXP_SUBSTR'
+    function = "REGEXP_SUBSTR"
 
     def __init__(self, expression, regex):
-        if not hasattr(regex, 'resolve_expression'):
+        if not hasattr(regex, "resolve_expression"):
             regex = Value(regex)
 
-        super(RegexpSubstr, self).__init__(expression, regex,
-                                           output_field=CharField())
+        super(RegexpSubstr, self).__init__(expression, regex, output_field=CharField())
 
 
 # MariaDB Dynamic Columns Functions
+
 
 class AsType(Func):
     """
     Helper for ColumnAdd when you want to add a column with a given type
     """
-    function = ''
-    template = '%(expressions)s AS %(data_type)s'
+
+    function = ""
+    template = "%(expressions)s AS %(data_type)s"
 
     def __init__(self, expression, data_type):
-        if not hasattr(expression, 'resolve_expression'):
+        if not hasattr(expression, "resolve_expression"):
             expression = Value(expression)
 
         if data_type not in self.TYPE_MAP:
@@ -375,55 +388,52 @@ class AsType(Func):
     @property
     def TYPE_MAP(self):
         from django_mysql.models.fields.dynamic import KeyTransform
+
         return KeyTransform.TYPE_MAP
 
 
 class ColumnAdd(Func):
-    function = 'COLUMN_ADD'
+    function = "COLUMN_ADD"
 
     def __init__(self, expression, to_add):
         from django_mysql.models.fields import DynamicField
 
         expressions = [expression]
         for name, value in to_add.items():
-            if not hasattr(name, 'resolve_expression'):
+            if not hasattr(name, "resolve_expression"):
                 name = Value(name)
 
             if isinstance(value, dict):
-                raise ValueError(
-                    "ColumnAdd with nested values is not supported",
-                )
-            if not hasattr(value, 'resolve_expression'):
+                raise ValueError("ColumnAdd with nested values is not supported")
+            if not hasattr(value, "resolve_expression"):
                 value = Value(value)
 
             expressions.extend((name, value))
 
-        super(ColumnAdd, self).__init__(*expressions,
-                                        output_field=DynamicField())
+        super(ColumnAdd, self).__init__(*expressions, output_field=DynamicField())
 
 
 class ColumnDelete(Func):
-    function = 'COLUMN_DELETE'
+    function = "COLUMN_DELETE"
 
     def __init__(self, expression, *to_delete):
         from django_mysql.models.fields import DynamicField
 
         expressions = [expression]
         for name in to_delete:
-            if not hasattr(name, 'resolve_expression'):
+            if not hasattr(name, "resolve_expression"):
                 name = Value(name)
             expressions.append(name)
 
-        super(ColumnDelete, self).__init__(*expressions,
-                                           output_field=DynamicField())
+        super(ColumnDelete, self).__init__(*expressions, output_field=DynamicField())
 
 
 class ColumnGet(Func):
-    function = 'COLUMN_GET'
-    template = 'COLUMN_GET(%(expressions)s AS %(data_type)s)'
+    function = "COLUMN_GET"
+    template = "COLUMN_GET(%(expressions)s AS %(data_type)s)"
 
     def __init__(self, expression, column_name, data_type):
-        if not hasattr(column_name, 'resolve_expression'):
+        if not hasattr(column_name, "resolve_expression"):
             column_name = Value(column_name)
 
         try:
@@ -431,14 +441,15 @@ class ColumnGet(Func):
         except KeyError:
             raise ValueError("Invalid data_type '{}'".format(data_type))
 
-        if data_type == 'BINARY':
+        if data_type == "BINARY":
             output_field = output_field()
 
-        super(ColumnGet, self).__init__(expression, column_name,
-                                        output_field=output_field,
-                                        data_type=data_type)
+        super(ColumnGet, self).__init__(
+            expression, column_name, output_field=output_field, data_type=data_type
+        )
 
     @property
     def TYPE_MAP(self):
         from django_mysql.models.fields.dynamic import KeyTransform
+
         return KeyTransform.TYPE_MAP

--- a/django_mysql/models/lookups.py
+++ b/django_mysql/models/lookups.py
@@ -2,30 +2,37 @@ import collections
 import json
 
 from django.db.models import CharField, Lookup, Transform
-from django.db.models.lookups import BuiltinLookup, Exact, GreaterThan, GreaterThanOrEqual, LessThan, LessThanOrEqual
+from django.db.models.lookups import (
+    BuiltinLookup,
+    Exact,
+    GreaterThan,
+    GreaterThanOrEqual,
+    LessThan,
+    LessThanOrEqual,
+)
 
 from django_mysql.models.functions import JSONValue
 
 
 class CaseSensitiveExact(BuiltinLookup):
-    lookup_name = 'case_exact'
+    lookup_name = "case_exact"
 
     def get_rhs_op(self, connection, rhs):
-        return '= BINARY %s' % rhs
+        return "= BINARY %s" % rhs
 
 
 class SoundsLike(Lookup):
-    lookup_name = 'sounds_like'
+    lookup_name = "sounds_like"
 
     def as_sql(self, qn, connection):
         lhs, lhs_params = self.process_lhs(qn, connection)
         rhs, rhs_params = self.process_rhs(qn, connection)
         params = tuple(lhs_params) + tuple(rhs_params)
-        return '%s SOUNDS LIKE %s' % (lhs, rhs), params
+        return "%s SOUNDS LIKE %s" % (lhs, rhs), params
 
 
 class Soundex(Transform):
-    lookup_name = 'soundex'
+    lookup_name = "soundex"
     output_field = CharField()
 
     def as_sql(self, compiler, connection):
@@ -38,11 +45,11 @@ class Soundex(Transform):
 
 # JSONField
 
-class JSONLookupMixin(object):
 
+class JSONLookupMixin(object):
     def get_prep_lookup(self):
         value = self.rhs
-        if not hasattr(value, '_prepare') and value is not None:
+        if not hasattr(value, "_prepare") and value is not None:
             return JSONValue(value)
         return super(JSONLookupMixin, self).get_prep_lookup()
 
@@ -52,55 +59,53 @@ class JSONExact(JSONLookupMixin, Exact):
 
 
 class JSONGreaterThan(JSONLookupMixin, GreaterThan):
-    lookup_name = 'gt'
+    lookup_name = "gt"
 
 
 class JSONGreaterThanOrEqual(JSONLookupMixin, GreaterThanOrEqual):
-    lookup_name = 'gte'
+    lookup_name = "gte"
 
 
 class JSONLessThan(JSONLookupMixin, LessThan):
-    lookup_name = 'lt'
+    lookup_name = "lt"
 
 
 class JSONLessThanOrEqual(JSONLookupMixin, LessThanOrEqual):
-    lookup_name = 'lte'
+    lookup_name = "lte"
 
 
 class JSONContainedBy(Lookup):
-    lookup_name = 'contained_by'
+    lookup_name = "contained_by"
 
     def as_sql(self, qn, connection):
         lhs, lhs_params = self.process_lhs(qn, connection)
         rhs, rhs_params = self.process_rhs(qn, connection)
         params = tuple(rhs_params) + tuple(lhs_params)
-        return 'JSON_CONTAINS({}, {})'.format(rhs, lhs), params
+        return "JSON_CONTAINS({}, {})".format(rhs, lhs), params
 
 
 class JSONContains(JSONLookupMixin, Lookup):
-    lookup_name = 'contains'
+    lookup_name = "contains"
 
     def as_sql(self, qn, connection):
         lhs, lhs_params = self.process_lhs(qn, connection)
         rhs, rhs_params = self.process_rhs(qn, connection)
         params = tuple(lhs_params) + tuple(rhs_params)
-        return 'JSON_CONTAINS({}, {})'.format(lhs, rhs), params
+        return "JSON_CONTAINS({}, {})".format(lhs, rhs), params
 
 
 class JSONHasKey(Lookup):
-    lookup_name = 'has_key'
+    lookup_name = "has_key"
 
     def get_prep_lookup(self):
         if not isinstance(self.rhs, str):
-            raise ValueError(
-                "JSONField's 'has_key' lookup only works with str values",
-            )
+            raise ValueError("JSONField's 'has_key' lookup only works with str values")
         return super(JSONHasKey, self).get_prep_lookup()
 
     def as_sql(self, qn, connection):
         lhs, lhs_params = self.process_lhs(qn, connection)
         key_name = self.rhs
-        path = '$.{}'.format(json.dumps(key_name))
+        path = "$.{}".format(json.dumps(key_name))
         params = tuple(lhs_params) + (path,)
         return "JSON_CONTAINS_PATH({}, 'one', %s)".format(lhs), params
 
@@ -109,51 +114,46 @@ class JSONSequencesMixin(object):
     def get_prep_lookup(self):
         if not isinstance(self.rhs, collections.Sequence):
             raise ValueError(
-                "JSONField's '{}' lookup only works with Sequences"
-                .format(self.lookup_name),
+                "JSONField's '{}' lookup only works with Sequences".format(
+                    self.lookup_name
+                )
             )
         return self.rhs
 
 
 class JSONHasKeys(JSONSequencesMixin, Lookup):
-    lookup_name = 'has_keys'
+    lookup_name = "has_keys"
 
     def as_sql(self, qn, connection):
         lhs, lhs_params = self.process_lhs(qn, connection)
-        paths = tuple(
-            '$.{}'.format(json.dumps(key_name))
-            for key_name in self.rhs
-        )
+        paths = tuple("$.{}".format(json.dumps(key_name)) for key_name in self.rhs)
         params = tuple(lhs_params) + paths
 
-        sql = ['JSON_CONTAINS_PATH(', lhs, ", 'all', "]
-        sql.append(', '.join('%s' for _ in paths))
-        sql.append(')')
-        return ''.join(sql), params
+        sql = ["JSON_CONTAINS_PATH(", lhs, ", 'all', "]
+        sql.append(", ".join("%s" for _ in paths))
+        sql.append(")")
+        return "".join(sql), params
 
 
 class JSONHasAnyKeys(JSONSequencesMixin, Lookup):
-    lookup_name = 'has_any_keys'
+    lookup_name = "has_any_keys"
 
     def as_sql(self, qn, connection):
         lhs, lhs_params = self.process_lhs(qn, connection)
-        paths = tuple(
-            '$.{}'.format(json.dumps(key_name))
-            for key_name in self.rhs
-        )
+        paths = tuple("$.{}".format(json.dumps(key_name)) for key_name in self.rhs)
         params = tuple(lhs_params) + paths
 
-        sql = ['JSON_CONTAINS_PATH(', lhs, ", 'one', "]
-        sql.append(', '.join('%s' for _ in paths))
-        sql.append(')')
-        return ''.join(sql), params
+        sql = ["JSON_CONTAINS_PATH(", lhs, ", 'one', "]
+        sql.append(", ".join("%s" for _ in paths))
+        sql.append(")")
+        return "".join(sql), params
 
 
 # Set{Char,Text}Field
 
 
 class SetContains(Lookup):
-    lookup_name = 'contains'
+    lookup_name = "contains"
 
     def get_prep_lookup(self):
         if isinstance(self.rhs, (list, set)):
@@ -161,8 +161,9 @@ class SetContains(Lookup):
             # (ANDing all the FIND_IN_SET calls), so just reject them
             raise ValueError(
                 "Can't do contains with a set and {klass}, you should "
-                "pass them as separate filters."
-                .format(klass=self.lhs.__class__.__name__),
+                "pass them as separate filters.".format(
+                    klass=self.lhs.__class__.__name__
+                )
             )
         return super(SetContains, self).get_prep_lookup()
 
@@ -171,21 +172,21 @@ class SetContains(Lookup):
         rhs, rhs_params = self.process_rhs(qn, connection)
         params = tuple(lhs_params) + tuple(rhs_params)
         # Put rhs on the left since that's the order FIND_IN_SET uses
-        return 'FIND_IN_SET(%s, %s)' % (rhs, lhs), params
+        return "FIND_IN_SET(%s, %s)" % (rhs, lhs), params
 
 
 class SetIContains(SetContains):
-    lookup_name = 'icontains'
+    lookup_name = "icontains"
 
 
 # DynamicField
 
 
 class DynColHasKey(Lookup):
-    lookup_name = 'has_key'
+    lookup_name = "has_key"
 
     def as_sql(self, qn, connection):
         lhs, lhs_params = self.process_lhs(qn, connection)
         rhs, rhs_params = self.process_rhs(qn, connection)
         params = tuple(lhs_params) + tuple(rhs_params)
-        return 'COLUMN_EXISTS(%s, %s)' % (lhs, rhs), params
+        return "COLUMN_EXISTS(%s, %s)" % (lhs, rhs), params

--- a/django_mysql/models/transforms.py
+++ b/django_mysql/models/transforms.py
@@ -4,17 +4,19 @@ from django_mysql.utils import collapse_spaces
 
 
 class SetLength(Transform):
-    lookup_name = 'len'
+    lookup_name = "len"
     output_field = IntegerField()
 
     # No str.count equivalent in MySQL :(
-    expr = collapse_spaces("""
+    expr = collapse_spaces(
+        """
         (
             CHAR_LENGTH(%s) -
             CHAR_LENGTH(REPLACE(%s, ',', '')) +
             IF(CHAR_LENGTH(%s), 1, 0)
         )
-    """)
+    """
+    )
 
     def as_sql(self, compiler, connection):
         lhs, params = compiler.compile(self.lhs)

--- a/django_mysql/monkey_patches.py
+++ b/django_mysql/monkey_patches.py
@@ -8,14 +8,14 @@ from django_mysql.rewrite_query import REWRITE_MARKER, rewrite_query
 
 def patch():
     # Depends on setting
-    if getattr(settings, 'DJANGO_MYSQL_REWRITE_QUERIES', False):
+    if getattr(settings, "DJANGO_MYSQL_REWRITE_QUERIES", False):
         patch_CursorWrapper_execute()
 
 
 def patch_CursorWrapper_execute():
 
     # Be idemptotent
-    if getattr(CursorWrapper, '_has_django_mysql_execute', False):
+    if getattr(CursorWrapper, "_has_django_mysql_execute", False):
         return
 
     orig_execute = CursorWrapper.execute
@@ -23,7 +23,7 @@ def patch_CursorWrapper_execute():
     @functools.wraps(orig_execute)
     def execute(self, sql, args=None):
         if (
-            getattr(settings, 'DJANGO_MYSQL_REWRITE_QUERIES', False)
+            getattr(settings, "DJANGO_MYSQL_REWRITE_QUERIES", False)
             and REWRITE_MARKER in sql
         ):
             sql = rewrite_query(sql)

--- a/django_mysql/operations.py
+++ b/django_mysql/operations.py
@@ -17,8 +17,7 @@ class InstallPlugin(Operation):
     def database_forwards(self, app_label, schema_editor, from_st, to_st):
         if not self.plugin_installed(schema_editor):
             schema_editor.execute(
-                "INSTALL PLUGIN {} SONAME %s".format(self.name),
-                (self.soname,),
+                "INSTALL PLUGIN {} SONAME %s".format(self.name), (self.soname,)
             )
 
     def database_backwards(self, app_label, schema_editor, from_st, to_st):
@@ -34,7 +33,7 @@ class InstallPlugin(Operation):
                 (self.name,),
             )
             count = cursor.fetchone()[0]
-            return (count > 0)
+            return count > 0
 
     def describe(self):
         return "Installs plugin %s from %s" % (self.name, self.soname)
@@ -62,7 +61,6 @@ class InstallSOName(Operation):
 
 
 class AlterStorageEngine(Operation):
-
     def __init__(self, name, to_engine, from_engine=None):
         self.name = name
         self.engine = to_engine
@@ -70,13 +68,14 @@ class AlterStorageEngine(Operation):
 
     @property
     def reversible(self):
-        return (self.from_engine is not None)
+        return self.from_engine is not None
 
     def state_forwards(self, app_label, state):
         pass
 
-    def database_forwards(self, app_label, schema_editor, from_state, to_state,
-                          engine=None):
+    def database_forwards(
+        self, app_label, schema_editor, from_state, to_state, engine=None
+    ):
         if engine is None:
             engine = self.engine
 
@@ -93,25 +92,24 @@ class AlterStorageEngine(Operation):
                              ENGINE = %s""",
                     (new_model._meta.db_table, engine),
                 )
-                uses_engine_already = (cursor.fetchone()[0] > 0)
+                uses_engine_already = cursor.fetchone()[0] > 0
 
             if uses_engine_already:
                 return
 
             schema_editor.execute(
                 "ALTER TABLE {table} ENGINE={engine}".format(
-                    table=qn(new_model._meta.db_table),
-                    engine=engine,
-                ),
+                    table=qn(new_model._meta.db_table), engine=engine
+                )
             )
 
-    def database_backwards(self, app_label, schema_editor, from_state,
-                           to_state):
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
         if self.from_engine is None:
             raise NotImplementedError("You cannot reverse this operation")
 
-        return self.database_forwards(app_label, schema_editor, from_state,
-                                      to_state, engine=self.from_engine)
+        return self.database_forwards(
+            app_label, schema_editor, from_state, to_state, engine=self.from_engine
+        )
 
     @cached_property
     def name_lower(self):
@@ -125,9 +123,6 @@ class AlterStorageEngine(Operation):
             from_clause = " from {}".format(self.from_engine)
         else:
             from_clause = ""
-        return "Alter storage engine for {model}{from_clause} to {engine}" \
-               .format(
-                   model=self.name,
-                   from_clause=from_clause,
-                   engine=self.engine,
-               )
+        return "Alter storage engine for {model}{from_clause} to {engine}".format(
+            model=self.name, from_clause=from_clause, engine=self.engine
+        )

--- a/django_mysql/status.py
+++ b/django_mysql/status.py
@@ -11,6 +11,7 @@ class BaseStatus(object):
     """
     Base class for the status classes
     """
+
     query = ""
 
     def __init__(self, using=None):
@@ -23,9 +24,10 @@ class BaseStatus(object):
         return connections[self.db].cursor()
 
     def get(self, name):
-        if '%' in name:
-            raise ValueError("get() is for fetching single variables, "
-                             "no % wildcards")
+        if "%" in name:
+            raise ValueError(
+                "get() is for fetching single variables, " "no % wildcards"
+            )
         with self.get_cursor() as cursor:
             num_rows = cursor.execute(self.query + " LIKE %s", (name,))
             if num_rows == 0:
@@ -37,8 +39,9 @@ class BaseStatus(object):
             return {}
 
         if any(("%" in name) for name in names):
-            raise ValueError("get_many() is for fetching named "
-                             "variables, no % wildcards")
+            raise ValueError(
+                "get_many() is for fetching named " "variables, no % wildcards"
+            )
 
         with self.get_cursor() as cursor:
             query = [self.query, "WHERE Variable_name IN ("]
@@ -46,17 +49,14 @@ class BaseStatus(object):
             query.append(")")
             cursor.execute(" ".join(query), names)
 
-            return {
-                name: self._cast(value)
-                for name, value in cursor.fetchall()
-            }
+            return {name: self._cast(value) for name, value in cursor.fetchall()}
 
     def as_dict(self, prefix=None):
         with self.get_cursor() as cursor:
             if prefix is None:
                 cursor.execute(self.query)
             else:
-                cursor.execute(self.query + " LIKE %s", (prefix + '%',))
+                cursor.execute(self.query + " LIKE %s", (prefix + "%",))
             rows = cursor.fetchall()
             return {name: self._cast(value) for name, value in rows}
 
@@ -71,9 +71,9 @@ class BaseStatus(object):
             except ValueError:
                 pass
 
-        if value == 'ON':
+        if value == "ON":
             return True
-        elif value == 'OFF':
+        elif value == "OFF":
             return False
 
         return value
@@ -84,7 +84,7 @@ class GlobalStatus(BaseStatus):
 
     def wait_until_load_low(self, thresholds=None, timeout=60.0, sleep=0.1):
         if thresholds is None:
-            thresholds = {'Threads_running': 10}
+            thresholds = {"Threads_running": 10}
 
         start = time.time()
         names = thresholds.keys()
@@ -104,9 +104,8 @@ class GlobalStatus(BaseStatus):
                 raise TimeoutError(
                     "Span too long waiting for load to drop: "
                     + ",".join(
-                        "{} > {}".format(name, thresholds[name])
-                        for name in higher
-                    ),
+                        "{} > {}".format(name, thresholds[name]) for name in higher
+                    )
                 )
             time.sleep(sleep)
 

--- a/django_mysql/validators.py
+++ b/django_mysql/validators.py
@@ -4,47 +4,39 @@ from django.utils.translation import ungettext_lazy
 
 class ListMaxLengthValidator(MaxLengthValidator):
     message = ungettext_lazy(
-        'List contains %(show_value)d item, '
-        'it should contain no more than %(limit_value)d.',
-
-        'List contains %(show_value)d items, '
-        'it should contain no more than %(limit_value)d.',
-
-        'limit_value',
+        "List contains %(show_value)d item, "
+        "it should contain no more than %(limit_value)d.",
+        "List contains %(show_value)d items, "
+        "it should contain no more than %(limit_value)d.",
+        "limit_value",
     )
 
 
 class ListMinLengthValidator(MinLengthValidator):
     message = ungettext_lazy(
-        'List contains %(show_value)d item, '
-        'it should contain no fewer than %(limit_value)d.',
-
-        'List contains %(show_value)d items, '
-        'it should contain no fewer than %(limit_value)d.',
-
-        'limit_value',
+        "List contains %(show_value)d item, "
+        "it should contain no fewer than %(limit_value)d.",
+        "List contains %(show_value)d items, "
+        "it should contain no fewer than %(limit_value)d.",
+        "limit_value",
     )
 
 
 class SetMaxLengthValidator(MaxLengthValidator):
     message = ungettext_lazy(
-        'Set contains %(show_value)d item, '
-        'it should contain no more than %(limit_value)d.',
-
-        'Set contains %(show_value)d items, '
-        'it should contain no more than %(limit_value)d.',
-
-        'limit_value',
+        "Set contains %(show_value)d item, "
+        "it should contain no more than %(limit_value)d.",
+        "Set contains %(show_value)d items, "
+        "it should contain no more than %(limit_value)d.",
+        "limit_value",
     )
 
 
 class SetMinLengthValidator(MinLengthValidator):
     message = ungettext_lazy(
-        'Set contains %(show_value)d item, '
-        'it should contain no fewer than %(limit_value)d.',
-
-        'Set contains %(show_value)d items, '
-        'it should contain no fewer than %(limit_value)d.',
-
-        'limit_value',
+        "Set contains %(show_value)d item, "
+        "it should contain no fewer than %(limit_value)d.",
+        "Set contains %(show_value)d items, "
+        "it should contain no fewer than %(limit_value)d.",
+        "limit_value",
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+target-version = ['py35']

--- a/requirements/py35-django111.txt
+++ b/requirements/py35-django111.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -67,9 +67,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8-comprehensions==2.1.0 \
     --hash=sha256:35f826956e87f230415cde9c3b8b454e785736cf5ff0be551c441b41b937f699 \
     --hash=sha256:f0b61d983d608790abf3664830d68efd3412265c2d10f6a4ba1a353274dbeb64

--- a/requirements/py35-django20.txt
+++ b/requirements/py35-django20.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -67,9 +67,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8-comprehensions==2.1.0 \
     --hash=sha256:35f826956e87f230415cde9c3b8b454e785736cf5ff0be551c441b41b937f699 \
     --hash=sha256:f0b61d983d608790abf3664830d68efd3412265c2d10f6a4ba1a353274dbeb64

--- a/requirements/py35-django21.txt
+++ b/requirements/py35-django21.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -67,9 +67,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8-comprehensions==2.1.0 \
     --hash=sha256:35f826956e87f230415cde9c3b8b454e785736cf5ff0be551c441b41b937f699 \
     --hash=sha256:f0b61d983d608790abf3664830d68efd3412265c2d10f6a4ba1a353274dbeb64

--- a/requirements/py35-django22.txt
+++ b/requirements/py35-django22.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -67,9 +67,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8-comprehensions==2.1.0 \
     --hash=sha256:35f826956e87f230415cde9c3b8b454e785736cf5ff0be551c441b41b937f699 \
     --hash=sha256:f0b61d983d608790abf3664830d68efd3412265c2d10f6a4ba1a353274dbeb64

--- a/requirements/py36-django111.txt
+++ b/requirements/py36-django111.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -67,9 +67,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8-comprehensions==2.1.0 \
     --hash=sha256:35f826956e87f230415cde9c3b8b454e785736cf5ff0be551c441b41b937f699 \
     --hash=sha256:f0b61d983d608790abf3664830d68efd3412265c2d10f6a4ba1a353274dbeb64

--- a/requirements/py36-django20.txt
+++ b/requirements/py36-django20.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -67,9 +67,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8-comprehensions==2.1.0 \
     --hash=sha256:35f826956e87f230415cde9c3b8b454e785736cf5ff0be551c441b41b937f699 \
     --hash=sha256:f0b61d983d608790abf3664830d68efd3412265c2d10f6a4ba1a353274dbeb64

--- a/requirements/py36-django21.txt
+++ b/requirements/py36-django21.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -67,9 +67,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8-comprehensions==2.1.0 \
     --hash=sha256:35f826956e87f230415cde9c3b8b454e785736cf5ff0be551c441b41b937f699 \
     --hash=sha256:f0b61d983d608790abf3664830d68efd3412265c2d10f6a4ba1a353274dbeb64

--- a/requirements/py36-django22.txt
+++ b/requirements/py36-django22.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -67,9 +67,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8-comprehensions==2.1.0 \
     --hash=sha256:35f826956e87f230415cde9c3b8b454e785736cf5ff0be551c441b41b937f699 \
     --hash=sha256:f0b61d983d608790abf3664830d68efd3412265c2d10f6a4ba1a353274dbeb64

--- a/requirements/py37-django111.txt
+++ b/requirements/py37-django111.txt
@@ -4,6 +4,10 @@
 #
 #    ./compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via black, flake8-bugbear, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -24,6 +31,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 coverage==4.5.3 \
     --hash=sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9 \
     --hash=sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74 \
@@ -67,9 +78,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8-comprehensions==2.1.0 \
     --hash=sha256:35f826956e87f230415cde9c3b8b454e785736cf5ff0be551c441b41b937f699 \
     --hash=sha256:f0b61d983d608790abf3664830d68efd3412265c2d10f6a4ba1a353274dbeb64
@@ -180,6 +191,10 @@ six==1.12.0 \
 sqlparse==0.3.0 \
     --hash=sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177 \
     --hash=sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/py37-django20.txt
+++ b/requirements/py37-django20.txt
@@ -4,6 +4,10 @@
 #
 #    ./compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via black, flake8-bugbear, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -24,6 +31,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 coverage==4.5.3 \
     --hash=sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9 \
     --hash=sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74 \
@@ -67,9 +78,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8-comprehensions==2.1.0 \
     --hash=sha256:35f826956e87f230415cde9c3b8b454e785736cf5ff0be551c441b41b937f699 \
     --hash=sha256:f0b61d983d608790abf3664830d68efd3412265c2d10f6a4ba1a353274dbeb64
@@ -180,6 +191,10 @@ six==1.12.0 \
 sqlparse==0.3.0 \
     --hash=sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177 \
     --hash=sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/py37-django21.txt
+++ b/requirements/py37-django21.txt
@@ -4,6 +4,10 @@
 #
 #    ./compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via black, flake8-bugbear, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -24,6 +31,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 coverage==4.5.3 \
     --hash=sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9 \
     --hash=sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74 \
@@ -67,9 +78,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8-comprehensions==2.1.0 \
     --hash=sha256:35f826956e87f230415cde9c3b8b454e785736cf5ff0be551c441b41b937f699 \
     --hash=sha256:f0b61d983d608790abf3664830d68efd3412265c2d10f6a4ba1a353274dbeb64
@@ -182,6 +193,10 @@ six==1.12.0 \
 sqlparse==0.3.0 \
     --hash=sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177 \
     --hash=sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/py37-django22.txt
+++ b/requirements/py37-django22.txt
@@ -4,6 +4,10 @@
 #
 #    ./compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via black, flake8-bugbear, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -24,6 +31,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 coverage==4.5.3 \
     --hash=sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9 \
     --hash=sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74 \
@@ -67,9 +78,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8-comprehensions==2.1.0 \
     --hash=sha256:35f826956e87f230415cde9c3b8b454e785736cf5ff0be551c441b41b937f699 \
     --hash=sha256:f0b61d983d608790abf3664830d68efd3412265c2d10f6a4ba1a353274dbeb64
@@ -182,6 +193,10 @@ six==1.12.0 \
 sqlparse==0.3.0 \
     --hash=sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177 \
     --hash=sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,8 +1,9 @@
+black ; python_version == '3.7.*'
 coverage
 django
 docutils
 flake8
-flake8-commas
+flake8-bugbear
 flake8-comprehensions
 flake8-tidy-imports
 isort

--- a/runtests.py
+++ b/runtests.py
@@ -11,5 +11,5 @@ def main():
     return pytest.main()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,15 +1,17 @@
 [flake8]
-accept-encodings = utf-8
-ignore = X99999, C815, W503
-max-line-length = 120
+max-line-length = 80
+select = C,E,F,W,B,B950
+ignore = E203,E501,W503
 
 [isort]
 include_trailing_comma = True
+force_grid_wrap = 0
 known_first_party = django_mysql
 known_third_party = pytest,django
-line_length = 120
-multi_line_output = 5
+line_length = 88
+multi_line_output = 3
 not_skip = __init__.py
+use_parentheses = True
 
 [metadata]
 license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -5,53 +5,51 @@ from setuptools import find_packages, setup
 
 
 def get_version(filename):
-    with open(filename, 'r') as fp:
+    with open(filename, "r") as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
 
-version = get_version(os.path.join('django_mysql', '__init__.py'))
+version = get_version(os.path.join("django_mysql", "__init__.py"))
 
 
-with open('README.rst', 'r') as readme_file:
+with open("README.rst", "r") as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst', 'r') as history_file:
-    history = history_file.read().replace('.. :changelog:', '')
+with open("HISTORY.rst", "r") as history_file:
+    history = history_file.read().replace(".. :changelog:", "")
 
 setup(
-    name='django-mysql',
+    name="django-mysql",
     version=version,
     description="Extensions to Django for use with MySQL/MariaDB",
-    long_description=readme + '\n\n' + history,
+    long_description=readme + "\n\n" + history,
     author="Adam Johnson",
-    author_email='me@adamj.eu',
-    url='https://github.com/adamchainz/django-mysql',
-    packages=find_packages(exclude=['tests', 'tests.*']),
+    author_email="me@adamj.eu",
+    url="https://github.com/adamchainz/django-mysql",
+    packages=find_packages(exclude=["tests", "tests.*"]),
     include_package_data=True,
-    install_requires=[
-        'Django>=1.11',
-    ],
-    python_requires='>=3.5',
+    install_requires=["Django>=1.11"],
+    python_requires=">=3.5",
     license="BSD",
     zip_safe=False,
-    keywords=['Django', 'MySQL', 'MariaDB'],
+    keywords=["Django", "MySQL", "MariaDB"],
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Framework :: Django',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
-        'Framework :: Django :: 2.2',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Natural Language :: English',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Topic :: Database',
+        "Development Status :: 5 - Production/Stable",
+        "Framework :: Django",
+        "Framework :: Django :: 1.11",
+        "Framework :: Django :: 2.0",
+        "Framework :: Django :: 2.1",
+        "Framework :: Django :: 2.2",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Topic :: Database",
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from pytest_django.plugin import _blocking_manager
 
 
 def pytest_report_header(config):
-    dot_version = '.'.join(str(x) for x in django.VERSION)
+    dot_version = ".".join(str(x) for x in django.VERSION)
     header = "Django version: " + dot_version
 
     with _blocking_manager.unblock():
@@ -19,14 +19,11 @@ def pytest_report_header(config):
 
 
 # MySQL 5.7 warns about some sql mode changes
-warnings.filterwarnings('ignore', r'.*Changing sql mode.*')
-warnings.filterwarnings(
-    'ignore',
-    r'.*sql modes should be used with strict mode.*',
-)
+warnings.filterwarnings("ignore", r".*Changing sql mode.*")
+warnings.filterwarnings("ignore", r".*sql modes should be used with strict mode.*")
 # MySQL 5.7 turned 'explain' into 'explain extended' so it always warns the
 # optimized query
-warnings.filterwarnings('ignore', r'.*/\* select#\d+ \*/')
+warnings.filterwarnings("ignore", r".*/\* select#\d+ \*/")
 # MySQL 5.7 deprecated some query hints
-warnings.filterwarnings('ignore', r".*'SQL_CACHE' is deprecated.*")
-warnings.filterwarnings('ignore', r".*'SQL_NO_CACHE' is deprecated.*")
+warnings.filterwarnings("ignore", r".*'SQL_CACHE' is deprecated.*")
+warnings.filterwarnings("ignore", r".*'SQL_NO_CACHE' is deprecated.*")

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -4,78 +4,64 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 
-SECRET_KEY = 'THISuISdNOT9A$SECRET9x&ji!vceayg+wwt472!bgs$0!i3k4'
+SECRET_KEY = "THISuISdNOT9A$SECRET9x&ji!vceayg+wwt472!bgs$0!i3k4"
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.mysql',
-        'NAME': 'django_mysql',
-        'USER': os.environ.get('DB_USER', ''),
-        'PASSWORD': os.environ.get('DB_PASSWORD', ''),
-        'HOST': os.environ.get('DB_HOST', ''),
-        'PORT': os.environ.get('DB_PORT', ''),
-        'OPTIONS': {
-            'charset': 'utf8mb4',
+    "default": {
+        "ENGINE": "django.db.backends.mysql",
+        "NAME": "django_mysql",
+        "USER": os.environ.get("DB_USER", ""),
+        "PASSWORD": os.environ.get("DB_PASSWORD", ""),
+        "HOST": os.environ.get("DB_HOST", ""),
+        "PORT": os.environ.get("DB_PORT", ""),
+        "OPTIONS": {
+            "charset": "utf8mb4",
             # The most forward compatible sql_mode, for 5.7
-            'init_command': "SET sql_mode='STRICT_TRANS_TABLES,NO_ZERO_DATE,"
-                            "NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,"
-                            "NO_AUTO_CREATE_USER', innodb_strict_mode=1",
+            "init_command": "SET sql_mode='STRICT_TRANS_TABLES,NO_ZERO_DATE,"
+            "NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,"
+            "NO_AUTO_CREATE_USER', innodb_strict_mode=1",
         },
-        'TEST': {
-            'COLLATION': "utf8mb4_general_ci",
-            'CHARSET': "utf8mb4",
-        },
+        "TEST": {"COLLATION": "utf8mb4_general_ci", "CHARSET": "utf8mb4"},
     },
-    'other': {
-        'ENGINE': 'django.db.backends.mysql',
-        'NAME': 'django_mysql2',
-        'USER': os.environ.get('DB_USER', ''),
-        'PASSWORD': os.environ.get('DB_PASSWORD', ''),
-        'HOST': os.environ.get('DB_HOST', ''),
-        'PORT': os.environ.get('DB_PORT', ''),
-        'OPTIONS': {
-            'charset': 'utf8mb4',
+    "other": {
+        "ENGINE": "django.db.backends.mysql",
+        "NAME": "django_mysql2",
+        "USER": os.environ.get("DB_USER", ""),
+        "PASSWORD": os.environ.get("DB_PASSWORD", ""),
+        "HOST": os.environ.get("DB_HOST", ""),
+        "PORT": os.environ.get("DB_PORT", ""),
+        "OPTIONS": {
+            "charset": "utf8mb4",
             # The most forward compatible sql_mode, for 5.7
-            'init_command': "SET sql_mode='STRICT_TRANS_TABLES,NO_ZERO_DATE,"
-                            "NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,"
-                            "NO_AUTO_CREATE_USER', innodb_strict_mode=1",
+            "init_command": "SET sql_mode='STRICT_TRANS_TABLES,NO_ZERO_DATE,"
+            "NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,"
+            "NO_AUTO_CREATE_USER', innodb_strict_mode=1",
         },
-        'TEST': {
-            'COLLATION': "utf8mb4_general_ci",
-            'CHARSET': "utf8mb4",
-        },
+        "TEST": {"COLLATION": "utf8mb4_general_ci", "CHARSET": "utf8mb4"},
     },
-    'other2': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    "other2": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
     },
 }
 
-DATABASE_ROUTERS = [
-    'tests.testapp.routers.NothingOnSQLiteRouter',
-]
+DATABASE_ROUTERS = ["tests.testapp.routers.NothingOnSQLiteRouter"]
 
 ALLOWED_HOSTS = []
 
-INSTALLED_APPS = [
-    'django.contrib.contenttypes',
-    'django_mysql',
-    'tests.testapp',
-]
+INSTALLED_APPS = ["django.contrib.contenttypes", "django_mysql", "tests.testapp"]
 
-ROOT_URLCONF = 'tests.urls'
-TIME_ZONE = 'UTC'
+ROOT_URLCONF = "tests.urls"
+TIME_ZONE = "UTC"
 USE_I18N = True
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'OPTIONS': {
-            'context_processors': [
-                'django.contrib.auth.context_processors.auth',
-            ],
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "OPTIONS": {
+            "context_processors": ["django.contrib.auth.context_processors.auth"]
         },
-    },
+    }
 ]
 
 

--- a/tests/testapp/enum_default_migrations/0001_initial.py
+++ b/tests/testapp/enum_default_migrations/0001_initial.py
@@ -9,16 +9,23 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.CreateModel(
-            name='EnumDefaultModel',
+            name="EnumDefaultModel",
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False,
-                 auto_created=True, primary_key=True)),
-                ('field', EnumField(choices=[
-                    ('lion', 'Lion'), ('tiger', 'Tiger'), 'bear',
-                ])),
+                (
+                    "id",
+                    models.AutoField(
+                        verbose_name="ID",
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    "field",
+                    EnumField(choices=[("lion", "Lion"), ("tiger", "Tiger"), "bear"]),
+                ),
             ],
-            options={
-            },
+            options={},
             bases=(models.Model,),
-        ),
+        )
     ]

--- a/tests/testapp/enum_default_migrations/0002_add_some_fields.py
+++ b/tests/testapp/enum_default_migrations/0002_add_some_fields.py
@@ -5,19 +5,19 @@ from django_mysql.models import EnumField
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('testapp', '0001_initial'),
-    ]
+    dependencies = [("testapp", "0001_initial")]
 
     operations = [
         migrations.AlterField(
-            model_name='EnumDefaultModel',
-            name='field',
-            field=EnumField(choices=[
-                ('lion', 'Lion'),
-                ('tiger', 'Tiger'),
-                ('bear', 'Bear'),
-                'oh my!',
-            ]),
-        ),
+            model_name="EnumDefaultModel",
+            name="field",
+            field=EnumField(
+                choices=[
+                    ("lion", "Lion"),
+                    ("tiger", "Tiger"),
+                    ("bear", "Bear"),
+                    "oh my!",
+                ]
+            ),
+        )
     ]

--- a/tests/testapp/enum_default_migrations/0003_remove_some_fields.py
+++ b/tests/testapp/enum_default_migrations/0003_remove_some_fields.py
@@ -5,16 +5,12 @@ from django_mysql.models import EnumField
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('testapp', '0002_add_some_fields'),
-    ]
+    dependencies = [("testapp", "0002_add_some_fields")]
 
     operations = [
         migrations.AlterField(
-            model_name='EnumDefaultModel',
-            name='field',
-            field=EnumField(choices=[
-                ('lion', 'Lion'), ('tiger', 'Tiger'), 'oh my!',
-            ]),
-        ),
+            model_name="EnumDefaultModel",
+            name="field",
+            field=EnumField(choices=[("lion", "Lion"), ("tiger", "Tiger"), "oh my!"]),
+        )
     ]

--- a/tests/testapp/list_default_migrations/0001_initial.py
+++ b/tests/testapp/list_default_migrations/0001_initial.py
@@ -9,15 +9,23 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.CreateModel(
-            name='IntListDefaultModel',
+            name="IntListDefaultModel",
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False,
-                 auto_created=True, primary_key=True)),
-                ('field', ListCharField(
-                    models.IntegerField(), size=None, max_length=32)),
+                (
+                    "id",
+                    models.AutoField(
+                        verbose_name="ID",
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    "field",
+                    ListCharField(models.IntegerField(), size=None, max_length=32),
+                ),
             ],
-            options={
-            },
+            options={},
             bases=(models.Model,),
-        ),
+        )
     ]

--- a/tests/testapp/list_default_migrations/0002_add_some_fields.py
+++ b/tests/testapp/list_default_migrations/0002_add_some_fields.py
@@ -5,25 +5,21 @@ from django_mysql.models import ListCharField
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('testapp', '0001_initial'),
-    ]
+    dependencies = [("testapp", "0001_initial")]
 
     operations = [
         migrations.AddField(
-            model_name='intlistdefaultmodel',
-            name='field_2',
-            field=ListCharField(models.IntegerField(),
-                                default=lambda: [],
-                                size=None,
-                                max_length=32),
+            model_name="intlistdefaultmodel",
+            name="field_2",
+            field=ListCharField(
+                models.IntegerField(), default=lambda: [], size=None, max_length=32
+            ),
         ),
         migrations.AddField(
-            model_name='intlistdefaultmodel',
-            name='field_3',
-            field=ListCharField(models.IntegerField(),
-                                default=lambda: [1, 5],
-                                size=None,
-                                max_length=32),
+            model_name="intlistdefaultmodel",
+            name="field_3",
+            field=ListCharField(
+                models.IntegerField(), default=lambda: [1, 5], size=None, max_length=32
+            ),
         ),
     ]

--- a/tests/testapp/management/commands/test_dbparams.py
+++ b/tests/testapp/management/commands/test_dbparams.py
@@ -8,66 +8,63 @@ from django.test import SimpleTestCase
 
 # Can't use @override_settings to swap out DATABASES, instead just mock.patch
 # a new ConnectionHandler into the command module
-command_connections = 'django_mysql.management.commands.dbparams.connections'
+command_connections = "django_mysql.management.commands.dbparams.connections"
 
-sqlite = ConnectionHandler({
-    'default': {'ENGINE': 'django.db.backends.sqlite3'},
-})
+sqlite = ConnectionHandler({"default": {"ENGINE": "django.db.backends.sqlite3"}})
 
-full_db = ConnectionHandler({'default': {
-    'ENGINE': 'django.db.backends.mysql',
-    'NAME': 'mydatabase',
-    'USER': 'ausername',
-    'PASSWORD': 'apassword',
-    'HOST': 'ahost.example.com',
-    'PORT': '12345',
-    'OPTIONS': {
-        'read_default_file': '/tmp/defaults.cnf',
-        'ssl': {'ca': '/tmp/mysql.cert'},
-    },
-}})
+full_db = ConnectionHandler(
+    {
+        "default": {
+            "ENGINE": "django.db.backends.mysql",
+            "NAME": "mydatabase",
+            "USER": "ausername",
+            "PASSWORD": "apassword",
+            "HOST": "ahost.example.com",
+            "PORT": "12345",
+            "OPTIONS": {
+                "read_default_file": "/tmp/defaults.cnf",
+                "ssl": {"ca": "/tmp/mysql.cert"},
+            },
+        }
+    }
+)
 
-socket_db = ConnectionHandler({'default': {
-    'ENGINE': 'django.db.backends.mysql',
-    'HOST': '/etc/mydb.sock',
-}})
+socket_db = ConnectionHandler(
+    {"default": {"ENGINE": "django.db.backends.mysql", "HOST": "/etc/mydb.sock"}}
+)
 
 
 class DBParamsTests(SimpleTestCase):
-
     def test_invalid_database(self):
         with pytest.raises(CommandError) as excinfo:
-            call_command('dbparams', 'nonexistent', skip_checks=True)
+            call_command("dbparams", "nonexistent", skip_checks=True)
         assert "does not exist" in str(excinfo.value)
 
     def test_invalid_both(self):
         with pytest.raises(CommandError):
-            call_command('dbparams', dsn=True, mysql=True, skip_checks=True)
+            call_command("dbparams", dsn=True, mysql=True, skip_checks=True)
 
     @mock.patch(command_connections, sqlite)
     def test_invalid_not_mysql(self):
         with pytest.raises(CommandError) as excinfo:
-            call_command('dbparams', skip_checks=True)
+            call_command("dbparams", skip_checks=True)
         assert "not a MySQL database connection" in str(excinfo.value)
 
     @mock.patch(command_connections, full_db)
     def test_mysql_full(self):
         out = StringIO()
-        call_command('dbparams', stdout=out, skip_checks=True)
+        call_command("dbparams", stdout=out, skip_checks=True)
         output = out.getvalue()
-        assert (
-            output
-            == (
-                "--defaults-file=/tmp/defaults.cnf --user=ausername "
-                + "--password=apassword --host=ahost.example.com --port=12345 "
-                + "--ssl-ca=/tmp/mysql.cert mydatabase"
-            )
+        assert output == (
+            "--defaults-file=/tmp/defaults.cnf --user=ausername "
+            + "--password=apassword --host=ahost.example.com --port=12345 "
+            + "--ssl-ca=/tmp/mysql.cert mydatabase"
         )
 
     @mock.patch(command_connections, socket_db)
     def test_mysql_socket(self):
         out = StringIO()
-        call_command('dbparams', stdout=out, skip_checks=True)
+        call_command("dbparams", stdout=out, skip_checks=True)
         output = out.getvalue()
         assert output == "--socket=/etc/mydb.sock"
 
@@ -75,9 +72,14 @@ class DBParamsTests(SimpleTestCase):
     def test_dsn_full(self):
         out = StringIO()
         err = StringIO()
-        call_command('dbparams', 'default', dsn=True, stdout=out, stderr=err, skip_checks=True)
+        call_command(
+            "dbparams", "default", dsn=True, stdout=out, stderr=err, skip_checks=True
+        )
         output = out.getvalue()
-        assert output == "F=/tmp/defaults.cnf,u=ausername,p=apassword,h=ahost.example.com,P=12345,D=mydatabase"
+        assert output == (
+            "F=/tmp/defaults.cnf,u=ausername,p=apassword,"
+            + "h=ahost.example.com,P=12345,D=mydatabase"
+        )
 
         errors = err.getvalue()
         assert "SSL params can't be" in errors
@@ -86,10 +88,10 @@ class DBParamsTests(SimpleTestCase):
     def test_dsn_socket(self):
         out = StringIO()
         err = StringIO()
-        call_command('dbparams', dsn=True, stdout=out, stderr=err, skip_checks=True)
+        call_command("dbparams", dsn=True, stdout=out, stderr=err, skip_checks=True)
 
         output = out.getvalue()
-        assert output == 'S=/etc/mydb.sock'
+        assert output == "S=/etc/mydb.sock"
 
         errors = err.getvalue()
         assert errors == ""

--- a/tests/testapp/management/commands/test_fix_datetime_columns.py
+++ b/tests/testapp/management/commands/test_fix_datetime_columns.py
@@ -16,20 +16,18 @@ from django_mysql.utils import connection_is_mariadb
 # a new ConnectionHandler into the command module
 
 command_connections = (
-    'django_mysql.management.commands.fix_datetime_columns.connections'
+    "django_mysql.management.commands.fix_datetime_columns.connections"
 )
 
-sqlite = ConnectionHandler({
-    'default': {'ENGINE': 'django.db.backends.sqlite3'},
-})
+sqlite = ConnectionHandler({"default": {"ENGINE": "django.db.backends.sqlite3"}})
 
 
 def run_it(*args, **kwargs):
-    run_args = ['fix_datetime_columns']
+    run_args = ["fix_datetime_columns"]
     run_args.extend(args)
 
     out = StringIO()
-    run_kwargs = {'stdout': out, 'skip_checks': True}
+    run_kwargs = {"stdout": out, "skip_checks": True}
     run_kwargs.update(kwargs)
 
     call_command(*run_args, **run_kwargs)
@@ -38,35 +36,29 @@ def run_it(*args, **kwargs):
 
 
 class Datetime6TestMixin(object):
-
     @classmethod
     def setUpClass(cls):
-        if (
-            connection_is_mariadb(connection)
-            or connection.mysql_version[:2] < (5, 6)
-        ):
-            raise SkipTest(
-                "Django only uses datetime(6) columns on MySQL 5.6+",
-            )
+        if connection_is_mariadb(connection) or connection.mysql_version[:2] < (5, 6):
+            raise SkipTest("Django only uses datetime(6) columns on MySQL 5.6+")
         super(Datetime6TestMixin, cls).setUpClass()
 
 
 class FixDatetimeColumnsTests(Datetime6TestMixin, TestCase):
 
     if django.VERSION >= (2, 2):
-        databases = ['default', 'other']
+        databases = ["default", "other"]
     else:
         multi_db = True
 
     def test_nothing_by_default(self):
-        assert run_it() == ''
+        assert run_it() == ""
 
     def test_nothing_by_default_alternative_connection(self):
-        assert run_it('other') == ''
+        assert run_it("other") == ""
 
     def test_invalid_database(self):
         with pytest.raises(CommandError) as excinfo:
-            run_it('bla')
+            run_it("bla")
 
         assert "does not exist" in str(excinfo.value)
 
@@ -78,79 +70,92 @@ class FixDatetimeColumnsTests(Datetime6TestMixin, TestCase):
 
 
 class SlowFixDatetimeColumnsTests(Datetime6TestMixin, TransactionTestCase):
-
     def test_with_one_column_to_migrate(self):
         with connection.cursor() as cursor:
-            cursor.execute("""
+            cursor.execute(
+                """
                 ALTER TABLE testapp_author
                     MODIFY COLUMN birthday datetime DEFAULT NULL
-            """)
+            """
+            )
             try:
                 out = run_it()
             finally:
-                cursor.execute("""
+                cursor.execute(
+                    """
                     ALTER TABLE testapp_author
                         MODIFY COLUMN birthday datetime(6) DEFAULT NULL
-                """)
-        assert out == dedent('''\
+                """
+                )
+        assert out == dedent(
+            """\
             ALTER TABLE `testapp_author`
                 MODIFY COLUMN `birthday` datetime(6) DEFAULT NULL;
-            ''')
+            """
+        )
 
     def test_with_two_columns_to_migrate(self):
         with connection.cursor() as cursor:
-            cursor.execute("""
+            cursor.execute(
+                """
                 ALTER TABLE testapp_author
                     MODIFY COLUMN birthday datetime DEFAULT NULL,
                     MODIFY COLUMN deathday datetime DEFAULT NULL
-            """)
+            """
+            )
             try:
                 out = run_it()
             finally:
-                cursor.execute("""
+                cursor.execute(
+                    """
                     ALTER TABLE testapp_author
                         MODIFY COLUMN birthday datetime(6) DEFAULT NULL,
                         MODIFY COLUMN deathday datetime(6) DEFAULT NULL
-                """)
-        assert out == dedent('''\
+                """
+                )
+        assert out == dedent(
+            """\
             ALTER TABLE `testapp_author`
                 MODIFY COLUMN `birthday` datetime(6) DEFAULT NULL,
                 MODIFY COLUMN `deathday` datetime(6) DEFAULT NULL;
-            ''')
+            """
+        )
 
 
 class ParseCreateTableTests(SimpleTestCase):
-
     def test_large_normalish_table(self):
-        sql = dedent("""\
-        CREATE TABLE `example` (
-          `id` int(11) NOT NULL AUTO_INCREMENT,
-          `varchary` varchar(255) NOT NULL,
-          `texty` longtext NOT NULL,
-          `inty` int(11) DEFAULT NULL,
-          `datetimey` datetime NOT NULL,
-          PRIMARY KEY (`id`),
-          KEY `example_abcdef` (`varchary`),
-          KEY `example_123456` (`inty`)
-          CONSTRAINT `example_constraint` FOREIGN KEY (`id`) REFERENCES `other` (`id`)
-        ) ENGINE=InnoDB AUTO_INCREMENT=999999 DEFAULT CHARSET=utf8mb4 ROW_FORMAT=COMPRESSED
-        """)  # noqa
+        sql = (
+            "CREATE TABLE `example` (\n"
+            + "  `id` int(11) NOT NULL AUTO_INCREMENT,\n"
+            + "  `varchary` varchar(255) NOT NULL,\n"
+            + "  `texty` longtext NOT NULL,\n"
+            + "  `inty` int(11) DEFAULT NULL,\n"
+            + "  `datetimey` datetime NOT NULL,\n"
+            + "  PRIMARY KEY (`id`),\n"
+            + "  KEY `example_abcdef` (`varchary`),\n"
+            + "  KEY `example_123456` (`inty`)\n"
+            + "  CONSTRAINT `example_constraint` FOREIGN KEY (`id`) "
+            + "REFERENCES `other` (`id`)\n"
+            + ") ENGINE=InnoDB AUTO_INCREMENT=999999 DEFAULT CHARSET=utf8mb4 "
+            + "ROW_FORMAT=COMPRESSED\n"
+        )
 
         assert parse_create_table(sql) == {
-            'id': 'int(11) NOT NULL AUTO_INCREMENT',
-            'varchary': 'varchar(255) NOT NULL',
-            'texty': 'longtext NOT NULL',
-            'inty': 'int(11) DEFAULT NULL',
-            'datetimey': 'datetime NOT NULL',
+            "id": "int(11) NOT NULL AUTO_INCREMENT",
+            "varchary": "varchar(255) NOT NULL",
+            "texty": "longtext NOT NULL",
+            "inty": "int(11) DEFAULT NULL",
+            "datetimey": "datetime NOT NULL",
         }
 
     def test_single_column(self):
-        sql = dedent("""\
-        CREATE TABLE `example_table` (
-          `the_data` longtext COLLATE utf8mb4_unicode_ci NOT NULL
-        ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='hi mum';
-        """)  # noqa
+        sql = (
+            "CREATE TABLE `example_table` (\n"
+            + "  `the_data` longtext COLLATE utf8mb4_unicode_ci NOT NULL\n"
+            + ") ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 "
+            + "COLLATE=utf8mb4_unicode_ci COMMENT='hi mum';"
+        )
 
         assert parse_create_table(sql) == {
-            'the_data': 'longtext COLLATE utf8mb4_unicode_ci NOT NULL',
+            "the_data": "longtext COLLATE utf8mb4_unicode_ci NOT NULL"
         }

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -2,14 +2,31 @@ import json
 from datetime import date, datetime, time
 
 from django.db import connection
-from django.db.models import CASCADE, CharField, DateTimeField, DecimalField, ForeignKey, IntegerField
+from django.db.models import (
+    CASCADE,
+    CharField,
+    DateTimeField,
+    DecimalField,
+    ForeignKey,
+    IntegerField,
+)
 from django.db.models import Model as VanillaModel
 from django.db.models import OneToOneField, TextField
 from django.utils import timezone
 
 from django_mysql.models import (
-    Bit1BooleanField, DynamicField, EnumField, JSONField, ListCharField, ListTextField, Model, NullBit1BooleanField,
-    SetCharField, SetTextField, SizedBinaryField, SizedTextField,
+    Bit1BooleanField,
+    DynamicField,
+    EnumField,
+    JSONField,
+    ListCharField,
+    ListTextField,
+    Model,
+    NullBit1BooleanField,
+    SetCharField,
+    SetTextField,
+    SizedBinaryField,
+    SizedTextField,
 )
 from django_mysql.utils import connection_is_mariadb
 
@@ -20,13 +37,14 @@ class TemporaryModel(Model):
     disabled unless an extra parameter is provided, in case the checks get run
     during tests, e.g. from call_command.
     """
+
     class Meta:
-        app_label = 'testapp'
+        app_label = "testapp"
         abstract = True
 
     @classmethod
     def check(cls, **kwargs):
-        actually_check = kwargs.pop('actually_check', False)
+        actually_check = kwargs.pop("actually_check", False)
         if actually_check:
             return super(TemporaryModel, cls).check(**kwargs)
         else:
@@ -34,42 +52,31 @@ class TemporaryModel(Model):
 
 
 class EnumModel(Model):
-    field = EnumField(choices=[
-        ('red', 'Red'),
-        ('bloodred', 'Blood Red'),
-        'green',
-        ('blue', 'Navy Blue'),
-        ('coralblue', 'Coral Blue'),
-    ])
+    field = EnumField(
+        choices=[
+            ("red", "Red"),
+            ("bloodred", "Blood Red"),
+            "green",
+            ("blue", "Navy Blue"),
+            ("coralblue", "Coral Blue"),
+        ]
+    )
 
 
 class NullableEnumModel(Model):
-    field = EnumField(choices=[
-        'goat',
-        ('deer', 'Deer'),
-        'bull',
-        "dog's",   # Test if escaping works
-    ], null=True)
+    field = EnumField(
+        choices=["goat", ("deer", "Deer"), "bull", "dog's"],  # Test if escaping works
+        null=True,
+    )
 
 
 class CharSetModel(Model):
-    field = SetCharField(
-        base_field=CharField(max_length=8),
-        size=3,
-        max_length=32,
-    )
-    field2 = SetCharField(
-        base_field=CharField(max_length=8),
-        max_length=255,
-    )
+    field = SetCharField(base_field=CharField(max_length=8), size=3, max_length=32)
+    field2 = SetCharField(base_field=CharField(max_length=8), max_length=255)
 
 
 class CharListModel(Model):
-    field = ListCharField(
-        base_field=CharField(max_length=8),
-        size=3,
-        max_length=32,
-    )
+    field = ListCharField(base_field=CharField(max_length=8), size=3, max_length=32)
 
 
 class IntSetModel(Model):
@@ -81,24 +88,25 @@ class IntListModel(Model):
 
 
 class CharSetDefaultModel(Model):
-    field = SetCharField(base_field=CharField(max_length=5),
-                         size=5,
-                         max_length=32,
-                         default=lambda: {"a", "d"})
+    field = SetCharField(
+        base_field=CharField(max_length=5),
+        size=5,
+        max_length=32,
+        default=lambda: {"a", "d"},
+    )
 
 
 class CharListDefaultModel(Model):
-    field = ListCharField(base_field=CharField(max_length=5),
-                          size=5,
-                          max_length=32,
-                          default=lambda: ["a", "d"])
+    field = ListCharField(
+        base_field=CharField(max_length=5),
+        size=5,
+        max_length=32,
+        default=lambda: ["a", "d"],
+    )
 
 
 class BigCharSetModel(Model):
-    field = SetTextField(
-        base_field=CharField(max_length=8),
-        max_length=32,
-    )
+    field = SetTextField(base_field=CharField(max_length=8), max_length=32)
 
 
 class BigCharListModel(Model):
@@ -116,33 +124,27 @@ class BigIntListModel(Model):
 class DynamicModel(Model):
     attrs = DynamicField(
         spec={
-            'datetimey': datetime,
-            'datey': date,
-            'floaty': float,
-            'inty': int,
-            'stry': str,
-            'timey': time,
-            'nesty': {
-                'level2': str,
-            },
-        },
+            "datetimey": datetime,
+            "datey": date,
+            "floaty": float,
+            "inty": int,
+            "stry": str,
+            "timey": time,
+            "nesty": {"level2": str},
+        }
     )
 
     @classmethod
     def check(cls, **kwargs):
         # Disable the checks on MySQL so that checks tests don't fail
         if not (
-            connection_is_mariadb(connection)
-            and connection.mysql_version >= (10, 0, 1)
+            connection_is_mariadb(connection) and connection.mysql_version >= (10, 0, 1)
         ):
             return []
         return super(DynamicModel, cls).check(**kwargs)
 
     def __unicode__(self):
-        return ",".join(
-            '{}:{}'.format(key, value)
-            for key, value in self.attrs.items()
-        )
+        return ",".join("{}:{}".format(key, value) for key, value in self.attrs.items())
 
 
 class SpeclessDynamicModel(Model):
@@ -152,24 +154,18 @@ class SpeclessDynamicModel(Model):
     def check(cls, **kwargs):
         # Disable the checks on MySQL so that checks tests don't fail
         if not (
-            connection_is_mariadb(connection)
-            and connection.mysql_version >= (10, 0, 1)
+            connection_is_mariadb(connection) and connection.mysql_version >= (10, 0, 1)
         ):
             return []
         return super(SpeclessDynamicModel, cls).check(**kwargs)
 
     def __unicode__(self):
-        return ",".join(
-            '{}:{}'.format(key, value)
-            for key, value in self.attrs.items()
-        )
+        return ",".join("{}:{}".format(key, value) for key, value in self.attrs.items())
 
 
 class Author(Model):
     name = CharField(max_length=32, db_index=True)
-    tutor = ForeignKey(
-        'self', on_delete=CASCADE, null=True, related_name='tutees',
-    )
+    tutor = ForeignKey("self", on_delete=CASCADE, null=True, related_name="tutees")
     bio = TextField()
     birthday = DateTimeField(null=True)
     deathday = DateTimeField(null=True)
@@ -180,7 +176,7 @@ class Author(Model):
 
 class Book(Model):
     title = CharField(max_length=32, db_index=True)
-    author = ForeignKey(Author, on_delete=CASCADE, related_name='books')
+    author = ForeignKey(Author, on_delete=CASCADE, related_name="books")
 
 
 class VanillaAuthor(VanillaModel):
@@ -208,7 +204,7 @@ class NameAuthorExtra(Model):
 
 class AuthorMultiIndex(Model):
     class Meta(object):
-        index_together = ('name', 'country')
+        index_together = ("name", "country")
 
     name = CharField(max_length=32, db_index=True)
     country = CharField(max_length=32)
@@ -219,8 +215,7 @@ class AuthorMultiIndex(Model):
 
 class AuthorHugeName(Model):
     class Meta(object):
-        db_table = 'this_is_an_author_with_an_incredibly_long_table_name_' \
-                   'you_know_it'
+        db_table = "this_is_an_author_with_an_incredibly_long_table_name_" "you_know_it"
 
     name = CharField(max_length=32)
 
@@ -254,7 +249,8 @@ class AgedCustomer(Customer):
 
 class TitledAgedCustomer(AgedCustomer):
     class Meta:
-        db_table = 'titled aged customer'  # Test name quoting
+        db_table = "titled aged customer"  # Test name quoting
+
     title = CharField(max_length=16)
 
 
@@ -279,10 +275,9 @@ class NullBit1Model(Model):
 
 
 class JSONModel(Model):
-    if (
-        not connection_is_mariadb(connection._nodb_connection)
-        and connection._nodb_connection.mysql_version >= (5, 7)
-    ):
+    if not connection_is_mariadb(
+        connection._nodb_connection
+    ) and connection._nodb_connection.mysql_version >= (5, 7):
         attrs = JSONField(null=True)
 
     def __unicode__(self):
@@ -290,6 +285,7 @@ class JSONModel(Model):
 
 
 # For cache tests
+
 
 def expensive_calculation():
     expensive_calculation.num_runs += 1
@@ -299,7 +295,4 @@ def expensive_calculation():
 class Poll(VanillaModel):
     question = CharField(max_length=200)
     answer = CharField(max_length=200)
-    pub_date = DateTimeField(
-        'date published',
-        default=expensive_calculation,
-    )
+    pub_date = DateTimeField("date published", default=expensive_calculation)

--- a/tests/testapp/routers.py
+++ b/tests/testapp/routers.py
@@ -1,4 +1,3 @@
 class NothingOnSQLiteRouter(object):
-
     def allow_migrate(self, db, app_label, **hints):
-        return db in ('default', 'other')
+        return db in ("default", "other")

--- a/tests/testapp/set_default_migrations/0001_initial.py
+++ b/tests/testapp/set_default_migrations/0001_initial.py
@@ -9,15 +9,23 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.CreateModel(
-            name='IntSetDefaultModel',
+            name="IntSetDefaultModel",
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False,
-                 auto_created=True, primary_key=True)),
-                ('field', SetCharField(
-                    models.IntegerField(), size=None, max_length=32)),
+                (
+                    "id",
+                    models.AutoField(
+                        verbose_name="ID",
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    "field",
+                    SetCharField(models.IntegerField(), size=None, max_length=32),
+                ),
             ],
-            options={
-            },
+            options={},
             bases=(models.Model,),
-        ),
+        )
     ]

--- a/tests/testapp/set_default_migrations/0002_add_some_fields.py
+++ b/tests/testapp/set_default_migrations/0002_add_some_fields.py
@@ -5,25 +5,21 @@ from django_mysql.models import SetCharField
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('testapp', '0001_initial'),
-    ]
+    dependencies = [("testapp", "0001_initial")]
 
     operations = [
         migrations.AddField(
-            model_name='intsetdefaultmodel',
-            name='field_2',
-            field=SetCharField(models.IntegerField(),
-                               default=lambda: set(),
-                               size=None,
-                               max_length=32),
+            model_name="intsetdefaultmodel",
+            name="field_2",
+            field=SetCharField(
+                models.IntegerField(), default=lambda: set(), size=None, max_length=32
+            ),
         ),
         migrations.AddField(
-            model_name='intsetdefaultmodel',
-            name='field_3',
-            field=SetCharField(models.IntegerField(),
-                               default=lambda: {1, 5},
-                               size=None,
-                               max_length=32),
+            model_name="intsetdefaultmodel",
+            name="field_3",
+            field=SetCharField(
+                models.IntegerField(), default=lambda: {1, 5}, size=None, max_length=32
+            ),
         ),
     ]

--- a/tests/testapp/sizedbinaryfield_migrations/0001_initial.py
+++ b/tests/testapp/sizedbinaryfield_migrations/0001_initial.py
@@ -9,14 +9,20 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.CreateModel(
-            name='SizedBinaryAlterModel',
+            name="SizedBinaryAlterModel",
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False,
-                 auto_created=True, primary_key=True)),
-                ('field', SizedBinaryField(size_class=4)),
+                (
+                    "id",
+                    models.AutoField(
+                        verbose_name="ID",
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                ("field", SizedBinaryField(size_class=4)),
             ],
-            options={
-            },
+            options={},
             bases=(models.Model,),
-        ),
+        )
     ]

--- a/tests/testapp/sizedbinaryfield_migrations/0002_alter_field.py
+++ b/tests/testapp/sizedbinaryfield_migrations/0002_alter_field.py
@@ -5,14 +5,12 @@ from django_mysql.models import SizedBinaryField
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('testapp', '0001_initial'),
-    ]
+    dependencies = [("testapp", "0001_initial")]
 
     operations = [
         migrations.AlterField(
-            model_name='sizedbinaryaltermodel',
-            name='field',
+            model_name="sizedbinaryaltermodel",
+            name="field",
             field=SizedBinaryField(size_class=2),
-        ),
+        )
     ]

--- a/tests/testapp/sizedtextfield_migrations/0001_initial.py
+++ b/tests/testapp/sizedtextfield_migrations/0001_initial.py
@@ -9,14 +9,20 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.CreateModel(
-            name='SizedTextAlterModel',
+            name="SizedTextAlterModel",
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False,
-                 auto_created=True, primary_key=True)),
-                ('field', SizedTextField(size_class=3)),
+                (
+                    "id",
+                    models.AutoField(
+                        verbose_name="ID",
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                ("field", SizedTextField(size_class=3)),
             ],
-            options={
-            },
+            options={},
             bases=(models.Model,),
-        ),
+        )
     ]

--- a/tests/testapp/sizedtextfield_migrations/0002_alter_field.py
+++ b/tests/testapp/sizedtextfield_migrations/0002_alter_field.py
@@ -5,14 +5,12 @@ from django_mysql.models import SizedTextField
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('testapp', '0001_initial'),
-    ]
+    dependencies = [("testapp", "0001_initial")]
 
     operations = [
         migrations.AlterField(
-            model_name='sizedtextaltermodel',
-            name='field',
+            model_name="sizedtextaltermodel",
+            name="field",
             field=SizedTextField(size_class=1),
-        ),
+        )
     ]

--- a/tests/testapp/test_aggregates.py
+++ b/tests/testapp/test_aggregates.py
@@ -8,135 +8,127 @@ from tests.testapp.models import Alphabet, Author
 
 
 class BitAndTests(TestCase):
-
     def test_implicit_name(self):
         Alphabet.objects.bulk_create([Alphabet(a=29), Alphabet(a=15)])
-        out = Alphabet.objects.all().aggregate(BitAnd('a'))
-        assert out == {'a__bitand': 13}
+        out = Alphabet.objects.all().aggregate(BitAnd("a"))
+        assert out == {"a__bitand": 13}
 
     def test_explicit_name(self):
         Alphabet.objects.bulk_create([Alphabet(a=11), Alphabet(a=24)])
-        out = Alphabet.objects.all().aggregate(aaa=BitAnd('a'))
-        assert out == {'aaa': 8}
+        out = Alphabet.objects.all().aggregate(aaa=BitAnd("a"))
+        assert out == {"aaa": 8}
 
     def test_no_rows(self):
-        out = Alphabet.objects.all().aggregate(BitAnd('a'))
+        out = Alphabet.objects.all().aggregate(BitAnd("a"))
         # Manual:
         # "This function returns 18446744073709551615 if there were no matching
         # rows. (This is the value of an unsigned BIGINT value with all bits
         # set to 1.)"
-        assert out == {'a__bitand': 18446744073709551615}
+        assert out == {"a__bitand": 18446744073709551615}
 
 
 class BitOrTests(TestCase):
-
     def test_implicit_name(self):
         Alphabet.objects.bulk_create([Alphabet(a=1), Alphabet(a=84)])
-        out = Alphabet.objects.all().aggregate(BitOr('a'))
-        assert out == {'a__bitor': 85}
+        out = Alphabet.objects.all().aggregate(BitOr("a"))
+        assert out == {"a__bitor": 85}
 
     def test_explicit_name(self):
         Alphabet.objects.bulk_create([Alphabet(a=29), Alphabet(a=15)])
-        out = Alphabet.objects.all().aggregate(aaa=BitOr('a'))
-        assert out == {'aaa': 31}
+        out = Alphabet.objects.all().aggregate(aaa=BitOr("a"))
+        assert out == {"aaa": 31}
 
     def test_no_rows(self):
-        out = Alphabet.objects.all().aggregate(BitOr('a'))
+        out = Alphabet.objects.all().aggregate(BitOr("a"))
         # Manual:
         # "This function returns 0 if there were no matching rows."
-        assert out == {'a__bitor': 0}
+        assert out == {"a__bitor": 0}
 
 
 class BitXorTests(TestCase):
-
     def test_implicit_name(self):
         Alphabet.objects.bulk_create([Alphabet(a=11), Alphabet(a=3)])
-        out = Alphabet.objects.all().aggregate(BitXor('a'))
-        assert out == {'a__bitxor': 8}
+        out = Alphabet.objects.all().aggregate(BitXor("a"))
+        assert out == {"a__bitxor": 8}
 
     def test_explicit_name(self):
         Alphabet.objects.bulk_create([Alphabet(a=123), Alphabet(a=456)])
-        out = Alphabet.objects.all().aggregate(aaa=BitXor('a'))
-        assert out == {'aaa': 435}
+        out = Alphabet.objects.all().aggregate(aaa=BitXor("a"))
+        assert out == {"aaa": 435}
 
     def test_no_rows(self):
-        out = Alphabet.objects.all().aggregate(BitXor('a'))
+        out = Alphabet.objects.all().aggregate(BitXor("a"))
         # Manual:
         # "This function returns 0 if there were no matching rows."
-        assert out == {'a__bitxor': 0}
+        assert out == {"a__bitxor": 0}
 
 
 class GroupConcatTests(TestCase):
-
     def setUp(self):
         super(GroupConcatTests, self).setUp()
-        self.shakes = Author.objects.create(name='William Shakespeare')
-        self.jk = Author.objects.create(name='JK Rowling', tutor=self.shakes)
-        self.grisham = Author.objects.create(name='Grisham', tutor=self.shakes)
+        self.shakes = Author.objects.create(name="William Shakespeare")
+        self.jk = Author.objects.create(name="JK Rowling", tutor=self.shakes)
+        self.grisham = Author.objects.create(name="Grisham", tutor=self.shakes)
 
         self.str_tutee_ids = [str(self.jk.id), str(self.grisham.id)]
 
     def test_basic_aggregate_ids(self):
-        out = self.shakes.tutees.aggregate(tids=GroupConcat('id'))
+        out = self.shakes.tutees.aggregate(tids=GroupConcat("id"))
         concatted_ids = ",".join(self.str_tutee_ids)
-        assert out == {'tids': concatted_ids}
+        assert out == {"tids": concatted_ids}
 
     def test_basic_annotate_ids(self):
-        concat = GroupConcat('tutees__id')
+        concat = GroupConcat("tutees__id")
         shakey = Author.objects.annotate(tids=concat).get(id=self.shakes.id)
         concatted_ids = ",".join(self.str_tutee_ids)
         assert shakey.tids, concatted_ids
 
     def test_separator(self):
-        concat = GroupConcat('id', separator=':')
+        concat = GroupConcat("id", separator=":")
         out = self.shakes.tutees.aggregate(tids=concat)
         concatted_ids = ":".join(self.str_tutee_ids)
-        assert out == {'tids': concatted_ids}
+        assert out == {"tids": concatted_ids}
 
     def test_separator_empty(self):
-        concat = GroupConcat('id', separator='')
+        concat = GroupConcat("id", separator="")
         out = self.shakes.tutees.aggregate(tids=concat)
         concatted_ids = "".join(self.str_tutee_ids)
-        assert out == {'tids': concatted_ids}
+        assert out == {"tids": concatted_ids}
 
     def test_separator_big(self):
-        concat = GroupConcat('id', separator='BIG')
+        concat = GroupConcat("id", separator="BIG")
         out = self.shakes.tutees.aggregate(tids=concat)
         concatted_ids = "BIG".join(self.str_tutee_ids)
-        assert out == {'tids': concatted_ids}
+        assert out == {"tids": concatted_ids}
 
     def test_expression(self):
-        concat = GroupConcat(F('id') + 1)
+        concat = GroupConcat(F("id") + 1)
         out = self.shakes.tutees.aggregate(tids=concat)
-        concatted_ids = ",".join([
-            str(self.jk.id + 1),
-            str(self.grisham.id + 1),
-        ])
-        assert out == {'tids': concatted_ids}
+        concatted_ids = ",".join([str(self.jk.id + 1), str(self.grisham.id + 1)])
+        assert out == {"tids": concatted_ids}
 
     def test_application_order(self):
-        out = (
-            Author.objects.exclude(id=self.shakes.id)
-                          .aggregate(tids=GroupConcat('tutor_id', distinct=True))
+        out = Author.objects.exclude(id=self.shakes.id).aggregate(
+            tids=GroupConcat("tutor_id", distinct=True)
         )
-        assert out == {'tids': str(self.shakes.id)}
+        assert out == {"tids": str(self.shakes.id)}
 
     @override_mysql_variables(SQL_MODE="ANSI")
     def test_separator_ansi_mode(self):
-        concat = GroupConcat('id', separator='>>')
+        concat = GroupConcat("id", separator=">>")
         out = self.shakes.tutees.aggregate(tids=concat)
         concatted_ids = ">>".join(self.str_tutee_ids)
-        assert out == {'tids': concatted_ids}
+        assert out == {"tids": concatted_ids}
 
     def test_ordering_invalid(self):
         with pytest.raises(ValueError) as excinfo:
-            self.shakes.tutees.aggregate(tids=GroupConcat('id', ordering='asceding'))
+            self.shakes.tutees.aggregate(tids=GroupConcat("id", ordering="asceding"))
         assert "'ordering' must be one of" in str(excinfo.value)
 
     def test_ordering_asc(self):
-        out = self.shakes.tutees.aggregate(tids=GroupConcat('id', ordering='asc'))
-        assert out == {'tids': ",".join(self.str_tutee_ids)}
+        out = self.shakes.tutees.aggregate(tids=GroupConcat("id", ordering="asc"))
+        assert out == {"tids": ",".join(self.str_tutee_ids)}
 
     def test_ordering_desc(self):
-        out = self.shakes.tutees.aggregate(tids=GroupConcat('id', ordering='desc'))
-        assert out == {'tids': ",".join(reversed(self.str_tutee_ids))}
+        out = self.shakes.tutees.aggregate(tids=GroupConcat("id", ordering="desc"))
+        assert out == {"tids": ",".join(reversed(self.str_tutee_ids))}

--- a/tests/testapp/test_bit1_field.py
+++ b/tests/testapp/test_bit1_field.py
@@ -47,8 +47,8 @@ class TestSaveLoad(TestCase):
         assert list(Bit1Model.objects.filter(flag_a=True)) == [m]
         assert list(Bit1Model.objects.filter(flag_a=False)) == []
 
-        assert list(Bit1Model.objects.filter(flag_a=F('flag_b'))) == [m]
-        assert list(Bit1Model.objects.exclude(flag_a=F('flag_b'))) == []
+        assert list(Bit1Model.objects.filter(flag_a=F("flag_b"))) == [m]
+        assert list(Bit1Model.objects.exclude(flag_a=F("flag_b"))) == []
 
         m.flag_a = False
         m.save()
@@ -56,8 +56,8 @@ class TestSaveLoad(TestCase):
         assert list(Bit1Model.objects.filter(flag_a=True)) == []
         assert list(Bit1Model.objects.filter(flag_a=False)) == [m]
 
-        assert list(Bit1Model.objects.filter(flag_a=F('flag_b'))) == []
-        assert list(Bit1Model.objects.exclude(flag_a=F('flag_b'))) == [m]
+        assert list(Bit1Model.objects.filter(flag_a=F("flag_b"))) == []
+        assert list(Bit1Model.objects.exclude(flag_a=F("flag_b"))) == [m]
 
         Bit1Model.objects.filter(flag_a=False).update(flag_a=True)
         assert list(Bit1Model.objects.filter(flag_a=True)) == [m]
@@ -69,20 +69,19 @@ class TestSaveLoad(TestCase):
 
 
 class TestSerialization(SimpleTestCase):
-
     def test_dumping(self):
         instance = Bit1Model(flag_a=True, flag_b=False)
-        data = json.loads(serializers.serialize('json', [instance]))[0]
-        fields = data['fields']
-        assert fields['flag_a']
-        assert not fields['flag_b']
+        data = json.loads(serializers.serialize("json", [instance]))[0]
+        fields = data["fields"]
+        assert fields["flag_a"]
+        assert not fields["flag_b"]
 
     def test_loading(self):
-        test_data = '''
+        test_data = """
             [{"fields": {"flag_a": false, "flag_b": true},
               "model": "testapp.Bit1Model", "pk": null}]
-        '''
-        objs = list(serializers.deserialize('json', test_data))
+        """
+        objs = list(serializers.deserialize("json", test_data))
         assert len(objs) == 1
         instance = objs[0].object
         assert not instance.flag_a
@@ -155,19 +154,18 @@ class TestNullSaveLoad(TestCase):
 
 
 class TestNullSerialization(SimpleTestCase):
-
     def test_dumping(self):
         instance = NullBit1Model(flag=None)
-        data = json.loads(serializers.serialize('json', [instance]))[0]
-        fields = data['fields']
-        assert fields['flag'] is None
+        data = json.loads(serializers.serialize("json", [instance]))[0]
+        fields = data["fields"]
+        assert fields["flag"] is None
 
     def test_loading(self):
-        test_data = '''
+        test_data = """
             [{"fields": {"flag": null},
               "model": "testapp.NullBit1Model", "pk": null}]
-        '''
-        objs = list(serializers.deserialize('json', test_data))
+        """
+        objs = list(serializers.deserialize("json", test_data))
         assert len(objs) == 1
         instance = objs[0].object
         assert instance.flag is None

--- a/tests/testapp/test_cache.py
+++ b/tests/testapp/test_cache.py
@@ -43,43 +43,44 @@ class MyInt(int):
 
 def custom_key_func(key, key_prefix, version):
     "A customized cache key function"
-    return 'CUSTOM-' + '-'.join([key_prefix, str(version), key])
+    return "CUSTOM-" + "-".join([key_prefix, str(version), key])
 
 
 def reverse_custom_key_func(full_key):
     "The reverse of custom_key_func"
     # Remove CUSTOM-
-    full_key = full_key[len('CUSTOM-'):]
+    full_key = full_key[len("CUSTOM-") :]
 
-    first_dash = full_key.find('-')
+    first_dash = full_key.find("-")
     key_prefix = full_key[:first_dash]
 
-    second_dash = full_key.find('-', first_dash + 1)
-    version = int(full_key[first_dash + 1:second_dash])
+    second_dash = full_key.find("-", first_dash + 1)
+    version = int(full_key[first_dash + 1 : second_dash])
 
-    key = full_key[second_dash + 1:]
+    key = full_key[second_dash + 1 :]
 
     return key, key_prefix, version
 
 
 _caches_setting_base = {
-    'default': {},
-    'prefix': {'KEY_PREFIX': 'cacheprefix{}'.format(os.getpid())},
-    'v2': {'VERSION': 2},
-    'custom_key': {'KEY_FUNCTION': custom_key_func,
-                   'REVERSE_KEY_FUNCTION': reverse_custom_key_func},
-    'custom_key2': {
-        'KEY_FUNCTION': __name__ + '.custom_key_func',
-        'REVERSE_KEY_FUNCTION': __name__ + '.reverse_custom_key_func',
+    "default": {},
+    "prefix": {"KEY_PREFIX": "cacheprefix{}".format(os.getpid())},
+    "v2": {"VERSION": 2},
+    "custom_key": {
+        "KEY_FUNCTION": custom_key_func,
+        "REVERSE_KEY_FUNCTION": reverse_custom_key_func,
     },
-    'cull': {'OPTIONS': {'CULL_PROBABILITY': 1,
-                         'MAX_ENTRIES': 30}},
-    'zero_cull': {'OPTIONS': {'CULL_FREQUENCY': 0,
-                              'CULL_PROBABILITY': 1,
-                              'MAX_ENTRIES': 30}},
-    'no_cull': {'OPTIONS': {'CULL_FREQUENCY': 2,
-                            'CULL_PROBABILITY': 0,
-                            'MAX_ENTRIES': 30}},
+    "custom_key2": {
+        "KEY_FUNCTION": __name__ + ".custom_key_func",
+        "REVERSE_KEY_FUNCTION": __name__ + ".reverse_custom_key_func",
+    },
+    "cull": {"OPTIONS": {"CULL_PROBABILITY": 1, "MAX_ENTRIES": 30}},
+    "zero_cull": {
+        "OPTIONS": {"CULL_FREQUENCY": 0, "CULL_PROBABILITY": 1, "MAX_ENTRIES": 30}
+    },
+    "no_cull": {
+        "OPTIONS": {"CULL_FREQUENCY": 2, "CULL_PROBABILITY": 0, "MAX_ENTRIES": 30}
+    },
 }
 
 
@@ -93,25 +94,23 @@ def caches_setting_for_tests(options=None, **params):
         cache_params.update(_caches_setting_base[key])
         cache_params.update(params)
         if options is not None:
-            cache_params['OPTIONS'] = cache_params.get('OPTIONS', {}).copy()
-            cache_params['OPTIONS'].update(**options)
+            cache_params["OPTIONS"] = cache_params.get("OPTIONS", {}).copy()
+            cache_params["OPTIONS"].update(**options)
     return setting
 
 
 # Spaces are used in the table name to ensure quoting/escaping is working
-def override_cache_settings(BACKEND='django_mysql.cache.MySQLCache', LOCATION='test cache table', **kwargs):
+def override_cache_settings(
+    BACKEND="django_mysql.cache.MySQLCache", LOCATION="test cache table", **kwargs
+):
     return override_settings(
-        CACHES=caches_setting_for_tests(
-            BACKEND=BACKEND,
-            LOCATION=LOCATION,
-            **kwargs
-        ),
+        CACHES=caches_setting_for_tests(BACKEND=BACKEND, LOCATION=LOCATION, **kwargs)
     )
 
 
 class MySQLCacheTableMixin(TransactionTestCase):
 
-    table_name = 'test cache table'
+    table_name = "test cache table"
 
     @classmethod
     def create_table(self):
@@ -122,12 +121,11 @@ class MySQLCacheTableMixin(TransactionTestCase):
     @classmethod
     def drop_table(self):
         with connection.cursor() as cursor:
-            cursor.execute('DROP TABLE `%s`' % self.table_name)
+            cursor.execute("DROP TABLE `%s`" % self.table_name)
 
 
 @override_cache_settings()
 class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.create_table()
@@ -160,15 +158,15 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
 
     def test_prefix(self):
         # Test for same cache key conflicts between shared backend
-        cache.set('somekey', 'value')
+        cache.set("somekey", "value")
 
         # should not be set in the prefixed cache
-        assert not caches['prefix'].has_key('somekey')  # noqa
+        assert not caches["prefix"].has_key("somekey")  # noqa
 
-        caches['prefix'].set('somekey', 'value2')
+        caches["prefix"].set("somekey", "value2")
 
-        assert cache.get('somekey') == 'value'
-        assert caches['prefix'].get('somekey') == 'value2'
+        assert cache.get("somekey") == "value"
+        assert caches["prefix"].get("somekey") == "value2"
 
     def test_non_existent(self):
         # Non-existent cache keys return as None/default
@@ -201,40 +199,40 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
 
     def test_incr(self):
         # Cache values can be incremented
-        cache.set('answer', 41)
-        assert cache.incr('answer') == 42
-        assert cache.get('answer') == 42
-        assert cache.incr('answer', 10) == 52
-        assert cache.get('answer') == 52
-        assert cache.incr('answer', -10) == 42
+        cache.set("answer", 41)
+        assert cache.incr("answer") == 42
+        assert cache.get("answer") == 42
+        assert cache.incr("answer", 10) == 52
+        assert cache.get("answer") == 52
+        assert cache.incr("answer", -10) == 42
         with pytest.raises(ValueError):
-            cache.incr('does_not_exist')
+            cache.incr("does_not_exist")
 
     def test_decr(self):
         # Cache values can be decremented
-        cache.set('answer', 43)
-        assert cache.decr('answer') == 42
-        assert cache.get('answer') == 42
-        assert cache.decr('answer', 10) == 32
-        assert cache.get('answer') == 32
-        assert cache.decr('answer', -10) == 42
+        cache.set("answer", 43)
+        assert cache.decr("answer") == 42
+        assert cache.get("answer") == 42
+        assert cache.decr("answer", 10) == 32
+        assert cache.get("answer") == 32
+        assert cache.decr("answer", -10) == 42
         with pytest.raises(ValueError):
-            cache.decr('does_not_exist')
+            cache.decr("does_not_exist")
 
     def test_close(self):
-        assert hasattr(cache, 'close')
+        assert hasattr(cache, "close")
         cache.close()
 
     def test_data_types(self):
         # Many different data types can be cached
         stuff = {
-            'string': 'this is a string',
-            'int': 42,
-            'list': [1, 2, 3, 4],
-            'tuple': (1, 2, 3, 4),
-            'dict': {'A': 1, 'B': 2},
-            'function': f,
-            'class': C,
+            "string": "this is a string",
+            "int": 42,
+            "list": [1, 2, 3, 4],
+            "tuple": (1, 2, 3, 4),
+            "dict": {"A": 1, "B": 2},
+            "function": f,
+            "class": C,
         }
         cache.set("stuff", stuff)
         assert cache.get("stuff") == stuff
@@ -246,8 +244,8 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
         my_poll = Poll.objects.create(question="Well?")
         assert Poll.objects.count() == 1
         pub_date = my_poll.pub_date
-        cache.set('question', my_poll)
-        cached_poll = cache.get('question')
+        cache.set("question", my_poll)
+        cached_poll = cache.get("question")
         assert cached_poll.pub_date == pub_date
         # We only want the default expensive calculation run once
         assert expensive_calculation.num_runs == 1
@@ -259,10 +257,10 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
         Poll.objects.all().delete()
         Poll.objects.create(question="What?")
         assert expensive_calculation.num_runs == 1
-        defer_qs = Poll.objects.all().defer('question')
+        defer_qs = Poll.objects.all().defer("question")
         assert defer_qs.count() == 1
         assert expensive_calculation.num_runs == 1
-        cache.set('deferred_queryset', defer_qs)
+        cache.set("deferred_queryset", defer_qs)
         # cache set should not re-evaluate default functions
         assert expensive_calculation.num_runs == 1
 
@@ -272,12 +270,12 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
         Poll.objects.all().delete()
         Poll.objects.create(question="What?")
         assert expensive_calculation.num_runs == 1
-        defer_qs = Poll.objects.all().defer('question')
+        defer_qs = Poll.objects.all().defer("question")
         assert defer_qs.count() == 1
-        cache.set('deferred_queryset', defer_qs)
+        cache.set("deferred_queryset", defer_qs)
         assert expensive_calculation.num_runs == 1
         runs_before_cache_read = expensive_calculation.num_runs
-        cache.get('deferred_queryset')
+        cache.get("deferred_queryset")
         # We only want the default expensive calculation run on creation and
         # set
         assert expensive_calculation.num_runs == runs_before_cache_read
@@ -285,10 +283,10 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
     def test_unicode(self):
         # Unicode values can be cached
         stuff = {
-            'ascii': 'ascii_value',
-            'unicode_ascii': 'Iñtërnâtiônàlizætiøn1',
-            'Iñtërnâtiônàlizætiøn': 'Iñtërnâtiônàlizætiøn2',
-            'ascii2': {'x': 1},
+            "ascii": "ascii_value",
+            "unicode_ascii": "Iñtërnâtiônàlizætiøn1",
+            "Iñtërnâtiônàlizætiøn": "Iñtërnâtiônàlizætiøn2",
+            "ascii2": {"x": 1},
         }
         # Test `set`
         for (key, value) in stuff.items():
@@ -302,7 +300,7 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
             assert cache.get(key) == value
 
         # Test `set_many`
-        for (key, value) in stuff.items():
+        for key, _value in stuff.items():
             cache.delete(key)
         cache.set_many(stuff)
         for (key, value) in stuff.items():
@@ -311,24 +309,25 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
     def test_binary_string(self):
         # Binary strings should be cacheable
         from zlib import compress, decompress
-        value = 'value_to_be_compressed'
+
+        value = "value_to_be_compressed"
         compressed_value = compress(value.encode())
 
         # Test set
-        cache.set('binary1', compressed_value)
-        compressed_result = cache.get('binary1')
+        cache.set("binary1", compressed_value)
+        compressed_result = cache.get("binary1")
         assert compressed_value == compressed_result
         assert value == decompress(compressed_result).decode()
 
         # Test add
-        cache.add('binary1-add', compressed_value)
-        compressed_result = cache.get('binary1-add')
+        cache.add("binary1-add", compressed_value)
+        compressed_result = cache.get("binary1-add")
         assert compressed_value == compressed_result
         assert value == decompress(compressed_result).decode()
 
         # Test set_many
-        cache.set_many({'binary1-set_many': compressed_value})
-        compressed_result = cache.get('binary1-set_many')
+        cache.set_many({"binary1-set_many": compressed_value})
+        compressed_result = cache.get("binary1-set_many")
         assert compressed_value == compressed_result
         assert value == decompress(compressed_result).decode()
 
@@ -359,54 +358,53 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
         assert "key1" not in cache
 
     def test_long_timeout(self):
-        '''
+        """
         Using a timeout greater than 30 days makes memcached think
         it is an absolute expiration timestamp instead of a relative
         offset. Test that we honour this convention. Refs #12399.
-        '''
-        cache.set('key1', 'eggs', 60 * 60 * 24 * 30 + 1)  # 30 days + 1 second
-        assert cache.get('key1') == 'eggs'
+        """
+        cache.set("key1", "eggs", 60 * 60 * 24 * 30 + 1)  # 30 days + 1 second
+        assert cache.get("key1") == "eggs"
 
-        cache.add('key2', 'ham', 60 * 60 * 24 * 30 + 1)
-        assert cache.get('key2') == 'ham'
+        cache.add("key2", "ham", 60 * 60 * 24 * 30 + 1)
+        assert cache.get("key2") == "ham"
 
         cache.set_many(
-            {'key3': 'sausage', 'key4': 'lobster bisque'},
-            60 * 60 * 24 * 30 + 1
+            {"key3": "sausage", "key4": "lobster bisque"}, 60 * 60 * 24 * 30 + 1
         )
-        assert cache.get('key3') == 'sausage'
-        assert cache.get('key4') == 'lobster bisque'
+        assert cache.get("key3") == "sausage"
+        assert cache.get("key4") == "lobster bisque"
 
     def test_forever_timeout(self):
-        '''
+        """
         Passing in None into timeout results in a value that is cached forever
-        '''
-        cache.set('key1', 'eggs', None)
-        assert cache.get('key1') == 'eggs'
+        """
+        cache.set("key1", "eggs", None)
+        assert cache.get("key1") == "eggs"
 
-        cache.add('key2', 'ham', None)
-        assert cache.get('key2') == 'ham'
-        added = cache.add('key1', 'new eggs', None)
+        cache.add("key2", "ham", None)
+        assert cache.get("key2") == "ham"
+        added = cache.add("key1", "new eggs", None)
         assert not added
-        assert cache.get('key1') == 'eggs'
+        assert cache.get("key1") == "eggs"
 
-        cache.set_many({'key3': 'sausage', 'key4': 'lobster bisque'}, None)
-        assert cache.get('key3') == 'sausage'
-        assert cache.get('key4') == 'lobster bisque'
+        cache.set_many({"key3": "sausage", "key4": "lobster bisque"}, None)
+        assert cache.get("key3") == "sausage"
+        assert cache.get("key4") == "lobster bisque"
 
     def test_zero_timeout(self):
-        '''
+        """
         Passing in zero into timeout results in a value that is not cached
-        '''
-        cache.set('key1', 'eggs', 0)
-        assert cache.get('key1') is None
+        """
+        cache.set("key1", "eggs", 0)
+        assert cache.get("key1") is None
 
-        cache.add('key2', 'ham', 0)
-        assert cache.get('key2') is None
+        cache.add("key2", "ham", 0)
+        assert cache.get("key2") is None
 
-        cache.set_many({'key3': 'sausage', 'key4': 'lobster bisque'}, 0)
-        assert cache.get('key3') is None
-        assert cache.get('key4') is None
+        cache.set_many({"key3": "sausage", "key4": "lobster bisque"}, 0)
+        assert cache.get("key3") is None
+        assert cache.get("key4") is None
 
     def test_float_timeout(self):
         # Make sure a timeout given as a float doesn't crash anything.
@@ -415,267 +413,294 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
 
     def test_cache_versioning_get_set(self):
         # set, using default version = 1
-        cache.set('answer1', 42)
-        assert cache.get('answer1') == 42
-        assert cache.get('answer1', version=1) == 42
-        assert cache.get('answer1', version=2) is None
+        cache.set("answer1", 42)
+        assert cache.get("answer1") == 42
+        assert cache.get("answer1", version=1) == 42
+        assert cache.get("answer1", version=2) is None
 
-        assert caches['v2'].get('answer1') is None
-        assert caches['v2'].get('answer1', version=1) == 42
-        assert caches['v2'].get('answer1', version=2) is None
+        assert caches["v2"].get("answer1") is None
+        assert caches["v2"].get("answer1", version=1) == 42
+        assert caches["v2"].get("answer1", version=2) is None
 
         # set, default version = 1, but manually override version = 2
-        cache.set('answer2', 42, version=2)
-        assert cache.get('answer2') is None
-        assert cache.get('answer2', version=1) is None
-        assert cache.get('answer2', version=2) == 42
+        cache.set("answer2", 42, version=2)
+        assert cache.get("answer2") is None
+        assert cache.get("answer2", version=1) is None
+        assert cache.get("answer2", version=2) == 42
 
-        assert caches['v2'].get('answer2') == 42
-        assert caches['v2'].get('answer2', version=1) is None
-        assert caches['v2'].get('answer2', version=2) == 42
+        assert caches["v2"].get("answer2") == 42
+        assert caches["v2"].get("answer2", version=1) is None
+        assert caches["v2"].get("answer2", version=2) == 42
 
         # v2 set, using default version = 2
-        caches['v2'].set('answer3', 42)
-        assert cache.get('answer3') is None
-        assert cache.get('answer3', version=1) is None
-        assert cache.get('answer3', version=2) == 42
+        caches["v2"].set("answer3", 42)
+        assert cache.get("answer3") is None
+        assert cache.get("answer3", version=1) is None
+        assert cache.get("answer3", version=2) == 42
 
-        assert caches['v2'].get('answer3') == 42
-        assert caches['v2'].get('answer3', version=1) is None
-        assert caches['v2'].get('answer3', version=2) == 42
+        assert caches["v2"].get("answer3") == 42
+        assert caches["v2"].get("answer3", version=1) is None
+        assert caches["v2"].get("answer3", version=2) == 42
 
         # v2 set, default version = 2, but manually override version = 1
-        caches['v2'].set('answer4', 42, version=1)
-        assert cache.get('answer4') == 42
-        assert cache.get('answer4', version=1) == 42
-        assert cache.get('answer4', version=2) is None
+        caches["v2"].set("answer4", 42, version=1)
+        assert cache.get("answer4") == 42
+        assert cache.get("answer4", version=1) == 42
+        assert cache.get("answer4", version=2) is None
 
-        assert caches['v2'].get('answer4') is None
-        assert caches['v2'].get('answer4', version=1) == 42
-        assert caches['v2'].get('answer4', version=2) is None
+        assert caches["v2"].get("answer4") is None
+        assert caches["v2"].get("answer4", version=1) == 42
+        assert caches["v2"].get("answer4", version=2) is None
 
     def test_cache_versioning_add(self):
 
         # add, default version = 1, but manually override version = 2
-        cache.add('answer1', 42, version=2)
-        assert cache.get('answer1', version=1) is None
-        assert cache.get('answer1', version=2) == 42
+        cache.add("answer1", 42, version=2)
+        assert cache.get("answer1", version=1) is None
+        assert cache.get("answer1", version=2) == 42
 
-        cache.add('answer1', 37, version=2)
-        assert cache.get('answer1', version=1) is None
-        assert cache.get('answer1', version=2) == 42
+        cache.add("answer1", 37, version=2)
+        assert cache.get("answer1", version=1) is None
+        assert cache.get("answer1", version=2) == 42
 
-        cache.add('answer1', 37, version=1)
-        assert cache.get('answer1', version=1) == 37
-        assert cache.get('answer1', version=2) == 42
+        cache.add("answer1", 37, version=1)
+        assert cache.get("answer1", version=1) == 37
+        assert cache.get("answer1", version=2) == 42
 
         # v2 add, using default version = 2
-        caches['v2'].add('answer2', 42)
-        assert cache.get('answer2', version=1) is None
-        assert cache.get('answer2', version=2) == 42
+        caches["v2"].add("answer2", 42)
+        assert cache.get("answer2", version=1) is None
+        assert cache.get("answer2", version=2) == 42
 
-        caches['v2'].add('answer2', 37)
-        assert cache.get('answer2', version=1) is None
-        assert cache.get('answer2', version=2) == 42
+        caches["v2"].add("answer2", 37)
+        assert cache.get("answer2", version=1) is None
+        assert cache.get("answer2", version=2) == 42
 
-        caches['v2'].add('answer2', 37, version=1)
-        assert cache.get('answer2', version=1) == 37
-        assert cache.get('answer2', version=2) == 42
+        caches["v2"].add("answer2", 37, version=1)
+        assert cache.get("answer2", version=1) == 37
+        assert cache.get("answer2", version=2) == 42
 
         # v2 add, default version = 2, but manually override version = 1
-        caches['v2'].add('answer3', 42, version=1)
-        assert cache.get('answer3', version=1) == 42
-        assert cache.get('answer3', version=2) is None
+        caches["v2"].add("answer3", 42, version=1)
+        assert cache.get("answer3", version=1) == 42
+        assert cache.get("answer3", version=2) is None
 
-        caches['v2'].add('answer3', 37, version=1)
-        assert cache.get('answer3', version=1) == 42
-        assert cache.get('answer3', version=2) is None
+        caches["v2"].add("answer3", 37, version=1)
+        assert cache.get("answer3", version=1) == 42
+        assert cache.get("answer3", version=2) is None
 
-        caches['v2'].add('answer3', 37)
-        assert cache.get('answer3', version=1) == 42
-        assert cache.get('answer3', version=2) == 37
+        caches["v2"].add("answer3", 37)
+        assert cache.get("answer3", version=1) == 42
+        assert cache.get("answer3", version=2) == 37
 
     def test_cache_versioning_has_key(self):
-        cache.set('answer1', 42)
+        cache.set("answer1", 42)
 
         # has_key
-        assert cache.has_key('answer1')  # noqa
-        assert cache.has_key('answer1', version=1)  # noqa
-        assert not cache.has_key('answer1', version=2)  # noqa
+        assert cache.has_key("answer1")  # noqa
+        assert cache.has_key("answer1", version=1)  # noqa
+        assert not cache.has_key("answer1", version=2)  # noqa
 
-        assert not caches['v2'].has_key('answer1')  # noqa
-        assert caches['v2'].has_key('answer1', version=1)  # noqa
-        assert not caches['v2'].has_key('answer1', version=2)  # noqa
+        assert not caches["v2"].has_key("answer1")  # noqa
+        assert caches["v2"].has_key("answer1", version=1)  # noqa
+        assert not caches["v2"].has_key("answer1", version=2)  # noqa
 
     def test_cache_versioning_delete(self):
-        cache.set('answer1', 37, version=1)
-        cache.set('answer1', 42, version=2)
-        cache.delete('answer1')
-        assert cache.get('answer1', version=1) is None
-        assert cache.get('answer1', version=2) == 42
+        cache.set("answer1", 37, version=1)
+        cache.set("answer1", 42, version=2)
+        cache.delete("answer1")
+        assert cache.get("answer1", version=1) is None
+        assert cache.get("answer1", version=2) == 42
 
-        cache.set('answer2', 37, version=1)
-        cache.set('answer2', 42, version=2)
-        cache.delete('answer2', version=2)
-        assert cache.get('answer2', version=1) == 37
-        assert cache.get('answer2', version=2) is None
+        cache.set("answer2", 37, version=1)
+        cache.set("answer2", 42, version=2)
+        cache.delete("answer2", version=2)
+        assert cache.get("answer2", version=1) == 37
+        assert cache.get("answer2", version=2) is None
 
-        cache.set('answer3', 37, version=1)
-        cache.set('answer3', 42, version=2)
-        caches['v2'].delete('answer3')
-        assert cache.get('answer3', version=1) == 37
-        assert cache.get('answer3', version=2) is None
+        cache.set("answer3", 37, version=1)
+        cache.set("answer3", 42, version=2)
+        caches["v2"].delete("answer3")
+        assert cache.get("answer3", version=1) == 37
+        assert cache.get("answer3", version=2) is None
 
-        cache.set('answer4', 37, version=1)
-        cache.set('answer4', 42, version=2)
-        caches['v2'].delete('answer4', version=1)
-        assert cache.get('answer4', version=1) is None
-        assert cache.get('answer4', version=2) == 42
+        cache.set("answer4", 37, version=1)
+        cache.set("answer4", 42, version=2)
+        caches["v2"].delete("answer4", version=1)
+        assert cache.get("answer4", version=1) is None
+        assert cache.get("answer4", version=2) == 42
 
     def test_cache_versioning_incr_decr(self):
-        cache.set('answer1', 37, version=1)
-        cache.set('answer1', 42, version=2)
-        cache.incr('answer1')
-        assert cache.get('answer1', version=1) == 38
-        assert cache.get('answer1', version=2) == 42
-        cache.decr('answer1')
-        assert cache.get('answer1', version=1) == 37
-        assert cache.get('answer1', version=2) == 42
+        cache.set("answer1", 37, version=1)
+        cache.set("answer1", 42, version=2)
+        cache.incr("answer1")
+        assert cache.get("answer1", version=1) == 38
+        assert cache.get("answer1", version=2) == 42
+        cache.decr("answer1")
+        assert cache.get("answer1", version=1) == 37
+        assert cache.get("answer1", version=2) == 42
 
-        cache.set('answer2', 37, version=1)
-        cache.set('answer2', 42, version=2)
-        cache.incr('answer2', version=2)
-        assert cache.get('answer2', version=1) == 37
-        assert cache.get('answer2', version=2) == 43
-        cache.decr('answer2', version=2)
-        assert cache.get('answer2', version=1) == 37
-        assert cache.get('answer2', version=2) == 42
+        cache.set("answer2", 37, version=1)
+        cache.set("answer2", 42, version=2)
+        cache.incr("answer2", version=2)
+        assert cache.get("answer2", version=1) == 37
+        assert cache.get("answer2", version=2) == 43
+        cache.decr("answer2", version=2)
+        assert cache.get("answer2", version=1) == 37
+        assert cache.get("answer2", version=2) == 42
 
-        cache.set('answer3', 37, version=1)
-        cache.set('answer3', 42, version=2)
-        caches['v2'].incr('answer3')
-        assert cache.get('answer3', version=1) == 37
-        assert cache.get('answer3', version=2) == 43
-        caches['v2'].decr('answer3')
-        assert cache.get('answer3', version=1) == 37
-        assert cache.get('answer3', version=2) == 42
+        cache.set("answer3", 37, version=1)
+        cache.set("answer3", 42, version=2)
+        caches["v2"].incr("answer3")
+        assert cache.get("answer3", version=1) == 37
+        assert cache.get("answer3", version=2) == 43
+        caches["v2"].decr("answer3")
+        assert cache.get("answer3", version=1) == 37
+        assert cache.get("answer3", version=2) == 42
 
-        cache.set('answer4', 37, version=1)
-        cache.set('answer4', 42, version=2)
-        caches['v2'].incr('answer4', version=1)
-        assert cache.get('answer4', version=1) == 38
-        assert cache.get('answer4', version=2) == 42
-        caches['v2'].decr('answer4', version=1)
-        assert cache.get('answer4', version=1) == 37
-        assert cache.get('answer4', version=2) == 42
+        cache.set("answer4", 37, version=1)
+        cache.set("answer4", 42, version=2)
+        caches["v2"].incr("answer4", version=1)
+        assert cache.get("answer4", version=1) == 38
+        assert cache.get("answer4", version=2) == 42
+        caches["v2"].decr("answer4", version=1)
+        assert cache.get("answer4", version=1) == 37
+        assert cache.get("answer4", version=2) == 42
 
     def test_cache_versioning_get_set_many(self):
         # set, using default version = 1
-        cache.set_many({'ford1': 37, 'arthur1': 42})
-        assert cache.get_many(['ford1', 'arthur1']) == {'ford1': 37, 'arthur1': 42}
-        assert cache.get_many(['ford1', 'arthur1'], version=1) == {'ford1': 37, 'arthur1': 42}
-        assert cache.get_many(['ford1', 'arthur1'], version=2) == {}
+        cache.set_many({"ford1": 37, "arthur1": 42})
+        assert cache.get_many(["ford1", "arthur1"]) == {"ford1": 37, "arthur1": 42}
+        assert cache.get_many(["ford1", "arthur1"], version=1) == {
+            "ford1": 37,
+            "arthur1": 42,
+        }
+        assert cache.get_many(["ford1", "arthur1"], version=2) == {}
 
-        assert caches['v2'].get_many(['ford1', 'arthur1']) == {}
-        assert caches['v2'].get_many(['ford1', 'arthur1'], version=1) == {'ford1': 37, 'arthur1': 42}
-        assert caches['v2'].get_many(['ford1', 'arthur1'], version=2) == {}
+        assert caches["v2"].get_many(["ford1", "arthur1"]) == {}
+        assert caches["v2"].get_many(["ford1", "arthur1"], version=1) == {
+            "ford1": 37,
+            "arthur1": 42,
+        }
+        assert caches["v2"].get_many(["ford1", "arthur1"], version=2) == {}
 
         # set, default version = 1, but manually override version = 2
-        cache.set_many({'ford2': 37, 'arthur2': 42}, version=2)
-        assert cache.get_many(['ford2', 'arthur2']) == {}
-        assert cache.get_many(['ford2', 'arthur2'], version=1) == {}
-        assert cache.get_many(['ford2', 'arthur2'], version=2) == {'ford2': 37, 'arthur2': 42}
+        cache.set_many({"ford2": 37, "arthur2": 42}, version=2)
+        assert cache.get_many(["ford2", "arthur2"]) == {}
+        assert cache.get_many(["ford2", "arthur2"], version=1) == {}
+        assert cache.get_many(["ford2", "arthur2"], version=2) == {
+            "ford2": 37,
+            "arthur2": 42,
+        }
 
-        assert caches['v2'].get_many(['ford2', 'arthur2']) == {'ford2': 37, 'arthur2': 42}
-        assert caches['v2'].get_many(['ford2', 'arthur2'], version=1) == {}
-        assert (
-            caches['v2'].get_many(['ford2', 'arthur2'], version=2)
-            == {'ford2': 37, 'arthur2': 42}
-        )
+        assert caches["v2"].get_many(["ford2", "arthur2"]) == {
+            "ford2": 37,
+            "arthur2": 42,
+        }
+        assert caches["v2"].get_many(["ford2", "arthur2"], version=1) == {}
+        assert caches["v2"].get_many(["ford2", "arthur2"], version=2) == {
+            "ford2": 37,
+            "arthur2": 42,
+        }
 
         # v2 set, using default version = 2
-        caches['v2'].set_many({'ford3': 37, 'arthur3': 42})
-        assert cache.get_many(['ford3', 'arthur3']) == {}
-        assert cache.get_many(['ford3', 'arthur3'], version=1) == {}
-        assert cache.get_many(['ford3', 'arthur3'], version=2) == {'ford3': 37, 'arthur3': 42}
+        caches["v2"].set_many({"ford3": 37, "arthur3": 42})
+        assert cache.get_many(["ford3", "arthur3"]) == {}
+        assert cache.get_many(["ford3", "arthur3"], version=1) == {}
+        assert cache.get_many(["ford3", "arthur3"], version=2) == {
+            "ford3": 37,
+            "arthur3": 42,
+        }
 
-        assert caches['v2'].get_many(['ford3', 'arthur3']) == {'ford3': 37, 'arthur3': 42}
-        assert caches['v2'].get_many(['ford3', 'arthur3'], version=1) == {}
-        assert caches['v2'].get_many(['ford3', 'arthur3'], version=2) == {'ford3': 37, 'arthur3': 42}
+        assert caches["v2"].get_many(["ford3", "arthur3"]) == {
+            "ford3": 37,
+            "arthur3": 42,
+        }
+        assert caches["v2"].get_many(["ford3", "arthur3"], version=1) == {}
+        assert caches["v2"].get_many(["ford3", "arthur3"], version=2) == {
+            "ford3": 37,
+            "arthur3": 42,
+        }
 
         # v2 set, default version = 2, but manually override version = 1
-        caches['v2'].set_many({'ford4': 37, 'arthur4': 42}, version=1)
-        assert cache.get_many(['ford4', 'arthur4']) == {'ford4': 37, 'arthur4': 42}
-        assert cache.get_many(['ford4', 'arthur4'], version=1) == {'ford4': 37, 'arthur4': 42}
-        assert cache.get_many(['ford4', 'arthur4'], version=2) == {}
+        caches["v2"].set_many({"ford4": 37, "arthur4": 42}, version=1)
+        assert cache.get_many(["ford4", "arthur4"]) == {"ford4": 37, "arthur4": 42}
+        assert cache.get_many(["ford4", "arthur4"], version=1) == {
+            "ford4": 37,
+            "arthur4": 42,
+        }
+        assert cache.get_many(["ford4", "arthur4"], version=2) == {}
 
-        assert caches['v2'].get_many(['ford4', 'arthur4']) == {}
-        assert caches['v2'].get_many(['ford4', 'arthur4'], version=1) == {'ford4': 37, 'arthur4': 42}
-        assert caches['v2'].get_many(['ford4', 'arthur4'], version=2) == {}
+        assert caches["v2"].get_many(["ford4", "arthur4"]) == {}
+        assert caches["v2"].get_many(["ford4", "arthur4"], version=1) == {
+            "ford4": 37,
+            "arthur4": 42,
+        }
+        assert caches["v2"].get_many(["ford4", "arthur4"], version=2) == {}
 
     def test_incr_version(self):
-        cache.set('answer', 42, version=2)
-        assert cache.get('answer') is None
-        assert cache.get('answer', version=1) is None
-        assert cache.get('answer', version=2) == 42
-        assert cache.get('answer', version=3) is None
+        cache.set("answer", 42, version=2)
+        assert cache.get("answer") is None
+        assert cache.get("answer", version=1) is None
+        assert cache.get("answer", version=2) == 42
+        assert cache.get("answer", version=3) is None
 
-        assert cache.incr_version('answer', version=2) == 3
-        assert cache.get('answer') is None
-        assert cache.get('answer', version=1) is None
-        assert cache.get('answer', version=2) is None
-        assert cache.get('answer', version=3) == 42
+        assert cache.incr_version("answer", version=2) == 3
+        assert cache.get("answer") is None
+        assert cache.get("answer", version=1) is None
+        assert cache.get("answer", version=2) is None
+        assert cache.get("answer", version=3) == 42
 
-        caches['v2'].set('answer2', 42)
-        assert caches['v2'].get('answer2') == 42
-        assert caches['v2'].get('answer2', version=1) is None
-        assert caches['v2'].get('answer2', version=2) == 42
-        assert caches['v2'].get('answer2', version=3) is None
+        caches["v2"].set("answer2", 42)
+        assert caches["v2"].get("answer2") == 42
+        assert caches["v2"].get("answer2", version=1) is None
+        assert caches["v2"].get("answer2", version=2) == 42
+        assert caches["v2"].get("answer2", version=3) is None
 
-        assert caches['v2'].incr_version('answer2') == 3
-        assert caches['v2'].get('answer2') is None
-        assert caches['v2'].get('answer2', version=1) is None
-        assert caches['v2'].get('answer2', version=2) is None
-        assert caches['v2'].get('answer2', version=3) == 42
+        assert caches["v2"].incr_version("answer2") == 3
+        assert caches["v2"].get("answer2") is None
+        assert caches["v2"].get("answer2", version=1) is None
+        assert caches["v2"].get("answer2", version=2) is None
+        assert caches["v2"].get("answer2", version=3) == 42
 
         with pytest.raises(ValueError):
-            cache.incr_version('does_not_exist')
+            cache.incr_version("does_not_exist")
 
     def test_decr_version(self):
-        cache.set('answer', 42, version=2)
-        assert cache.get('answer') is None
-        assert cache.get('answer', version=1) is None
-        assert cache.get('answer', version=2) == 42
+        cache.set("answer", 42, version=2)
+        assert cache.get("answer") is None
+        assert cache.get("answer", version=1) is None
+        assert cache.get("answer", version=2) == 42
 
-        assert cache.decr_version('answer', version=2) == 1
-        assert cache.get('answer') == 42
-        assert cache.get('answer', version=1) == 42
-        assert cache.get('answer', version=2) is None
+        assert cache.decr_version("answer", version=2) == 1
+        assert cache.get("answer") == 42
+        assert cache.get("answer", version=1) == 42
+        assert cache.get("answer", version=2) is None
 
-        caches['v2'].set('answer2', 42)
-        assert caches['v2'].get('answer2') == 42
-        assert caches['v2'].get('answer2', version=1) is None
-        assert caches['v2'].get('answer2', version=2) == 42
+        caches["v2"].set("answer2", 42)
+        assert caches["v2"].get("answer2") == 42
+        assert caches["v2"].get("answer2", version=1) is None
+        assert caches["v2"].get("answer2", version=2) == 42
 
-        assert caches['v2'].decr_version('answer2') == 1
-        assert caches['v2'].get('answer2') is None
-        assert caches['v2'].get('answer2', version=1) == 42
-        assert caches['v2'].get('answer2', version=2) is None
+        assert caches["v2"].decr_version("answer2") == 1
+        assert caches["v2"].get("answer2") is None
+        assert caches["v2"].get("answer2", version=1) == 42
+        assert caches["v2"].get("answer2", version=2) is None
 
         with pytest.raises(ValueError):
-            cache.decr_version('does_not_exist', version=2)
+            cache.decr_version("does_not_exist", version=2)
 
     def test_custom_key_func(self):
         # Two caches with different key functions aren't visible to each other
-        cache.set('answer1', 42)
-        assert cache.get('answer1') == 42
-        assert caches['custom_key'].get('answer1') is None
-        assert caches['custom_key2'].get('answer1') is None
+        cache.set("answer1", 42)
+        assert cache.get("answer1") == 42
+        assert caches["custom_key"].get("answer1") is None
+        assert caches["custom_key2"].get("answer1") is None
 
-        caches['custom_key'].set('answer2', 42)
-        assert cache.get('answer2') is None
-        assert caches['custom_key'].get('answer2') == 42
-        assert caches['custom_key2'].get('answer2') == 42
+        caches["custom_key"].set("answer2", 42)
+        assert cache.get("answer2") is None
+        assert caches["custom_key"].get("answer2") == 42
+        assert caches["custom_key2"].get("answer2") == 42
 
     def test_cache_write_unpickable_object(self):
         update_middleware = UpdateCacheMiddleware()
@@ -685,72 +710,72 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
         fetch_middleware.cache = cache
 
         factory = RequestFactory()
-        request = factory.get('/cache/test')
+        request = factory.get("/cache/test")
         request._cache_update_cache = True
         get_cache_data = FetchFromCacheMiddleware().process_request(request)
         assert get_cache_data is None
 
         response = HttpResponse()
-        content = 'Testing cookie serialization.'
+        content = "Testing cookie serialization."
         response.content = content
-        response.set_cookie('foo', 'bar')
+        response.set_cookie("foo", "bar")
 
         update_middleware.process_response(request, response)
 
         get_cache_data = fetch_middleware.process_request(request)
         assert get_cache_data is not None
-        assert get_cache_data.content == content.encode('utf-8')
+        assert get_cache_data.content == content.encode("utf-8")
         assert get_cache_data.cookies == response.cookies
 
         update_middleware.process_response(request, get_cache_data)
         get_cache_data = fetch_middleware.process_request(request)
         assert get_cache_data is not None
-        assert get_cache_data.content == content.encode('utf-8')
+        assert get_cache_data.content == content.encode("utf-8")
         assert get_cache_data.cookies == response.cookies
 
     def test_add_fail_on_pickleerror(self):
         "See https://code.djangoproject.com/ticket/21200"
         with pytest.raises(pickle.PickleError):
-            cache.add('unpickable', Unpickable())
+            cache.add("unpickable", Unpickable())
 
     def test_set_fail_on_pickleerror(self):
         "See https://code.djangoproject.com/ticket/21200"
         with pytest.raises(pickle.PickleError):
-            cache.set('unpickable', Unpickable())
+            cache.set("unpickable", Unpickable())
 
     def test_get_or_set(self):
-        assert cache.get('projector') is None
-        assert cache.get_or_set('projector', 42) == 42
-        assert cache.get('projector') == 42
+        assert cache.get("projector") is None
+        assert cache.get_or_set("projector", 42) == 42
+        assert cache.get("projector") == 42
 
     def test_get_or_set_callable(self):
         def my_callable():
-            return 'value'
+            return "value"
 
-        assert cache.get_or_set('mykey', my_callable) == 'value'
+        assert cache.get_or_set("mykey", my_callable) == "value"
 
     def test_get_or_set_version(self):
         msg_re = r"get_or_set\(\) missing 1 required positional argument: 'default'"
-        cache.get_or_set('brian', 1979, version=2)
+        cache.get_or_set("brian", 1979, version=2)
 
         with pytest.raises(TypeError, match=msg_re):
-            cache.get_or_set('brian')
+            cache.get_or_set("brian")
 
         with pytest.raises(TypeError, match=msg_re):
-            cache.get_or_set('brian', version=1)
+            cache.get_or_set("brian", version=1)
 
-        assert cache.get('brian', version=1) is None
-        assert cache.get_or_set('brian', 42, version=1) == 42
-        assert cache.get_or_set('brian', 1979, version=2) == 1979
-        assert cache.get('brian', version=3) is None
+        assert cache.get("brian", version=1) is None
+        assert cache.get_or_set("brian", 42, version=1) == 42
+        assert cache.get_or_set("brian", 1979, version=2) == 1979
+        assert cache.get("brian", version=3) is None
 
     # Modified Django tests
 
     def test_expiration(self):
         # Cache values can be set to expire
-        cache.set('expire1', 'very quickly', 0.1)
-        cache.set('expire2', 'very quickly', 0.1)
-        cache.set('expire3', 'very quickly', 0.1)
+        cache.set("expire1", "very quickly", 0.1)
+        cache.set("expire2", "very quickly", 0.1)
+        cache.set("expire3", "very quickly", 0.1)
 
         time.sleep(0.2)
         assert cache.get("expire1") is None
@@ -761,54 +786,51 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
 
     def test_get_many(self):
         # Multiple cache keys can be returned using get_many
-        cache.set('a', 'a')
-        cache.set('b', 'b')
-        cache.set('c', 'c')
-        cache.set('d', 'd')
+        cache.set("a", "a")
+        cache.set("b", "b")
+        cache.set("c", "c")
+        cache.set("d", "d")
 
         with self.assertNumQueries(1):
-            value = cache.get_many(['a', 'c', 'd'])
-        assert value == {'a': 'a', 'c': 'c', 'd': 'd'}
+            value = cache.get_many(["a", "c", "d"])
+        assert value == {"a": "a", "c": "c", "d": "d"}
 
         with self.assertNumQueries(1):
-            value = cache.get_many(['a', 'b', 'e'])
+            value = cache.get_many(["a", "b", "e"])
 
-        assert value == {'a': 'a', 'b': 'b'}
+        assert value == {"a": "a", "b": "b"}
 
     def test_get_many_with_one_expired(self):
         # Multiple cache keys can be returned using get_many
-        the_cache = caches['no_cull']
-        the_cache.set('a', 'a', 0.1)
+        the_cache = caches["no_cull"]
+        the_cache.set("a", "a", 0.1)
         time.sleep(0.2)
 
-        the_cache.set('b', 'b')
-        the_cache.set('c', 'c')
-        the_cache.set('d', 'd')
+        the_cache.set("b", "b")
+        the_cache.set("c", "c")
+        the_cache.set("d", "d")
 
         with self.assertNumQueries(1):
-            value = the_cache.get_many(['a', 'c', 'd'])
-        assert value == {'c': 'c', 'd': 'd'}
+            value = the_cache.get_many(["a", "c", "d"])
+        assert value == {"c": "c", "d": "d"}
 
         with self.assertNumQueries(1):
-            value = the_cache.get_many(['a', 'b', 'e'])
+            value = the_cache.get_many(["a", "b", "e"])
 
-        assert value == {'b': 'b'}
+        assert value == {"b": "b"}
 
     def test_set_many(self):
         # Single keys can be set using set_many
         # Perform a single query first to avoid spurious on-connect queries
-        caches['no_cull'].get('nonexistent')
+        caches["no_cull"].get("nonexistent")
 
         with self.assertNumQueries(1):
-            result = caches['no_cull'].set_many({"key1": "spam"})
+            result = caches["no_cull"].set_many({"key1": "spam"})
         assert result == []
 
         # Multiple keys can be set using set_many
         with self.assertNumQueries(1):
-            result = caches['no_cull'].set_many({
-                'key1': 'spam',
-                'key2': 'eggs',
-            })
+            result = caches["no_cull"].set_many({"key1": "spam", "key2": "eggs"})
         assert result == []
         assert cache.get("key1") == "spam"
         assert cache.get("key2") == "eggs"
@@ -816,9 +838,9 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
     def test_set_many_expiration(self):
         # set_many takes a second ``timeout`` parameter
         # Perform a single query first to avoid spurious on-connect queries
-        caches['no_cull'].get('nonexistent')
+        caches["no_cull"].get("nonexistent")
         with self.assertNumQueries(1):
-            caches['no_cull'].set_many({"key1": "spam", "key2": "eggs"}, 0.1)
+            caches["no_cull"].set_many({"key1": "spam", "key2": "eggs"}, 0.1)
         cache.set("key3", "ham")
         time.sleep(0.2)
 
@@ -828,9 +850,8 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
 
         # set_many expired values can be replaced
         with self.assertNumQueries(1):
-            caches['no_cull'].set_many(
-                {"key1": "spam", "key2": "egg", "key3": "spam", "key4": "ham"},
-                1,
+            caches["no_cull"].set_many(
+                {"key1": "spam", "key2": "egg", "key3": "spam", "key4": "ham"}, 1
             )
         v = cache.get("key1")
         assert v == "spam"
@@ -862,12 +883,12 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
             with pytest.warns(CacheKeyWarning):
                 # memcached does not allow whitespace or control characters in
                 # keys
-                cache.set('space key', 'value')
+                cache.set("space key", "value")
 
             with pytest.raises(ValueError):
                 # memcached limits key length to 250
                 # We have a 250 character max length on our table
-                cache.set('a' * 251, 'value')
+                cache.set("a" * 251, "value")
         finally:
             cache.key_func = old_func
 
@@ -875,7 +896,7 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
 
     def test_base_set_bad_value(self):
         with pytest.raises(ValueError) as excinfo:
-            cache._base_set('foo', 'key', 'value')
+            cache._base_set("foo", "key", "value")
         assert "'mode' should be" in str(excinfo.value)
 
     def test_add_with_expired(self):
@@ -892,31 +913,31 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
         assert result
         assert cache.get("mykey") == "newvalue"
 
-    @override_cache_settings(options={'COMPRESS_MIN_LENGTH': 10})
+    @override_cache_settings(options={"COMPRESS_MIN_LENGTH": 10})
     def test_compressed(self):
         cache.set("key", "a" * 11)
         assert cache.get("key") == "a" * 11
 
-    @override_cache_settings(options={'COMPRESS_MIN_LENGTH': 10,
-                                      'COMPRESS_LEVEL': 9})
+    @override_cache_settings(options={"COMPRESS_MIN_LENGTH": 10, "COMPRESS_LEVEL": 9})
     def test_compress_level(self):
         cache.set("key", "a" * 11)
         assert cache.get("key") == "a" * 11
 
         # Check a bad compression level = zlib error
-        with override_cache_settings(options={'COMPRESS_MIN_LENGTH': 10,
-                                              'COMPRESS_LEVEL': 123}):
+        with override_cache_settings(
+            options={"COMPRESS_MIN_LENGTH": 10, "COMPRESS_LEVEL": 123}
+        ):
             with pytest.raises(Exception) as excinfo:
                 cache.set("key", "a" * 11)
             assert "Bad compression level" in str(excinfo.value)
 
-    @override_cache_settings(options={'COMPRESS_MIN_LENGTH': 10})
+    @override_cache_settings(options={"COMPRESS_MIN_LENGTH": 10})
     def test_changing_compressed_option_leaves_compressed_data_readable(self):
         a11 = "a" * 11
         cache.set("key", a11)
 
         # Turn it off - remains readable and settable
-        with override_cache_settings(options={'COMPRESS_MIN_LENGTH': 0}):
+        with override_cache_settings(options={"COMPRESS_MIN_LENGTH": 0}):
             assert cache.get("key") == a11
             cache.set("key", a11)
             assert cache.get("key") == a11
@@ -929,56 +950,57 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
     def test_our_options_quacks_like_djangos(self):
         from django.core.cache.backends.db import Options
         from django_mysql.cache import Options as OurOptions
-        theirs = Options('something')
-        ours = OurOptions('something')
+
+        theirs = Options("something")
+        ours = OurOptions("something")
         assert set(ours.__dict__.keys()) == set(theirs.__dict__.keys())
 
     def test_cull(self):
-        self._perform_cull_test(caches['cull'], 50, 30)
+        self._perform_cull_test(caches["cull"], 50, 30)
 
     def test_zero_cull(self):
-        self._perform_cull_test(caches['zero_cull'], 50, 20)
+        self._perform_cull_test(caches["zero_cull"], 50, 20)
 
     def test_no_cull_only_deletes_when_told(self):
-        self._perform_cull_test(caches['no_cull'], 50, 50)
-        caches['no_cull'].cull()
+        self._perform_cull_test(caches["no_cull"], 50, 50)
+        caches["no_cull"].cull()
         assert self.table_count() == 25
 
     def test_cull_deletes_expired_first(self):
-        cull_cache = caches['cull']
+        cull_cache = caches["cull"]
         cull_cache.set("key", "value", 0.3)
         time.sleep(0.4)
 
         # Add 30 more entries. The expired key should get deleted, leaving the
         # 30 new keys
         self._perform_cull_test(cull_cache, 30, 30)
-        assert cull_cache.get('key') is None
+        assert cull_cache.get("key") is None
 
     def _perform_cull_test(self, cull_cache, initial_count, final_count):
         # Create initial cache key entries. This will overflow the cache,
         # causing a cull.
         for i in range(1, initial_count + 1):
-            cull_cache.set('cull%d' % i, 'value', 1000)
+            cull_cache.set("cull%d" % i, "value", 1000)
         count = 0
         # Count how many keys are left in the cache.
         for i in range(1, initial_count + 1):
-            if cull_cache.has_key('cull%d' % i):  # noqa
+            if cull_cache.has_key("cull%d" % i):  # noqa
                 count = count + 1
         assert count == final_count
 
     def test_incr_range(self):
-        cache.set('overwhelm', BIGINT_SIGNED_MAX - 1)
-        cache.incr('overwhelm')
+        cache.set("overwhelm", BIGINT_SIGNED_MAX - 1)
+        cache.incr("overwhelm")
         if django.VERSION >= (2, 0):
             expected = IntegrityError
         else:
             expected = OperationalError
         with pytest.raises(expected):
-            cache.incr('overwhelm')
+            cache.incr("overwhelm")
 
     def test_decr_range(self):
-        cache.set('underwhelm', BIGINT_SIGNED_MIN + 1)
-        cache.decr('underwhelm')
+        cache.set("underwhelm", BIGINT_SIGNED_MIN + 1)
+        cache.decr("underwhelm")
         if django.VERSION >= (2, 0):
             # IntegrityError on MySQL 5.7+ and MariaDB,
             # OperationalError on MySQL 5.6...
@@ -986,44 +1008,42 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
         else:
             expected = OperationalError
         with pytest.raises(expected):
-            cache.decr('underwhelm')
+            cache.decr("underwhelm")
 
     def test_cant_incr_decimals(self):
         # Cached values that aren't ints can't be incremented
-        cache.set('answer', Decimal('1.1'))
+        cache.set("answer", Decimal("1.1"))
         with pytest.raises(ValueError):
-            cache.incr('answer')
+            cache.incr("answer")
 
     def test_cant_decr_decimals(self):
         # Cached values that aren't ints can't be decremented
-        cache.set('answer', Decimal('9.9'))
+        cache.set("answer", Decimal("9.9"))
         with pytest.raises(ValueError):
-            cache.decr('answer')
+            cache.decr("answer")
 
     def test_set_int_subclass(self):
         # Storing an int subclass should return that int subclass
-        cache.set('myint', MyInt(2))
-        val = cache.get('myint')
+        cache.set("myint", MyInt(2))
+        val = cache.get("myint")
         assert val.times2() == 4
 
         # Can't increment it since it's a pickle object on the table, not an
         # integer
         with pytest.raises(ValueError):
-            cache.incr('myint')
+            cache.incr("myint")
 
     def test_unknown_value_type_errors(self):
         # Unknown value_type values should be errors, since we don't know how
         # to deserialize them. New value_types will probably be introduced by
         # later versions or subclasses of MySQLCache
 
-        cache.set('mykey', 123)
+        cache.set("mykey", 123)
         with connection.cursor() as cursor:
-            cursor.execute(
-                "UPDATE `%s` SET value_type = '?'" % self.table_name,
-            )
+            cursor.execute("UPDATE `%s` SET value_type = '?'" % self.table_name)
 
         with pytest.raises(ValueError):
-            cache.get('mykey')
+            cache.get("mykey")
 
     def test_key_case_sensitivity(self):
         """
@@ -1032,255 +1052,239 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
         At first MySQLCache did not use a binary collation for cache_key, which
         meant it was not case sensitive.
         """
-        cache.set('akey', 123)
-        cache.set('Akey', 456)
-        assert cache.get('akey') == 123
-        assert cache.get('Akey') == 456
+        cache.set("akey", 123)
+        cache.set("Akey", 456)
+        assert cache.get("akey") == 123
+        assert cache.get("Akey") == 456
 
     def test_value_type_case_sensitivity(self):
-        cache.set('akey', 123)
+        cache.set("akey", 123)
         with connection.cursor() as cursor:
             # Check that value_type is 'i' for integer
             cursor.execute("SELECT value_type FROM `%s`" % self.table_name)
             t = cursor.fetchone()[0]
-            assert t == 'i'
+            assert t == "i"
 
             # Should be case-sensitive, so i != I
             cursor.execute(
                 """SELECT COUNT(*) FROM `%s`
-                   WHERE value_type = 'I'""" % self.table_name)
+                   WHERE value_type = 'I'"""
+                % self.table_name
+            )
             n = cursor.fetchone()[0]
             assert n == 0
 
     def test_bad_key_prefix_for_reverse_function(self):
-        override = override_cache_settings(KEY_PREFIX='a:bad:prefix')
+        override = override_cache_settings(KEY_PREFIX="a:bad:prefix")
         with override, pytest.raises(ValueError) as excinfo:
-            caches['default']
-        assert str(excinfo.value).startswith(
-            "Cannot use the default KEY_FUNCTION")
+            caches["default"]
+        assert str(excinfo.value).startswith("Cannot use the default KEY_FUNCTION")
 
-    @parameterized.expand(['default', 'prefix', 'custom_key', 'custom_key2'])
+    @parameterized.expand(["default", "prefix", "custom_key", "custom_key2"])
     def test_keys_with_prefix(self, cache_name):
         cache = caches[cache_name]
-        assert cache.keys_with_prefix('') == set()
-        assert cache.keys_with_prefix('K') == set()
+        assert cache.keys_with_prefix("") == set()
+        assert cache.keys_with_prefix("K") == set()
 
-        cache.set('A2', True)
-        cache.set('K1', True)
-        cache.set('K23', True, 1000)
-        cache.set('K99', True, 0.1)
+        cache.set("A2", True)
+        cache.set("K1", True)
+        cache.set("K23", True, 1000)
+        cache.set("K99", True, 0.1)
         time.sleep(0.2)
-        assert cache.keys_with_prefix('') == {'A2', 'K1', 'K23'}
-        assert cache.keys_with_prefix('K') == {'K1', 'K23'}
+        assert cache.keys_with_prefix("") == {"A2", "K1", "K23"}
+        assert cache.keys_with_prefix("K") == {"K1", "K23"}
 
-        cache.delete('K1')
-        assert cache.keys_with_prefix('K') == {'K23'}
+        cache.delete("K1")
+        assert cache.keys_with_prefix("K") == {"K23"}
 
         cache.clear()
-        assert cache.keys_with_prefix('') == set()
-        assert cache.keys_with_prefix('K') == set()
+        assert cache.keys_with_prefix("") == set()
+        assert cache.keys_with_prefix("K") == set()
 
-    @parameterized.expand(['default', 'prefix', 'custom_key', 'custom_key2'])
+    @parameterized.expand(["default", "prefix", "custom_key", "custom_key2"])
     def test_keys_with_prefix_version(self, cache_name):
         cache = caches[cache_name]
 
-        cache.set('V12', True, version=1)
-        cache.set('V12', True, version=2)
-        cache.set('V2', True, version=2)
-        cache.set('V3', True, version=3)
-        assert cache.keys_with_prefix('V', version=1) == {'V12'}
-        assert cache.keys_with_prefix('V', version=2) == {'V12', 'V2'}
-        assert cache.keys_with_prefix('V', version=3) == {'V3'}
+        cache.set("V12", True, version=1)
+        cache.set("V12", True, version=2)
+        cache.set("V2", True, version=2)
+        cache.set("V3", True, version=3)
+        assert cache.keys_with_prefix("V", version=1) == {"V12"}
+        assert cache.keys_with_prefix("V", version=2) == {"V12", "V2"}
+        assert cache.keys_with_prefix("V", version=3) == {"V3"}
 
     @override_cache_settings(KEY_FUNCTION=custom_key_func)
     def test_keys_with_prefix_with_bad_cache(self):
         with pytest.raises(ValueError) as excinfo:
-            cache.keys_with_prefix('')
-        assert str(excinfo.value).startswith(
-            "To use the _with_prefix commands")
+            cache.keys_with_prefix("")
+        assert str(excinfo.value).startswith("To use the _with_prefix commands")
 
-    @parameterized.expand(['default', 'prefix', 'custom_key', 'custom_key2'])
+    @parameterized.expand(["default", "prefix", "custom_key", "custom_key2"])
     def test_get_with_prefix(self, cache_name):
         cache = caches[cache_name]
-        assert cache.get_with_prefix('') == {}
-        assert cache.get_with_prefix('K') == {}
+        assert cache.get_with_prefix("") == {}
+        assert cache.get_with_prefix("K") == {}
 
-        cache.set('A2', [True])
-        cache.set('K1', "Value1")
-        cache.set('K23', 2, 1000)
-        cache.set('K99', ["Value", 99], 0.1)
+        cache.set("A2", [True])
+        cache.set("K1", "Value1")
+        cache.set("K23", 2, 1000)
+        cache.set("K99", ["Value", 99], 0.1)
         time.sleep(0.2)
-        assert (
-            cache.get_with_prefix('')
-            == {'A2': [True], 'K1': "Value1", 'K23': 2}
-        )
-        assert (
-            cache.get_with_prefix('K')
-            == {'K1': "Value1", 'K23': 2}
-        )
+        assert cache.get_with_prefix("") == {"A2": [True], "K1": "Value1", "K23": 2}
+        assert cache.get_with_prefix("K") == {"K1": "Value1", "K23": 2}
 
-        cache.delete('K1')
-        assert cache.get_with_prefix('K') == {'K23': 2}
+        cache.delete("K1")
+        assert cache.get_with_prefix("K") == {"K23": 2}
 
         cache.clear()
-        assert cache.get_with_prefix('') == {}
-        assert cache.get_with_prefix('K') == {}
+        assert cache.get_with_prefix("") == {}
+        assert cache.get_with_prefix("K") == {}
 
-    @parameterized.expand(['default', 'prefix', 'custom_key', 'custom_key2'])
+    @parameterized.expand(["default", "prefix", "custom_key", "custom_key2"])
     def test_get_with_prefix_version(self, cache_name):
         cache = caches[cache_name]
 
-        cache.set('V12', ('version1',), version=1)
-        cache.set('V12', "str", version=2)
-        cache.set('V2', 2, version=2)
-        cache.set('V3', object, version=3)
-        assert cache.get_with_prefix('V', version=1) == {'V12': ('version1',)}
-        assert cache.get_with_prefix('V', version=2) == {'V12': "str", 'V2': 2}
-        assert cache.get_with_prefix('V', version=3) == {'V3': object}
+        cache.set("V12", ("version1",), version=1)
+        cache.set("V12", "str", version=2)
+        cache.set("V2", 2, version=2)
+        cache.set("V3", object, version=3)
+        assert cache.get_with_prefix("V", version=1) == {"V12": ("version1",)}
+        assert cache.get_with_prefix("V", version=2) == {"V12": "str", "V2": 2}
+        assert cache.get_with_prefix("V", version=3) == {"V3": object}
 
     @override_cache_settings(KEY_FUNCTION=custom_key_func)
     def test_get_with_prefix_with_bad_cache(self):
         with pytest.raises(ValueError) as excinfo:
-            cache.get_with_prefix('')
-        assert str(excinfo.value).startswith(
-            "To use the _with_prefix commands")
+            cache.get_with_prefix("")
+        assert str(excinfo.value).startswith("To use the _with_prefix commands")
 
-    @parameterized.expand(['default', 'prefix', 'custom_key', 'custom_key2'])
+    @parameterized.expand(["default", "prefix", "custom_key", "custom_key2"])
     def test_delete_with_prefix(self, cache_name):
         cache = caches[cache_name]
 
         # Check it runs on an empty cache
-        assert cache.delete_with_prefix('') == 0
-        assert cache.delete_with_prefix('K') == 0
+        assert cache.delete_with_prefix("") == 0
+        assert cache.delete_with_prefix("K") == 0
 
-        cache.set('A1', True)
-        cache.set('A2', True)
-        cache.set('K2', True)
-        cache.set('K44', True)
+        cache.set("A1", True)
+        cache.set("A2", True)
+        cache.set("K2", True)
+        cache.set("K44", True)
 
-        assert cache.keys_with_prefix('') == {'A1', 'A2', 'K2', 'K44'}
-        assert cache.delete_with_prefix('A') == 2
-        assert cache.keys_with_prefix('') == {'K2', 'K44'}
-        assert cache.delete_with_prefix('A') == 0
-        assert cache.keys_with_prefix('') == {'K2', 'K44'}
-        assert cache.delete_with_prefix('K') == 2
-        assert cache.keys_with_prefix('K') == set()
-        assert cache.keys_with_prefix('') == set()
+        assert cache.keys_with_prefix("") == {"A1", "A2", "K2", "K44"}
+        assert cache.delete_with_prefix("A") == 2
+        assert cache.keys_with_prefix("") == {"K2", "K44"}
+        assert cache.delete_with_prefix("A") == 0
+        assert cache.keys_with_prefix("") == {"K2", "K44"}
+        assert cache.delete_with_prefix("K") == 2
+        assert cache.keys_with_prefix("K") == set()
+        assert cache.keys_with_prefix("") == set()
 
-    @parameterized.expand(['default', 'prefix', 'custom_key', 'custom_key2'])
+    @parameterized.expand(["default", "prefix", "custom_key", "custom_key2"])
     def test_delete_with_prefix_version(self, cache_name):
         cache = caches[cache_name]
 
-        cache.set('V12', True, version=1)
-        cache.set('V12', True, version=2)
-        cache.set('V2', True, version=2)
-        cache.set('V3', True, version=3)
+        cache.set("V12", True, version=1)
+        cache.set("V12", True, version=2)
+        cache.set("V2", True, version=2)
+        cache.set("V3", True, version=3)
 
         has_key = cache.has_key  # avoid lint error
 
-        assert cache.delete_with_prefix('V', version=1) == 1
-        assert not has_key('V12', version=1)
-        assert has_key('V12', version=2)
-        assert has_key('V2', version=2)
-        assert has_key('V3', version=3)
+        assert cache.delete_with_prefix("V", version=1) == 1
+        assert not has_key("V12", version=1)
+        assert has_key("V12", version=2)
+        assert has_key("V2", version=2)
+        assert has_key("V3", version=3)
 
-        assert cache.delete_with_prefix('V', version=2) == 2
-        assert not has_key('V12', version=1)
-        assert not has_key('V12', version=2)
-        assert not has_key('V2', version=2)
-        assert has_key('V3', version=3)
+        assert cache.delete_with_prefix("V", version=2) == 2
+        assert not has_key("V12", version=1)
+        assert not has_key("V12", version=2)
+        assert not has_key("V2", version=2)
+        assert has_key("V3", version=3)
 
-        assert cache.delete_with_prefix('V', version=3) == 1
-        assert not has_key('V12', version=1)
-        assert not has_key('V12', version=2)
-        assert not has_key('V2', version=2)
-        assert not has_key('V3', version=3)
+        assert cache.delete_with_prefix("V", version=3) == 1
+        assert not has_key("V12", version=1)
+        assert not has_key("V12", version=2)
+        assert not has_key("V2", version=2)
+        assert not has_key("V3", version=3)
 
     @override_cache_settings(KEY_FUNCTION=custom_key_func)
     def test_delete_with_prefix_with_no_reverse_works(self):
-        cache.set_many({'K1': 'value', 'K2': 'value2', 'B2': 'Anothervalue'})
-        assert cache.delete_with_prefix('K') == 2
-        assert cache.get_many(['K1', 'K2', 'B2']) == {'B2': 'Anothervalue'}
+        cache.set_many({"K1": "value", "K2": "value2", "B2": "Anothervalue"})
+        assert cache.delete_with_prefix("K") == 2
+        assert cache.get_many(["K1", "K2", "B2"]) == {"B2": "Anothervalue"}
 
     def test_mysql_cache_migration_alias(self):
         out = StringIO()
-        call_command('mysql_cache_migration', 'default', stdout=out)
+        call_command("mysql_cache_migration", "default", stdout=out)
         output = out.getvalue()
 
-        num_run_sqls = (len(output.split('RunSQL')) - 1)
+        num_run_sqls = len(output.split("RunSQL")) - 1
         assert num_run_sqls == 1
 
     def test_mysql_cache_migration_non_existent(self):
         out = StringIO()
         with pytest.raises(CommandError):
-            call_command('mysql_cache_migration', 'nonexistent', stdout=out)
+            call_command("mysql_cache_migration", "nonexistent", stdout=out)
 
-    @override_cache_settings(
-        BACKEND='django.core.cache.backends.dummy.DummyCache',
-    )
+    @override_cache_settings(BACKEND="django.core.cache.backends.dummy.DummyCache")
     def test_mysql_cache_migration_no_mysql_caches(self):
         err = StringIO()
-        call_command('mysql_cache_migration', stderr=err)
+        call_command("mysql_cache_migration", stderr=err)
         assert "No MySQLCache instances in CACHES" in err.getvalue()
 
     # cull_mysql_caches tests
 
-    @override_cache_settings(options={'MAX_ENTRIES': -1})
+    @override_cache_settings(options={"MAX_ENTRIES": -1})
     def test_cull_max_entries_minus_one(self):
         # cull with MAX_ENTRIES = -1 should never clear anything that is not
         # expired
 
         # one expired key
-        cache.set('key', 'value', 0.1)
+        cache.set("key", "value", 0.1)
         time.sleep(0.2)
 
         # 90 non-expired keys
         for n in range(9):
-            cache.set_many({
-                str(n * 10 + i): True
-                for i in range(10)
-            })
+            cache.set_many({str(n * 10 + i): True for i in range(10)})
 
         cache.cull()
         assert self.table_count() == 90
 
     def test_cull_mysql_caches_basic(self):
-        cache.set('key', 'value', 0.1)
+        cache.set("key", "value", 0.1)
         time.sleep(0.2)
         assert self.table_count() == 1
-        call_command('cull_mysql_caches', verbosity=0)
+        call_command("cull_mysql_caches", verbosity=0)
         assert self.table_count() == 0
 
     def test_cull_mysql_caches_named_cache(self):
-        cache.set('key', 'value', 0.1)
+        cache.set("key", "value", 0.1)
         time.sleep(0.2)
         assert self.table_count() == 1
 
         out = StringIO()
-        call_command('cull_mysql_caches', 'default', verbosity=1, stdout=out)
+        call_command("cull_mysql_caches", "default", verbosity=1, stdout=out)
         output = out.getvalue()
-        assert (
-            output.strip()
-            == "Deleting from cache 'default'... 1 entries deleted."
-        )
+        assert output.strip() == "Deleting from cache 'default'... 1 entries deleted."
         assert self.table_count() == 0
 
     def test_cull_mysql_caches_bad_cache_name(self):
         with pytest.raises(CommandError) as excinfo:
-            call_command('cull_mysql_caches', "NOTACACHE", verbosity=0)
+            call_command("cull_mysql_caches", "NOTACACHE", verbosity=0)
         assert "Cache 'NOTACACHE' does not exist" == str(excinfo.value)
 
 
 @override_cache_settings()
 class MySQLCacheMigrationTests(MySQLCacheTableMixin, TransactionTestCase):
-
     @pytest.fixture(autouse=True)
     def flake8dir(self, flake8dir):
         self.flake8dir = flake8dir
 
     def test_mysql_cache_migration(self):
         out = StringIO()
-        call_command('mysql_cache_migration', stdout=out)
+        call_command("mysql_cache_migration", stdout=out)
         output = out.getvalue()
 
         # Lint it
@@ -1289,12 +1293,12 @@ class MySQLCacheMigrationTests(MySQLCacheTableMixin, TransactionTestCase):
         assert result.out_lines == []
 
         # Dynamic import and check
-        migration_mod = imp.new_module('0001_add_cache_tables')
+        migration_mod = imp.new_module("0001_add_cache_tables")
         exec(output, migration_mod.__dict__)
-        assert hasattr(migration_mod, 'Migration')
+        assert hasattr(migration_mod, "Migration")
         migration = migration_mod.Migration
-        assert hasattr(migration, 'dependencies')
-        assert hasattr(migration, 'operations')
+        assert hasattr(migration, "dependencies")
+        assert hasattr(migration, "operations")
 
         # Since they all have the same table name, there should only be one
         # operation

--- a/tests/testapp/test_checks.py
+++ b/tests/testapp/test_checks.py
@@ -9,18 +9,18 @@ from django_mysql.test.utils import override_mysql_variables
 class CallCheckTest(TestCase):
 
     if django.VERSION >= (2, 2):
-        databases = ['default', 'other']
+        databases = ["default", "other"]
     else:
         multi_db = True
 
     def test_check(self):
-        call_command('check')
+        call_command("check")
 
 
 class VariablesTests(TransactionTestCase):
 
     if django.VERSION >= (2, 2):
-        databases = ['default', 'other']
+        databases = ["default", "other"]
     else:
         multi_db = True
 
@@ -31,19 +31,19 @@ class VariablesTests(TransactionTestCase):
     def test_fails_if_no_strict(self):
         errors = check_variables([])
         assert len(errors) == 1
-        assert errors[0].id == 'django_mysql.W001'
+        assert errors[0].id == "django_mysql.W001"
         assert "MySQL Strict Mode" in errors[0].msg
 
     @override_mysql_variables(innodb_strict_mode=0)
     def test_fails_if_no_innodb_strict(self):
         errors = check_variables([])
         assert len(errors) == 1
-        assert errors[0].id == 'django_mysql.W002'
+        assert errors[0].id == "django_mysql.W002"
         assert "InnoDB Strict Mode" in errors[0].msg
 
-    @override_mysql_variables(character_set_connection='utf8')
+    @override_mysql_variables(character_set_connection="utf8")
     def test_fails_if_not_utf8mb4(self):
         errors = check_variables([])
         assert len(errors) == 1
-        assert errors[0].id == 'django_mysql.W003'
+        assert errors[0].id == "django_mysql.W003"
         assert "utf8mb4" in errors[0].msg

--- a/tests/testapp/test_enumfield.py
+++ b/tests/testapp/test_enumfield.py
@@ -21,23 +21,23 @@ class TestEnumField(TestCase):
 
     def test_invalid_choices(self):
         with pytest.raises(TypeError) as exc_info:
-            EnumField(choices=['red', 10])
+            EnumField(choices=["red", 10])
         assert 'Invalid choice "10"' in str(exc_info.value)
 
     def test_invalid_max_length(self):
         with pytest.raises(TypeError) as exc_info:
-            EnumField(choices=['red'], max_length=100)
+            EnumField(choices=["red"], max_length=100)
         assert '"max_length" is not a valid argument' in str(exc_info.value)
 
     def test_correct(self):
-        s = EnumModel.objects.create(field='red')
-        assert s.field == 'red'
+        s = EnumModel.objects.create(field="red")
+        assert s.field == "red"
         s = EnumModel.objects.get(id=s.id)
-        assert s.field == 'red'
+        assert s.field == "red"
 
     def test_invalid_value(self):
         with pytest.raises(DataError):
-            EnumModel.objects.create(field='elephant')
+            EnumModel.objects.create(field="elephant")
 
     def test_empty(self):
         with pytest.raises(DataError):
@@ -50,7 +50,7 @@ class TestEnumField(TestCase):
         assert s.field is None
 
     def test_isnull_lookup(self):
-        NullableEnumModel.objects.create(field='goat')
+        NullableEnumModel.objects.create(field="goat")
         s = NullableEnumModel.objects.create()
         actual = NullableEnumModel.objects.filter(field__isnull=True)
         expected = [s]
@@ -58,41 +58,41 @@ class TestEnumField(TestCase):
         assert list(actual) == expected
 
     def test_basic_lookup(self):
-        s1 = EnumModel.objects.create(field='green')
-        EnumModel.objects.create(field='red')
-        s2 = EnumModel.objects.create(field='green')
+        s1 = EnumModel.objects.create(field="green")
+        EnumModel.objects.create(field="red")
+        s2 = EnumModel.objects.create(field="green")
 
-        actual = EnumModel.objects.filter(field='green')
+        actual = EnumModel.objects.filter(field="green")
         expected = [s1, s2]
 
         assert list(actual) == expected
 
     def test_in_lookup(self):
-        s1 = EnumModel.objects.create(field='green')
-        EnumModel.objects.create(field='red')
-        s2 = EnumModel.objects.create(field='green')
+        s1 = EnumModel.objects.create(field="green")
+        EnumModel.objects.create(field="red")
+        s2 = EnumModel.objects.create(field="green")
 
-        actual = EnumModel.objects.filter(field__in=['green'])
+        actual = EnumModel.objects.filter(field__in=["green"])
         expected = [s1, s2]
 
         assert list(actual) == expected
 
     def test_icontains_lookup(self):
-        s1 = EnumModel.objects.create(field='coralBlue')
-        s2 = EnumModel.objects.create(field='blue')
-        EnumModel.objects.create(field='green')
+        s1 = EnumModel.objects.create(field="coralBlue")
+        s2 = EnumModel.objects.create(field="blue")
+        EnumModel.objects.create(field="green")
 
-        actual = EnumModel.objects.filter(field__icontains='Blue')
+        actual = EnumModel.objects.filter(field__icontains="Blue")
         expected = [s1, s2]
 
         assert list(actual) == expected
 
     def test_contains_lookup(self):
-        s1 = EnumModel.objects.create(field='coralblue')
-        s2 = EnumModel.objects.create(field='blue')
-        EnumModel.objects.create(field='green')
+        s1 = EnumModel.objects.create(field="coralblue")
+        s2 = EnumModel.objects.create(field="blue")
+        EnumModel.objects.create(field="green")
 
-        actual = EnumModel.objects.filter(field__contains='blue')
+        actual = EnumModel.objects.filter(field__contains="blue")
         expected = [s1, s2]
 
         assert list(actual) == expected
@@ -101,7 +101,7 @@ class TestEnumField(TestCase):
 class TestCheck(TestCase):
 
     if django.VERSION >= (2, 2):
-        databases = ['default', 'other']
+        databases = ["default", "other"]
     else:
         multi_db = True
 
@@ -111,43 +111,52 @@ class TestCheck(TestCase):
 
 
 class TestDeconstruct(TestCase):
-
     def test_deconstruct(self):
-        field = EnumField(choices=['a', 'b'])
+        field = EnumField(choices=["a", "b"])
         name, path, args, kwargs = field.deconstruct()
-        assert path == 'django_mysql.models.EnumField'
-        assert 'max_length' not in kwargs
+        assert path == "django_mysql.models.EnumField"
+        assert "max_length" not in kwargs
         EnumField(*args, **kwargs)
 
 
 class TestMigrations(TransactionTestCase):
-
-    @override_settings(MIGRATION_MODULES={"testapp": "tests.testapp.enum_default_migrations"})
+    @override_settings(
+        MIGRATION_MODULES={"testapp": "tests.testapp.enum_default_migrations"}
+    )
     def test_adding_field_with_default(self):
-        table_name = 'testapp_enumdefaultmodel'
+        table_name = "testapp_enumdefaultmodel"
         table_names = connection.introspection.table_names
         with connection.cursor() as cursor:
             assert table_name not in table_names(cursor)
 
-        call_command('migrate', 'testapp', verbosity=0, skip_checks=True, interactive=False)
+        call_command(
+            "migrate", "testapp", verbosity=0, skip_checks=True, interactive=False
+        )
         with connection.cursor() as cursor:
             assert table_name in table_names(cursor)
 
-        call_command('migrate', 'testapp', 'zero', verbosity=0, skip_checks=True, interactive=False)
+        call_command(
+            "migrate",
+            "testapp",
+            "zero",
+            verbosity=0,
+            skip_checks=True,
+            interactive=False,
+        )
         with connection.cursor() as cursor:
             assert table_name not in table_names(cursor)
 
 
 class TestFormfield(TestCase):
     def test_formfield(self):
-        model_field = EnumField(choices=['this', 'that'])
+        model_field = EnumField(choices=["this", "that"])
         form_field = model_field.formfield()
 
-        assert form_field.clean('this') == 'this'
-        assert form_field.clean('that') == 'that'
+        assert form_field.clean("this") == "this"
+        assert form_field.clean("that") == "that"
 
         with pytest.raises(ValidationError):
-            form_field.clean('')
+            form_field.clean("")
 
         with pytest.raises(ValidationError):
-            form_field.clean('invalid')
+            form_field.clean("invalid")

--- a/tests/testapp/test_forms.py
+++ b/tests/testapp/test_forms.py
@@ -8,168 +8,184 @@ from django_mysql.forms import JSONField, SimpleListField, SimpleSetField
 
 
 class TestSimpleListField(SimpleTestCase):
-
     def test_valid(self):
         field = SimpleListField(forms.CharField())
-        value = field.clean('a,b,c')
-        assert value == ['a', 'b', 'c']
+        value = field.clean("a,b,c")
+        assert value == ["a", "b", "c"]
 
     def test_to_python_no_leading_commas(self):
         field = SimpleListField(forms.IntegerField())
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean(',1')
-        assert excinfo.value.messages[0] == 'No leading, trailing, or double commas.'
+            field.clean(",1")
+        assert excinfo.value.messages[0] == "No leading, trailing, or double commas."
 
     def test_to_python_no_trailing_commas(self):
         field = SimpleListField(forms.IntegerField())
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('1,')
-        assert excinfo.value.messages[0] == 'No leading, trailing, or double commas.'
+            field.clean("1,")
+        assert excinfo.value.messages[0] == "No leading, trailing, or double commas."
 
     def test_to_python_no_double_commas(self):
         field = SimpleListField(forms.IntegerField())
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('1,,2')
-        assert excinfo.value.messages[0] == 'No leading, trailing, or double commas.'
+            field.clean("1,,2")
+        assert excinfo.value.messages[0] == "No leading, trailing, or double commas."
 
     def test_to_python_base_field_does_not_validate(self):
         field = SimpleListField(forms.IntegerField())
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('a,b,9')
-        assert excinfo.value.messages[0] == 'Item 1 in the list did not validate: Enter a whole number.'
+            field.clean("a,b,9")
+        assert (
+            excinfo.value.messages[0]
+            == "Item 1 in the list did not validate: Enter a whole number."
+        )
 
     def test_validate_fail(self):
         field = SimpleListField(
-            forms.ChoiceField(choices=(('a', 'The letter A'),
-                                       ('b', 'The letter B'))),
+            forms.ChoiceField(choices=(("a", "The letter A"), ("b", "The letter B")))
         )
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('a,c')
-        assert (
-            excinfo.value.messages[0]
-            == 'Item 2 in the list did not validate: Select a valid choice. c is not one of the available choices.'
+            field.clean("a,c")
+        assert excinfo.value.messages[0] == (
+            "Item 2 in the list did not validate: Select a valid choice. "
+            + "c is not one of the available choices."
         )
 
     def test_validators_fail(self):
-        field = SimpleListField(forms.RegexField('[a-e]{2}'))
+        field = SimpleListField(forms.RegexField("[a-e]{2}"))
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('a,bc,de')
-        assert excinfo.value.messages[0] == 'Item 1 in the list did not validate: Enter a valid value.'
+            field.clean("a,bc,de")
+        assert (
+            excinfo.value.messages[0]
+            == "Item 1 in the list did not validate: Enter a valid value."
+        )
 
     def test_validators_fail_base_max_length(self):
         field = SimpleListField(forms.CharField(max_length=5))
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('longer,yes')
-        assert (
-            excinfo.value.messages[0]
-            == 'Item 1 in the list did not validate: Ensure this value has at most 5 characters (it has 6).'
+            field.clean("longer,yes")
+        assert excinfo.value.messages[0] == (
+            "Item 1 in the list did not validate: Ensure this value has "
+            + "at most 5 characters (it has 6)."
         )
 
     def test_validators_fail_base_min_max_length(self):
         # there's just no satisfying some people...
         field = SimpleListField(forms.CharField(min_length=10, max_length=8))
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('undefined')
-        assert (
-            excinfo.value.messages[0]
-            == 'Item 1 in the list did not validate: Ensure this value has at least 10 characters (it has 9).'
+            field.clean("undefined")
+        assert excinfo.value.messages[0] == (
+            "Item 1 in the list did not validate: Ensure this value has "
+            + "at least 10 characters (it has 9)."
         )
-        assert (
-            excinfo.value.messages[1]
-            == 'Item 1 in the list did not validate: Ensure this value has at most 8 characters (it has 9).'
+        assert excinfo.value.messages[1] == (
+            "Item 1 in the list did not validate: Ensure this value has "
+            + "at most 8 characters (it has 9)."
         )
 
     def test_prepare_value(self):
         field = SimpleListField(forms.CharField())
-        value = field.prepare_value(['a', 'b', 'c'])
-        assert value.split(',') == ['a', 'b', 'c']
+        value = field.prepare_value(["a", "b", "c"])
+        assert value.split(",") == ["a", "b", "c"]
 
-        assert field.prepare_value('1,a') == '1,a'
+        assert field.prepare_value("1,a") == "1,a"
 
     def test_max_length(self):
         field = SimpleListField(forms.CharField(), max_length=2)
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('a,b,c')
-        assert excinfo.value.messages[0] == 'List contains 3 items, it should contain no more than 2.'
+            field.clean("a,b,c")
+        assert (
+            excinfo.value.messages[0]
+            == "List contains 3 items, it should contain no more than 2."
+        )
 
     def test_min_length(self):
         field = SimpleListField(forms.CharField(), min_length=4)
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('a,b,c')
-        assert excinfo.value.messages[0] == 'List contains 3 items, it should contain no fewer than 4.'
+            field.clean("a,b,c")
+        assert (
+            excinfo.value.messages[0]
+            == "List contains 3 items, it should contain no fewer than 4."
+        )
 
     def test_required(self):
         field = SimpleListField(forms.CharField(), required=True)
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('')
-        assert excinfo.value.messages[0] == 'This field is required.'
+            field.clean("")
+        assert excinfo.value.messages[0] == "This field is required."
 
 
 class TestSimpleSetField(SimpleTestCase):
-
     def test_valid(self):
         field = SimpleSetField(forms.CharField())
-        value = field.clean('a,b,c')
-        assert value == {'a', 'b', 'c'}
+        value = field.clean("a,b,c")
+        assert value == {"a", "b", "c"}
 
     def test_to_python_no_leading_commas(self):
         field = SimpleSetField(forms.IntegerField())
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean(',1')
-        assert excinfo.value.messages[0] == 'No leading, trailing, or double commas.'
+            field.clean(",1")
+        assert excinfo.value.messages[0] == "No leading, trailing, or double commas."
 
     def test_to_python_no_trailing_commas(self):
         field = SimpleSetField(forms.IntegerField())
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('1,')
-        assert excinfo.value.messages[0] == 'No leading, trailing, or double commas.'
+            field.clean("1,")
+        assert excinfo.value.messages[0] == "No leading, trailing, or double commas."
 
     def test_to_python_no_double_commas(self):
         field = SimpleSetField(forms.IntegerField())
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('1,,2')
-        assert excinfo.value.messages[0] == 'No leading, trailing, or double commas.'
+            field.clean("1,,2")
+        assert excinfo.value.messages[0] == "No leading, trailing, or double commas."
 
     def test_to_python_base_field_does_not_validate(self):
         field = SimpleSetField(forms.IntegerField())
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('a,b,9')
-        assert excinfo.value.messages[0] == 'Item 1 in the set did not validate: Enter a whole number.'
+            field.clean("a,b,9")
+        assert (
+            excinfo.value.messages[0]
+            == "Item 1 in the set did not validate: Enter a whole number."
+        )
 
     def test_to_python_duplicates_not_allowed(self):
         field = SimpleSetField(forms.IntegerField())
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('1,1')
-        assert excinfo.value.messages[0] == "Duplicates are not supported. '1' appears twice or more."
+            field.clean("1,1")
+        assert (
+            excinfo.value.messages[0]
+            == "Duplicates are not supported. '1' appears twice or more."
+        )
 
     def test_to_python_two_duplicates_not_allowed(self):
         field = SimpleSetField(forms.IntegerField())
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('1,2,1,2')
-        assert excinfo.value.messages[0] == "Duplicates are not supported. '1' appears twice or more."
-        assert excinfo.value.messages[1] == "Duplicates are not supported. '2' appears twice or more."
+            field.clean("1,2,1,2")
+        assert (
+            excinfo.value.messages[0]
+            == "Duplicates are not supported. '1' appears twice or more."
+        )
+        assert (
+            excinfo.value.messages[1]
+            == "Duplicates are not supported. '2' appears twice or more."
+        )
 
     def test_validate_fail(self):
         field = SimpleSetField(
-            forms.ChoiceField(
-                choices=[('a', 'The letter A'), ('b', 'The letter B')],
-            ),
+            forms.ChoiceField(choices=[("a", "The letter A"), ("b", "The letter B")])
         )
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('a,c')
-        assert (
-            excinfo.value.messages[0]
-            == (
-                'Item "c" in the set did not validate: '
-                + 'Select a valid choice. c is not one of the available '
-                + 'choices.'
-            )
+            field.clean("a,c")
+        assert excinfo.value.messages[0] == (
+            'Item "c" in the set did not validate: '
+            + "Select a valid choice. c is not one of the available "
+            + "choices."
         )
 
     def test_validators_fail(self):
-        field = SimpleSetField(forms.RegexField('[a-e]{2}'))
+        field = SimpleSetField(forms.RegexField("[a-e]{2}"))
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('a,bc,de')
+            field.clean("a,bc,de")
         assert (
             excinfo.value.messages[0]
             == 'Item "a" in the set did not validate: Enter a valid value.'
@@ -178,94 +194,103 @@ class TestSimpleSetField(SimpleTestCase):
     def test_validators_fail_base_max_length(self):
         field = SimpleSetField(forms.CharField(max_length=5))
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('longer,yes')
-        assert (
-            excinfo.value.messages[0]
-            == 'Item "longer" in the set did not validate: Ensure this value has at most 5 characters (it has 6).'
+            field.clean("longer,yes")
+        assert excinfo.value.messages[0] == (
+            'Item "longer" in the set did not validate: Ensure this value '
+            + "has at most 5 characters (it has 6)."
         )
 
     def test_validators_fail_base_min_max_length(self):
         # there's just no satisfying some people...
         field = SimpleSetField(forms.CharField(min_length=10, max_length=8))
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('undefined')
-        assert (
-            excinfo.value.messages[0]
-            == 'Item "undefined" in the set did not validate: Ensure this value has at least 10 characters (it has 9).'
+            field.clean("undefined")
+        assert excinfo.value.messages[0] == (
+            'Item "undefined" in the set did not validate: Ensure this '
+            + "value has at least 10 characters (it has 9)."
         )
-        assert (
-            excinfo.value.messages[1]
-            == 'Item "undefined" in the set did not validate: Ensure this value has at most 8 characters (it has 9).'
+        assert excinfo.value.messages[1] == (
+            'Item "undefined" in the set did not validate: Ensure this '
+            + "value has at most 8 characters (it has 9)."
         )
 
     def test_prepare_value(self):
         field = SimpleSetField(forms.CharField())
-        value = field.prepare_value({'a', 'b', 'c'})
-        assert list(sorted(value.split(','))) == ['a', 'b', 'c']
-        assert field.prepare_value('1,a') == '1,a'
+        value = field.prepare_value({"a", "b", "c"})
+        assert list(sorted(value.split(","))) == ["a", "b", "c"]
+        assert field.prepare_value("1,a") == "1,a"
 
     def test_max_length(self):
         field = SimpleSetField(forms.CharField(), max_length=2)
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('a,b,c')
-        assert excinfo.value.messages[0] == 'Set contains 3 items, it should contain no more than 2.'
+            field.clean("a,b,c")
+        assert (
+            excinfo.value.messages[0]
+            == "Set contains 3 items, it should contain no more than 2."
+        )
 
     def test_min_length(self):
         field = SimpleSetField(forms.CharField(), min_length=4)
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('a,b,c')
-        assert excinfo.value.messages[0] == 'Set contains 3 items, it should contain no fewer than 4.'
+            field.clean("a,b,c")
+        assert (
+            excinfo.value.messages[0]
+            == "Set contains 3 items, it should contain no fewer than 4."
+        )
 
     def test_required(self):
         field = SimpleSetField(forms.CharField(), required=True)
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('')
-        assert excinfo.value.messages[0] == 'This field is required.'
+            field.clean("")
+        assert excinfo.value.messages[0] == "This field is required."
 
 
 class TestJSONField(SimpleTestCase):
-
     def test_valid(self):
         field = JSONField()
         value = field.clean('{"a": "b"}')
-        assert value == {'a': 'b'}
+        assert value == {"a": "b"}
 
     def test_valid_empty(self):
         field = JSONField(required=False)
-        value = field.clean('')
+        value = field.clean("")
         assert value is None
 
     def test_invalid(self):
         field = JSONField()
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean('{some badly formed: json}')
-        assert excinfo.value.messages[0] == "'{some badly formed: json}' value must be valid JSON."
+            field.clean("{some badly formed: json}")
+        assert (
+            excinfo.value.messages[0]
+            == "'{some badly formed: json}' value must be valid JSON."
+        )
 
     def test_prepare_value(self):
         field = JSONField()
-        assert field.prepare_value({'a': 'b'}) == '{"a": "b"}'
-        assert field.prepare_value(['a', 'b']) == '["a", "b"]'
-        assert field.prepare_value(True) == 'true'
-        assert field.prepare_value(False) == 'false'
-        assert field.prepare_value(3.14) == '3.14'
-        assert field.prepare_value(None) == 'null'
-        assert field.prepare_value('foo') == '"foo"'
+        assert field.prepare_value({"a": "b"}) == '{"a": "b"}'
+        assert field.prepare_value(["a", "b"]) == '["a", "b"]'
+        assert field.prepare_value(True) == "true"
+        assert field.prepare_value(False) == "false"
+        assert field.prepare_value(3.14) == "3.14"
+        assert field.prepare_value(None) == "null"
+        assert field.prepare_value("foo") == '"foo"'
 
     def test_redisplay_wrong_input(self):
         """
         When displaying a bound form (typically due to invalid input), the form
         should not overquote JSONField inputs.
         """
+
         class JsonForm(forms.Form):
             name = forms.CharField(max_length=2)
             jfield = JSONField()
 
         # JSONField input is fine, name is too long
-        form = JsonForm({'name': 'xyz', 'jfield': '["foo"]'})
-        assert '[&quot;foo&quot;]</textarea>' in form.as_p()
+        form = JsonForm({"name": "xyz", "jfield": '["foo"]'})
+        assert "[&quot;foo&quot;]</textarea>" in form.as_p()
 
         # This time, the JSONField input is wrong
-        form = JsonForm({'name': 'xy', 'jfield': '{"foo"}'})
+        form = JsonForm({"name": "xy", "jfield": '{"foo"}'})
         # Appears once in the textarea and once in the error message
         assert form.as_p().count(escape('{"foo"}')) == 2
 
@@ -274,12 +299,12 @@ class TestJSONField(SimpleTestCase):
         tests = [
             '["a", "b", "c"]',
             '{"a": 1, "b": 2}',
-            '1',
-            '1.5',
+            "1",
+            "1.5",
             '"foo"',
-            'true',
-            'false',
-            'null',
+            "true",
+            "false",
+            "null",
         ]
         for json_string in tests:
             val = field.clean(json_string)
@@ -289,5 +314,5 @@ class TestJSONField(SimpleTestCase):
         class JsonForm(forms.Form):
             jfield = JSONField(disabled=True)
 
-        form = JsonForm({'jfield': '["bar"]'}, initial={'jfield': ['foo']})
-        assert '[&quot;foo&quot;]</textarea>' in form.as_p()
+        form = JsonForm({"jfield": '["bar"]'}, initial={"jfield": ["foo"]})
+        assert "[&quot;foo&quot;]</textarea>" in form.as_p()

--- a/tests/testapp/test_functions.py
+++ b/tests/testapp/test_functions.py
@@ -9,9 +9,38 @@ from django.db.models.functions import Length, Lower, Upper
 from django.test import TestCase
 
 from django_mysql.models.functions import (
-    CRC32, ELT, MD5, SHA1, SHA2, Abs, AsType, Ceiling, ColumnAdd, ColumnDelete, ColumnGet, ConcatWS, Field, Floor,
-    Greatest, If, JSONArrayAppend, JSONExtract, JSONInsert, JSONKeys, JSONLength, JSONReplace, JSONSet, LastInsertId,
-    Least, RegexpInstr, RegexpReplace, RegexpSubstr, Round, Sign, UpdateXML, XMLExtractValue,
+    CRC32,
+    ELT,
+    MD5,
+    SHA1,
+    SHA2,
+    Abs,
+    AsType,
+    Ceiling,
+    ColumnAdd,
+    ColumnDelete,
+    ColumnGet,
+    ConcatWS,
+    Field,
+    Floor,
+    Greatest,
+    If,
+    JSONArrayAppend,
+    JSONExtract,
+    JSONInsert,
+    JSONKeys,
+    JSONLength,
+    JSONReplace,
+    JSONSet,
+    LastInsertId,
+    Least,
+    RegexpInstr,
+    RegexpReplace,
+    RegexpSubstr,
+    Round,
+    Sign,
+    UpdateXML,
+    XMLExtractValue,
 )
 from django_mysql.utils import connection_is_mariadb
 from tests.testapp.models import Alphabet, Author, DynamicModel, JSONModel
@@ -20,33 +49,33 @@ from tests.testapp.test_jsonfield import JSONFieldTestCase
 
 
 class ComparisonFunctionTests(TestCase):
-
     def test_greatest(self):
-        Alphabet.objects.create(d='A', e='B')
-        ab = Alphabet.objects.annotate(best=Greatest('d', 'e')).first()
-        assert ab.best == 'B'
+        Alphabet.objects.create(d="A", e="B")
+        ab = Alphabet.objects.annotate(best=Greatest("d", "e")).first()
+        assert ab.best == "B"
 
     def test_greatest_takes_no_kwargs(self):
         with pytest.raises(TypeError):
-            Greatest('a', something='wrong')
+            Greatest("a", something="wrong")
 
     def test_least(self):
         Alphabet.objects.create(a=1, b=2, c=-1)
-        ab = Alphabet.objects.annotate(worst=Least('a', 'b', 'c')).first()
+        ab = Alphabet.objects.annotate(worst=Least("a", "b", "c")).first()
         assert ab.worst == -1
 
 
 class ControlFlowFunctionTests(TestCase):
-
     def test_if_basic(self):
-        Alphabet.objects.create(d='String')
-        Alphabet.objects.create(d='')
-        Alphabet.objects.create(d='String')
-        Alphabet.objects.create(d='')
+        Alphabet.objects.create(d="String")
+        Alphabet.objects.create(d="")
+        Alphabet.objects.create(d="String")
+        Alphabet.objects.create(d="")
 
-        results = list(Alphabet.objects.annotate(
-            has_d=If(Length('d'), Value(True), Value(False)),
-        ).order_by('id').values_list('has_d', flat=True))
+        results = list(
+            Alphabet.objects.annotate(has_d=If(Length("d"), Value(True), Value(False)))
+            .order_by("id")
+            .values_list("has_d", flat=True)
+        )
         assert results == [True, False, True, False]
 
     def test_if_with_Q(self):
@@ -54,96 +83,100 @@ class ControlFlowFunctionTests(TestCase):
         Alphabet.objects.create(a=13, b=17)
         Alphabet.objects.create(a=14, b=17)
 
-        result = list(Alphabet.objects.annotate(
-            conditional=If(Q(a__lte=13), 'a', 'b'),
-        ).order_by('id').values_list('conditional', flat=True))
+        result = list(
+            Alphabet.objects.annotate(conditional=If(Q(a__lte=13), "a", "b"))
+            .order_by("id")
+            .values_list("conditional", flat=True)
+        )
         assert result == [12, 13, 17]
 
     def test_if_with_string_values(self):
-        Alphabet.objects.create(a=1, d='Lentils')
-        Alphabet.objects.create(a=2, d='Cabbage')
-        Alphabet.objects.create(a=3, d='Rice')
+        Alphabet.objects.create(a=1, d="Lentils")
+        Alphabet.objects.create(a=2, d="Cabbage")
+        Alphabet.objects.create(a=3, d="Rice")
 
-        result = list(Alphabet.objects.annotate(
-            conditional=If(Q(a=2), Upper('d'), Lower('d')),
-        ).order_by('id').values_list('conditional', flat=True))
-        assert result == ['lentils', 'CABBAGE', 'rice']
+        result = list(
+            Alphabet.objects.annotate(conditional=If(Q(a=2), Upper("d"), Lower("d")))
+            .order_by("id")
+            .values_list("conditional", flat=True)
+        )
+        assert result == ["lentils", "CABBAGE", "rice"]
 
     def test_if_field_lookups_work(self):
-        Alphabet.objects.create(a=1, d='Lentils')
-        Alphabet.objects.create(a=2, d='Cabbage')
-        Alphabet.objects.create(a=3, d='Rice')
+        Alphabet.objects.create(a=1, d="Lentils")
+        Alphabet.objects.create(a=2, d="Cabbage")
+        Alphabet.objects.create(a=3, d="Rice")
 
-        result = list(Alphabet.objects.annotate(
-            conditional=If(Q(a__gte=2), Upper('d'), Value('')),
-        ).filter(
-            conditional__startswith='C',
-        ).order_by('id').values_list('conditional', flat=True))
-        assert result == ['CABBAGE']
+        result = list(
+            Alphabet.objects.annotate(
+                conditional=If(Q(a__gte=2), Upper("d"), Value(""))
+            )
+            .filter(conditional__startswith="C")
+            .order_by("id")
+            .values_list("conditional", flat=True)
+        )
+        assert result == ["CABBAGE"]
 
     def test_if_false_default_None(self):
         Alphabet.objects.create(a=1)
 
-        result = list(Alphabet.objects.annotate(
-            conditional=If(Q(a=2), Value(1)),
-        ).filter(
-            conditional__isnull=True,
-        ).values_list('conditional', flat=True))
+        result = list(
+            Alphabet.objects.annotate(conditional=If(Q(a=2), Value(1)))
+            .filter(conditional__isnull=True)
+            .values_list("conditional", flat=True)
+        )
         assert result == [None]
 
 
 class NumericFunctionTests(TestCase):
-
     def test_abs(self):
         Alphabet.objects.create(a=-2)
-        ab = Alphabet.objects.annotate(aaa=Abs('a')).first()
+        ab = Alphabet.objects.annotate(aaa=Abs("a")).first()
         assert ab.aaa == 2
 
     def test_ceiling(self):
         Alphabet.objects.create(g=0.5)
-        ab = Alphabet.objects.annotate(gceil=Ceiling('g')).first()
+        ab = Alphabet.objects.annotate(gceil=Ceiling("g")).first()
         assert ab.gceil == 1
 
     def test_crc32(self):
-        Alphabet.objects.create(d='AAAAAA')
-        ab = Alphabet.objects.annotate(crc=CRC32('d')).first()
+        Alphabet.objects.create(d="AAAAAA")
+        ab = Alphabet.objects.annotate(crc=CRC32("d")).first()
         # Precalculated this in MySQL prompt. Python's binascii.crc32 doesn't
         # match - maybe sign issues?
         assert ab.crc == 2854018686
 
     def test_crc32_only_takes_one_arg_no_kwargs(self):
         with pytest.raises(TypeError):
-            CRC32('d', 'c')
+            CRC32("d", "c")
 
         with pytest.raises(TypeError):
-            CRC32('d', something='wrong')
+            CRC32("d", something="wrong")
 
     def test_floor(self):
         Alphabet.objects.create(g=1.5)
-        ab = Alphabet.objects.annotate(gfloor=Floor('g')).first()
+        ab = Alphabet.objects.annotate(gfloor=Floor("g")).first()
         assert ab.gfloor == 1
 
     def test_round(self):
         Alphabet.objects.create(g=24.459)
-        ab = Alphabet.objects.annotate(ground=Round('g')).get()
+        ab = Alphabet.objects.annotate(ground=Round("g")).get()
         assert ab.ground == 24
 
     def test_round_up(self):
         Alphabet.objects.create(g=27.859)
-        ab = Alphabet.objects.annotate(ground=Round('g')).get()
+        ab = Alphabet.objects.annotate(ground=Round("g")).get()
         assert ab.ground == 28
 
     def test_round_places(self):
         Alphabet.objects.create(a=81731)
-        ab = Alphabet.objects.annotate(around=Round('a', -2)).get()
+        ab = Alphabet.objects.annotate(around=Round("a", -2)).get()
         assert ab.around == 81700
 
     def test_sign(self):
         Alphabet.objects.create(a=123, b=0, c=-999)
         ab = Alphabet.objects.annotate(
-            asign=Sign('a'),
-            bsign=Sign('b'),
-            csign=Sign('c'),
+            asign=Sign("a"), bsign=Sign("b"), csign=Sign("c")
         ).first()
         assert ab.asign == 1
         assert ab.bsign == 0
@@ -151,181 +184,176 @@ class NumericFunctionTests(TestCase):
 
 
 class StringFunctionTests(TestCase):
-
     def test_concat_ws(self):
-        Alphabet.objects.create(d='AAA', e='BBB')
-        ab = Alphabet.objects.annotate(de=ConcatWS('d', 'e')).first()
-        assert ab.de == 'AAA,BBB'
+        Alphabet.objects.create(d="AAA", e="BBB")
+        ab = Alphabet.objects.annotate(de=ConcatWS("d", "e")).first()
+        assert ab.de == "AAA,BBB"
 
     def test_concat_ws_integers(self):
         Alphabet.objects.create(a=1, b=2)
-        ab = Alphabet.objects.annotate(ab=ConcatWS('a', 'b')).first()
-        assert ab.ab == '1,2'
+        ab = Alphabet.objects.annotate(ab=ConcatWS("a", "b")).first()
+        assert ab.ab == "1,2"
 
     def test_concat_ws_skips_nulls(self):
-        Alphabet.objects.create(d='AAA', e=None, f=2)
-        ab = Alphabet.objects.annotate(de=ConcatWS('d', 'e', 'f')).first()
-        assert ab.de == 'AAA,2'
+        Alphabet.objects.create(d="AAA", e=None, f=2)
+        ab = Alphabet.objects.annotate(de=ConcatWS("d", "e", "f")).first()
+        assert ab.de == "AAA,2"
 
     def test_concat_ws_separator(self):
-        Alphabet.objects.create(d='AAA', e='BBB')
-        ab = (
-            Alphabet.objects.annotate(de=ConcatWS('d', 'e', separator=':'))
-                            .first()
-        )
-        assert ab.de == 'AAA:BBB'
+        Alphabet.objects.create(d="AAA", e="BBB")
+        ab = Alphabet.objects.annotate(de=ConcatWS("d", "e", separator=":")).first()
+        assert ab.de == "AAA:BBB"
 
     def test_concat_ws_separator_null_returns_none(self):
         Alphabet.objects.create(a=1, b=2)
-        concat = ConcatWS('a', 'b', separator=None)
+        concat = ConcatWS("a", "b", separator=None)
         ab = Alphabet.objects.annotate(ab=concat).first()
         assert ab.ab is None
 
     def test_concat_ws_separator_field(self):
-        Alphabet.objects.create(a=1, d='AAA', e='BBB')
-        concat = ConcatWS('d', 'e', separator=F('a'))
+        Alphabet.objects.create(a=1, d="AAA", e="BBB")
+        concat = ConcatWS("d", "e", separator=F("a"))
         ab = Alphabet.objects.annotate(de=concat).first()
-        assert ab.de == 'AAA1BBB'
+        assert ab.de == "AAA1BBB"
 
     def test_concat_ws_bad_arg(self):
         with pytest.raises(ValueError) as excinfo:
-            ConcatWS('a', 'b', separataaa=',')
-        assert 'Invalid keyword arguments for ConcatWS: separataaa' in str(excinfo.value)
+            ConcatWS("a", "b", separataaa=",")
+        assert "Invalid keyword arguments for ConcatWS: separataaa" in str(
+            excinfo.value
+        )
 
     def test_concat_ws_too_few_fields(self):
         with pytest.raises(ValueError) as excinfo:
-            ConcatWS('a')
-        assert 'ConcatWS must take at least two expressions' in str(excinfo.value)
+            ConcatWS("a")
+        assert "ConcatWS must take at least two expressions" in str(excinfo.value)
 
     def test_concat_ws_then_lookups_from_textfield(self):
-        Alphabet.objects.create(d='AAA', e='BBB')
-        Alphabet.objects.create(d='AAA', e='CCC')
+        Alphabet.objects.create(d="AAA", e="BBB")
+        Alphabet.objects.create(d="AAA", e="CCC")
         ab = (
-            Alphabet.objects.annotate(de=ConcatWS('d', 'e', separator=':'))
-                            .filter(de__endswith=':BBB')
-                            .first()
+            Alphabet.objects.annotate(de=ConcatWS("d", "e", separator=":"))
+            .filter(de__endswith=":BBB")
+            .first()
         )
-        assert ab.de == 'AAA:BBB'
+        assert ab.de == "AAA:BBB"
 
     def test_elt_simple(self):
         Alphabet.objects.create(a=2)
-        ab = Alphabet.objects.annotate(elt=ELT('a', ['apple', 'orange'])).get()
-        assert ab.elt == 'orange'
-        ab = Alphabet.objects.annotate(elt=ELT('a', ['apple'])).get()
+        ab = Alphabet.objects.annotate(elt=ELT("a", ["apple", "orange"])).get()
+        assert ab.elt == "orange"
+        ab = Alphabet.objects.annotate(elt=ELT("a", ["apple"])).get()
         assert ab.elt is None
 
     def test_field_simple(self):
-        Alphabet.objects.create(d='a')
-        ab = Alphabet.objects.annotate(dp=Field('d', ['a', 'b'])).first()
+        Alphabet.objects.create(d="a")
+        ab = Alphabet.objects.annotate(dp=Field("d", ["a", "b"])).first()
         assert ab.dp == 1
-        ab = Alphabet.objects.annotate(dp=Field('d', ['b', 'a'])).first()
+        ab = Alphabet.objects.annotate(dp=Field("d", ["b", "a"])).first()
         assert ab.dp == 2
-        ab = Alphabet.objects.annotate(dp=Field('d', ['c', 'd'])).first()
+        ab = Alphabet.objects.annotate(dp=Field("d", ["c", "d"])).first()
         assert ab.dp == 0
 
     def test_order_by(self):
-        Alphabet.objects.create(a=1, d='AAA')
-        Alphabet.objects.create(a=2, d='CCC')
-        Alphabet.objects.create(a=4, d='BBB')
-        Alphabet.objects.create(a=3, d='BBB')
+        Alphabet.objects.create(a=1, d="AAA")
+        Alphabet.objects.create(a=2, d="CCC")
+        Alphabet.objects.create(a=4, d="BBB")
+        Alphabet.objects.create(a=3, d="BBB")
         avalues = list(
-            Alphabet.objects.order_by(Field('d', ['AAA', 'BBB']), 'a')
-                            .values_list('a', flat=True),
+            Alphabet.objects.order_by(Field("d", ["AAA", "BBB"]), "a").values_list(
+                "a", flat=True
+            )
         )
         assert avalues == [2, 1, 3, 4]
 
 
 class XMLFunctionTests(TestCase):
-
     def test_updatexml_simple(self):
-        Alphabet.objects.create(d='<value>123</value>')
-        Alphabet.objects.update(
-            d=UpdateXML('d', '/value', '<value>456</value>'),
-        )
+        Alphabet.objects.create(d="<value>123</value>")
+        Alphabet.objects.update(d=UpdateXML("d", "/value", "<value>456</value>"))
         d = Alphabet.objects.get().d
-        assert d == '<value>456</value>'
+        assert d == "<value>456</value>"
 
     def test_updatexml_annotate(self):
-        Alphabet.objects.create(d='<value>123</value>')
-        d2 = Alphabet.objects.annotate(
-            d2=UpdateXML('d', '/value', '<value>456</value>'),
-        ).get().d2
-        assert d2 == '<value>456</value>'
+        Alphabet.objects.create(d="<value>123</value>")
+        d2 = (
+            Alphabet.objects.annotate(d2=UpdateXML("d", "/value", "<value>456</value>"))
+            .get()
+            .d2
+        )
+        assert d2 == "<value>456</value>"
 
     def test_xmlextractvalue_simple(self):
-        Alphabet.objects.create(d='<some><xml /></some>')
-        Alphabet.objects.create(d='<someother><xml /></someother>')
-        Alphabet.objects.create(d='<some></some><some></some>')
+        Alphabet.objects.create(d="<some><xml /></some>")
+        Alphabet.objects.create(d="<someother><xml /></someother>")
+        Alphabet.objects.create(d="<some></some><some></some>")
         evs = list(
-            Alphabet.objects.annotate(ev=XMLExtractValue('d', 'count(/some)'))
-                            .values_list('ev', flat=True),
+            Alphabet.objects.annotate(
+                ev=XMLExtractValue("d", "count(/some)")
+            ).values_list("ev", flat=True)
         )
-        assert evs == ['1', '0', '2']
+        assert evs == ["1", "0", "2"]
 
     def test_xmlextractvalue_invalid_xml(self):
         Alphabet.objects.create(d='{"this": "isNotXML"}')
-        ab = (
-            Alphabet.objects.annotate(ev=XMLExtractValue('d', '/some'))
-                            .first()
-        )
-        assert ab.ev == ''
+        ab = Alphabet.objects.annotate(ev=XMLExtractValue("d", "/some")).first()
+        assert ab.ev == ""
 
 
 class EncryptionFunctionTests(TestCase):
-
     def test_md5_string(self):
-        string = 'A string'
+        string = "A string"
         Alphabet.objects.create(d=string)
-        pymd5 = hashlib.md5(string.encode('ascii')).hexdigest()
-        ab = Alphabet.objects.annotate(md5=MD5('d')).first()
+        pymd5 = hashlib.md5(string.encode("ascii")).hexdigest()
+        ab = Alphabet.objects.annotate(md5=MD5("d")).first()
         assert ab.md5 == pymd5
 
     def test_sha1_string(self):
-        string = 'A string'
+        string = "A string"
         Alphabet.objects.create(d=string)
-        pysha1 = hashlib.sha1(string.encode('ascii')).hexdigest()
-        ab = Alphabet.objects.annotate(sha=SHA1('d')).first()
+        pysha1 = hashlib.sha1(string.encode("ascii")).hexdigest()
+        ab = Alphabet.objects.annotate(sha=SHA1("d")).first()
         assert ab.sha == pysha1
 
     def test_sha2_string(self):
-        string = 'A string'
+        string = "A string"
         Alphabet.objects.create(d=string)
 
         for hash_len in (224, 256, 384, 512):
-            sha_func = getattr(hashlib, 'sha{}'.format(hash_len))
-            pysha = sha_func(string.encode('ascii')).hexdigest()
-            ab = Alphabet.objects.annotate(sha=SHA2('d', hash_len)).first()
+            sha_func = getattr(hashlib, "sha{}".format(hash_len))
+            pysha = sha_func(string.encode("ascii")).hexdigest()
+            ab = Alphabet.objects.annotate(sha=SHA2("d", hash_len)).first()
             assert ab.sha == pysha
 
     def test_sha2_string_hash_len_default(self):
-        string = 'A string'
+        string = "A string"
         Alphabet.objects.create(d=string)
-        pysha512 = hashlib.sha512(string.encode('ascii')).hexdigest()
-        ab = Alphabet.objects.annotate(sha=SHA2('d')).first()
+        pysha512 = hashlib.sha512(string.encode("ascii")).hexdigest()
+        ab = Alphabet.objects.annotate(sha=SHA2("d")).first()
         assert ab.sha == pysha512
 
     def test_sha2_bad_hash_len(self):
         with pytest.raises(ValueError):
-            SHA2('a', 123)
+            SHA2("a", 123)
 
 
 class InformationFunctionTests(TestCase):
 
     if django.VERSION >= (2, 2):
-        databases = ['default', 'other']
+        databases = ["default", "other"]
     else:
         multi_db = True
 
     def test_last_insert_id(self):
         Alphabet.objects.create(a=7891)
-        Alphabet.objects.update(a=LastInsertId('a') + 1)
+        Alphabet.objects.update(a=LastInsertId("a") + 1)
         lid = LastInsertId.get()
         assert lid == 7891
 
     def test_last_insert_id_other_db_connection(self):
-        Alphabet.objects.using('other').create(a=9191)
-        Alphabet.objects.using('other').update(a=LastInsertId('a') + 9)
-        lid = LastInsertId.get(using='other')
+        Alphabet.objects.using("other").create(a=9191)
+        Alphabet.objects.using("other").update(a=LastInsertId("a") + 9)
+        lid = LastInsertId.get(using="other")
         assert lid == 9191
 
     def test_last_insert_id_in_query(self):
@@ -333,7 +361,7 @@ class InformationFunctionTests(TestCase):
         ab2 = Alphabet.objects.create(a=1838, b=12636)
 
         # Delete but store value of b and re-assign it to first second Alphabet
-        Alphabet.objects.filter(id=ab1.id, b=LastInsertId('b')).delete()
+        Alphabet.objects.filter(id=ab1.id, b=LastInsertId("b")).delete()
         Alphabet.objects.filter(id=ab2.id).update(b=LastInsertId())
 
         ab = Alphabet.objects.get()
@@ -341,33 +369,34 @@ class InformationFunctionTests(TestCase):
 
 
 class JSONFunctionTests(JSONFieldTestCase):
-
     def setUp(self):
         super(JSONFunctionTests, self).setUp()
-        self.obj = JSONModel.objects.create(attrs={
-            'int': 88,
-            'flote': 1.5,
-            'sub': {
-                'document': 'store',
-            },
-            'arr': ['dee', 'arr', 'arr'],
-        })
+        self.obj = JSONModel.objects.create(
+            attrs={
+                "int": 88,
+                "flote": 1.5,
+                "sub": {"document": "store"},
+                "arr": ["dee", "arr", "arr"],
+            }
+        )
 
     def test_json_extract_kwarg_bad(self):
         with pytest.raises(TypeError) as excinfo:
-            JSONExtract('foo', 'bar', foo=1)
-        assert str(excinfo.value) == "__init__() got an unexpected keyword argument 'foo'"
+            JSONExtract("foo", "bar", foo=1)
+        assert (
+            str(excinfo.value) == "__init__() got an unexpected keyword argument 'foo'"
+        )
 
     def test_json_extract_output_field_too_many_paths(self):
         with pytest.raises(TypeError) as excinfo:
-            JSONExtract('foo', 'bar', 'baz', output_field=1)
+            JSONExtract("foo", "bar", "baz", output_field=1)
         assert "output_field won't work with more than one path" in str(excinfo.value)
 
     def test_json_extract_flote(self):
         results = list(
-            JSONModel.objects.annotate(
-                x=JSONExtract('attrs', '$.flote'),
-            ).values_list('x', flat=True),
+            JSONModel.objects.annotate(x=JSONExtract("attrs", "$.flote")).values_list(
+                "x", flat=True
+            )
         )
         assert results == [1.5]
         assert isinstance(results[0], float)
@@ -375,10 +404,10 @@ class JSONFunctionTests(JSONFieldTestCase):
     def test_json_extract_flote_as_float(self):
         results = list(
             JSONModel.objects.annotate(
-                x=JSONExtract('attrs', '$.flote', output_field=FloatField()),
-            ).filter(
-                x__gt=0.1,
-            ).values_list('x', flat=True),
+                x=JSONExtract("attrs", "$.flote", output_field=FloatField())
+            )
+            .filter(x__gt=0.1)
+            .values_list("x", flat=True)
         )
         assert results == [1.5]
         assert isinstance(results[0], float)
@@ -386,8 +415,8 @@ class JSONFunctionTests(JSONFieldTestCase):
     def test_json_extract_multiple(self):
         results = list(
             JSONModel.objects.annotate(
-                x=JSONExtract('attrs', '$.int', '$.flote'),
-            ).values_list('x', flat=True),
+                x=JSONExtract("attrs", "$.int", "$.flote")
+            ).values_list("x", flat=True)
         )
         assert results == [[88, 1.5]]
         assert isinstance(results[0][0], int)
@@ -395,190 +424,175 @@ class JSONFunctionTests(JSONFieldTestCase):
 
     def test_json_extract_filter(self):
         results = list(
-            JSONModel.objects.annotate(
-                x=JSONExtract('attrs', '$.sub'),
-            ).filter(
-                x={'document': 'store'},
-            ),
+            JSONModel.objects.annotate(x=JSONExtract("attrs", "$.sub")).filter(
+                x={"document": "store"}
+            )
         )
         assert results == [self.obj]
 
     def test_json_keys(self):
         results = list(
-            JSONModel.objects.annotate(
-                x=JSONKeys('attrs'),
-            ).values_list('x', flat=True),
+            JSONModel.objects.annotate(x=JSONKeys("attrs")).values_list("x", flat=True)
         )
         assert set(results[0]) == set(self.obj.attrs.keys())
 
     def test_json_keys_path(self):
         results = list(
-            JSONModel.objects.annotate(
-                x=JSONKeys('attrs', '$.sub'),
-            ).values_list('x', flat=True),
+            JSONModel.objects.annotate(x=JSONKeys("attrs", "$.sub")).values_list(
+                "x", flat=True
+            )
         )
-        assert set(results[0]) == set(self.obj.attrs['sub'].keys())
+        assert set(results[0]) == set(self.obj.attrs["sub"].keys())
 
     def test_json_length(self):
         results = list(
-            JSONModel.objects.annotate(
-                x=JSONLength('attrs'),
-            ).values_list('x', flat=True),
+            JSONModel.objects.annotate(x=JSONLength("attrs")).values_list(
+                "x", flat=True
+            )
         )
         assert results == [len(self.obj.attrs)]
 
     def test_json_length_path(self):
         results = list(
-            JSONModel.objects.annotate(
-                x=JSONLength('attrs', '$.sub'),
-            ).values_list('x', flat=True),
+            JSONModel.objects.annotate(x=JSONLength("attrs", "$.sub")).values_list(
+                "x", flat=True
+            )
         )
-        assert results == [len(self.obj.attrs['sub'])]
+        assert results == [len(self.obj.attrs["sub"])]
 
     def test_json_length_type(self):
         results = list(
-            JSONModel.objects.annotate(
-                x=JSONLength('attrs'),
-            ).filter(x__range=[3, 5]),
+            JSONModel.objects.annotate(x=JSONLength("attrs")).filter(x__range=[3, 5])
         )
         assert results == [self.obj]
 
     def test_json_insert(self):
-        self.obj.attrs = JSONInsert('attrs', {'$.int': 99, '$.int2': 102})
+        self.obj.attrs = JSONInsert("attrs", {"$.int": 99, "$.int2": 102})
         self.obj.save()
         self.obj.refresh_from_db()
-        assert self.obj.attrs['int'] == 88
-        assert self.obj.attrs['int2'] == 102
+        assert self.obj.attrs["int"] == 88
+        assert self.obj.attrs["int2"] == 102
 
     def test_json_insert_dict(self):
         self.obj.attrs = JSONInsert(
-            'attrs',
-            {'$.sub': {'paper': 'drop'}, '$.sub2': {'int': 42, 'foo': 'bar'}},
+            "attrs", {"$.sub": {"paper": "drop"}, "$.sub2": {"int": 42, "foo": "bar"}}
         )
         self.obj.save()
         self.obj.refresh_from_db()
-        assert self.obj.attrs['sub'] == {'document': 'store'}
-        assert self.obj.attrs['sub2']['int'] == 42
-        assert self.obj.attrs['sub2']['foo'] == 'bar'
+        assert self.obj.attrs["sub"] == {"document": "store"}
+        assert self.obj.attrs["sub2"]["int"] == 42
+        assert self.obj.attrs["sub2"]["foo"] == "bar"
 
     def test_json_insert_array(self):
         self.obj.attrs = JSONInsert(
-            'attrs',
-            {'$.arr': [1, 'two', 3], '$.arr2': ['one', 2]},
+            "attrs", {"$.arr": [1, "two", 3], "$.arr2": ["one", 2]}
         )
         self.obj.save()
         self.obj.refresh_from_db()
-        assert self.obj.attrs['arr'] == ['dee', 'arr', 'arr']
-        assert self.obj.attrs['arr2'][0] == 'one'
-        assert self.obj.attrs['arr2'][1] == 2
+        assert self.obj.attrs["arr"] == ["dee", "arr", "arr"]
+        assert self.obj.attrs["arr2"][0] == "one"
+        assert self.obj.attrs["arr2"][1] == 2
 
     def test_json_insert_empty_data(self):
         with pytest.raises(ValueError) as excinfo:
-            JSONInsert('attrs', {})
+            JSONInsert("attrs", {})
         assert '"data" cannot be empty' in str(excinfo.value)
 
     def test_json_replace_pairs(self):
-        self.obj.attrs = JSONReplace('attrs', {'$.int': 101, '$.int2': 102})
+        self.obj.attrs = JSONReplace("attrs", {"$.int": 101, "$.int2": 102})
         self.obj.save()
         self.obj.refresh_from_db()
-        assert self.obj.attrs['int'] == 101
-        assert 'int2' not in self.obj.attrs
+        assert self.obj.attrs["int"] == 101
+        assert "int2" not in self.obj.attrs
 
     def test_json_replace_dict(self):
         self.obj.attrs = JSONReplace(
-            'attrs',
-            {'$.sub': {'paper': 'drop'}, '$.sub2': {'int': 42, 'foo': 'bar'}},
+            "attrs", {"$.sub": {"paper": "drop"}, "$.sub2": {"int": 42, "foo": "bar"}}
         )
         self.obj.save()
         self.obj.refresh_from_db()
-        assert self.obj.attrs['sub'] == {'paper': 'drop'}
-        assert 'sub2' not in self.obj.attrs
+        assert self.obj.attrs["sub"] == {"paper": "drop"}
+        assert "sub2" not in self.obj.attrs
 
     def test_json_replace_array(self):
         self.obj.attrs = JSONReplace(
-            'attrs',
-            {'$.arr': [1, 'two', 3], '$.arr2': ['one', 2]},
+            "attrs", {"$.arr": [1, "two", 3], "$.arr2": ["one", 2]}
         )
         self.obj.save()
         self.obj.refresh_from_db()
-        assert self.obj.attrs['arr'] == [1, 'two', 3]
-        assert 'arr2' not in self.obj.attrs
+        assert self.obj.attrs["arr"] == [1, "two", 3]
+        assert "arr2" not in self.obj.attrs
 
     def test_json_replace_empty_data(self):
         with pytest.raises(ValueError) as excinfo:
-            JSONReplace('attrs', {})
+            JSONReplace("attrs", {})
         assert '"data" cannot be empty' in str(excinfo.value)
 
     def test_json_set_pairs(self):
-        self.obj.attrs = JSONSet('attrs', {'$.int': 101, '$.int2': 102})
+        self.obj.attrs = JSONSet("attrs", {"$.int": 101, "$.int2": 102})
         self.obj.save()
         self.obj.refresh_from_db()
-        assert self.obj.attrs['int'] == 101
-        assert self.obj.attrs['int2'] == 102
+        assert self.obj.attrs["int"] == 101
+        assert self.obj.attrs["int2"] == 102
 
     def test_json_set_dict(self):
         self.obj.attrs = JSONSet(
-            'attrs',
-            {'$.sub': {'paper': 'drop'}, '$.sub2': {'int': 42, 'foo': 'bar'}},
+            "attrs", {"$.sub": {"paper": "drop"}, "$.sub2": {"int": 42, "foo": "bar"}}
         )
         self.obj.save()
         self.obj.refresh_from_db()
-        assert self.obj.attrs['sub'] == {'paper': 'drop'}
-        assert self.obj.attrs['sub2']['int'] == 42
-        assert self.obj.attrs['sub2']['foo'] == 'bar'
+        assert self.obj.attrs["sub"] == {"paper": "drop"}
+        assert self.obj.attrs["sub2"]["int"] == 42
+        assert self.obj.attrs["sub2"]["foo"] == "bar"
 
     def test_json_set_array(self):
         self.obj.attrs = JSONSet(
-            'attrs',
-            {'$.arr': [1, 'two', 3], '$.arr2': ['one', 2]},
+            "attrs", {"$.arr": [1, "two", 3], "$.arr2": ["one", 2]}
         )
         self.obj.save()
         self.obj.refresh_from_db()
-        assert self.obj.attrs['arr'] == [1, 'two', 3]
-        assert self.obj.attrs['arr2'][0] == 'one'
-        assert self.obj.attrs['arr2'][1] == 2
+        assert self.obj.attrs["arr"] == [1, "two", 3]
+        assert self.obj.attrs["arr2"][0] == "one"
+        assert self.obj.attrs["arr2"][1] == 2
 
     def test_json_set_complex_data(self):
         data = {
-            'list': ['one', {'int': 2}, None],
-            'dict': {
-                'sub_list': [1, ['two', 3]],
-                'sub_dict': {'paper': 'drop'},
-                'sub_null': None,
+            "list": ["one", {"int": 2}, None],
+            "dict": {
+                "sub_list": [1, ["two", 3]],
+                "sub_dict": {"paper": "drop"},
+                "sub_null": None,
             },
-            'empty': [],
-            'null': None,
-            'value': 11,
+            "empty": [],
+            "null": None,
+            "value": 11,
         }
-        self.obj.attrs = JSONSet('attrs', {'$.data': data})
+        self.obj.attrs = JSONSet("attrs", {"$.data": data})
         self.obj.save()
         self.obj.refresh_from_db()
-        assert self.obj.attrs['data'] == data
+        assert self.obj.attrs["data"] == data
 
     def test_json_set_empty_data(self):
         with pytest.raises(ValueError) as excinfo:
-            JSONSet('attrs', {})
+            JSONSet("attrs", {})
         assert '"data" cannot be empty' in str(excinfo.value)
 
     def test_json_array_append(self):
         self.obj.attrs = JSONArrayAppend(
-            'attrs',
-            {'$.arr': 'max', '$.arr[0]': 1.1, '$.sub.document': 3},
+            "attrs", {"$.arr": "max", "$.arr[0]": 1.1, "$.sub.document": 3}
         )
         self.obj.save()
         self.obj.refresh_from_db()
-        assert self.obj.attrs['arr'] == [['dee', 1.1], 'arr', 'arr', 'max']
-        assert self.obj.attrs['sub']['document'] == ['store', 3]
+        assert self.obj.attrs["arr"] == [["dee", 1.1], "arr", "arr", "max"]
+        assert self.obj.attrs["sub"]["document"] == ["store", 3]
 
 
 class RegexpFunctionTests(TestCase):
-
     def setUp(self):
         super(RegexpFunctionTests, self).setUp()
-        have_regex_functions = (
-            connection_is_mariadb(connection)
-            and connection.mysql_version >= (10, 0, 5)
-        )
+        have_regex_functions = connection_is_mariadb(
+            connection
+        ) and connection.mysql_version >= (10, 0, 5)
         if not have_regex_functions:
             raise SkipTest("MariaDB 10.0.5+ is required")
 
@@ -586,9 +600,9 @@ class RegexpFunctionTests(TestCase):
         Alphabet.objects.create(d="ABC")
         Alphabet.objects.create(d="ABBC")
         ab = (
-            Alphabet.objects.annotate(d_double_pos=RegexpInstr('d', r'[b]{2}'))
-                            .filter(d_double_pos__gt=0)
-                            .get()
+            Alphabet.objects.annotate(d_double_pos=RegexpInstr("d", r"[b]{2}"))
+            .filter(d_double_pos__gt=0)
+            .get()
         )
         assert ab.d == "ABBC"
         assert ab.d_double_pos == 2
@@ -597,22 +611,22 @@ class RegexpFunctionTests(TestCase):
         Alphabet.objects.create(d="A string to search")
         Alphabet.objects.create(d="Something to query")
         Alphabet.objects.create(d="Please do inspect me")
-        Alphabet.objects.update(a=RegexpInstr('d', r'search|query|inspect') - 1)
-        all_abs = Alphabet.objects.all().order_by('id')
+        Alphabet.objects.update(a=RegexpInstr("d", r"search|query|inspect") - 1)
+        all_abs = Alphabet.objects.all().order_by("id")
         assert all_abs[0].a == 12
         assert all_abs[1].a == 13
         assert all_abs[2].a == 10
 
     def test_regex_replace_update(self):
         Alphabet.objects.create(d="I'm feeling sad")
-        n = Alphabet.objects.update(d=RegexpReplace('d', r'\bsad\b', 'happy'))
+        n = Alphabet.objects.update(d=RegexpReplace("d", r"\bsad\b", "happy"))
         assert n == 1
         ab = Alphabet.objects.get()
         assert ab.d == "I'm feeling happy"
 
     def test_regex_replace_update_groups(self):
         Alphabet.objects.create(d="A,,List,with,,empty,,,,strings, ")
-        n = Alphabet.objects.update(d=RegexpReplace('d', r',{2,}', ','))
+        n = Alphabet.objects.update(d=RegexpReplace("d", r",{2,}", ","))
         assert n == 1
         ab = Alphabet.objects.get()
         assert ab.d == "A,List,with,empty,strings, "
@@ -620,62 +634,53 @@ class RegexpFunctionTests(TestCase):
     def test_regex_replace_filter_backref(self):
         Author.objects.create(name="Charles Dickens")
         Author.objects.create(name="Roald Dahl")
-        qs = (
-            Author.objects.annotate(
-                surname_first=RegexpReplace('name', r'^(.*) (.*)$', r'\2, \1'),
-            ).order_by('surname_first')
-        )
+        qs = Author.objects.annotate(
+            surname_first=RegexpReplace("name", r"^(.*) (.*)$", r"\2, \1")
+        ).order_by("surname_first")
         assert qs[0].name == "Roald Dahl"
         assert qs[1].name == "Charles Dickens"
 
     def test_regex_substr(self):
-        Alphabet.objects.create(d='The <tag> is there')
-        qs = (
-            Alphabet.objects.annotate(d_tag=RegexpSubstr('d', r'<[^>]+>'))
-                            .filter(d_tag__gt='')
+        Alphabet.objects.create(d="The <tag> is there")
+        qs = Alphabet.objects.annotate(d_tag=RegexpSubstr("d", r"<[^>]+>")).filter(
+            d_tag__gt=""
         )
         ab = qs.get()
-        assert ab.d_tag == '<tag>'
+        assert ab.d_tag == "<tag>"
 
     def test_regex_substr_field(self):
-        Alphabet.objects.create(d='This is the string', e=r'\bis\b')
+        Alphabet.objects.create(d="This is the string", e=r"\bis\b")
         qs = (
-            Alphabet.objects.annotate(substr=RegexpSubstr('d', F('e')))
-                            .filter(substr__gt='')
-                            .values_list('substr', flat=True)
+            Alphabet.objects.annotate(substr=RegexpSubstr("d", F("e")))
+            .filter(substr__gt="")
+            .values_list("substr", flat=True)
         )
         substr = qs[0]
-        assert substr == 'is'
+        assert substr == "is"
 
     def test_regex_substr_filter(self):
         Author.objects.create(name="Euripides")
         Author.objects.create(name="Frank Miller")
         Author.objects.create(name="Sophocles")
         qs = list(
-            Author.objects.annotate(
-                name_has_space=Length(RegexpSubstr('name', r'\s')),
-            ).filter(name_has_space=0)
-            .order_by('id').values_list('name', flat=True),
+            Author.objects.annotate(name_has_space=Length(RegexpSubstr("name", r"\s")))
+            .filter(name_has_space=0)
+            .order_by("id")
+            .values_list("name", flat=True)
         )
-        assert qs == ['Euripides', 'Sophocles']
+        assert qs == ["Euripides", "Sophocles"]
 
 
 class DynamicColumnsFunctionTests(DynColTestCase):
-
     def setUp(self):
         super(DynamicColumnsFunctionTests, self).setUp()
-        DynamicModel.objects.create(attrs={
-            'flote': 1.0,
-            'sub': {
-                'document': 'store',
-            },
-        })
+        DynamicModel.objects.create(attrs={"flote": 1.0, "sub": {"document": "store"}})
 
     def test_get_float(self):
         results = list(
             DynamicModel.objects.annotate(
-                x=ColumnGet('attrs', 'flote', 'DOUBLE'),
-            ).values_list('x', flat=True),
+                x=ColumnGet("attrs", "flote", "DOUBLE")
+            ).values_list("x", flat=True)
         )
         assert results == [1.0]
         assert isinstance(results[0], float)
@@ -683,8 +688,8 @@ class DynamicColumnsFunctionTests(DynColTestCase):
     def test_get_int(self):
         results = list(
             DynamicModel.objects.annotate(
-                x=ColumnGet('attrs', 'flote', 'INTEGER'),
-            ).values_list('x', flat=True),
+                x=ColumnGet("attrs", "flote", "INTEGER")
+            ).values_list("x", flat=True)
         )
         assert results == [1]
         assert isinstance(results[0], int)
@@ -692,78 +697,68 @@ class DynamicColumnsFunctionTests(DynColTestCase):
     def test_get_null(self):
         results = list(
             DynamicModel.objects.annotate(
-                x=ColumnGet('attrs', 'nonexistent', 'INTEGER'),
-            ).values_list('x', flat=True),
+                x=ColumnGet("attrs", "nonexistent", "INTEGER")
+            ).values_list("x", flat=True)
         )
         assert results == [None]
 
     def test_get_nested(self):
         results = list(
             DynamicModel.objects.annotate(
-                x=ColumnGet(
-                    ColumnGet('attrs', 'sub', 'BINARY'),
-                    'document',
-                    'CHAR',
-                ),
-            ).values_list('x', flat=True),
+                x=ColumnGet(ColumnGet("attrs", "sub", "BINARY"), "document", "CHAR")
+            ).values_list("x", flat=True)
         )
-        assert results == ['store']
+        assert results == ["store"]
 
     def test_get_invalid_data_type(self):
         with pytest.raises(ValueError) as excinfo:
-            ColumnGet('bla', 'key', 'INTGRRR')
+            ColumnGet("bla", "key", "INTGRRR")
         assert "Invalid data_type 'INTGRRR'" in str(excinfo.value)
 
     def test_add(self):
         results = list(
             DynamicModel.objects.annotate(
-                attrs2=ColumnAdd('attrs', {'another': 'key'}),
-            ).values_list('attrs2', flat=True),
+                attrs2=ColumnAdd("attrs", {"another": "key"})
+            ).values_list("attrs2", flat=True)
         )
-        assert results == [{
-            'flote': 1.0,
-            'sub': {'document': 'store'},
-            'another': 'key',
-        }]
+        assert results == [
+            {"flote": 1.0, "sub": {"document": "store"}, "another": "key"}
+        ]
 
     def test_add_nested(self):
         with pytest.raises(ValueError) as excinfo:
             list(
                 DynamicModel.objects.annotate(
-                    attrs2=ColumnAdd('attrs', {'sub2': {'document': 'store'}}),
-                ).values_list('attrs2', flat=True),
+                    attrs2=ColumnAdd("attrs", {"sub2": {"document": "store"}})
+                ).values_list("attrs2", flat=True)
             )
         assert "nested values is not supported" in str(excinfo.value)
 
     def test_add_update(self):
-        DynamicModel.objects.update(attrs=ColumnAdd('attrs', {'over': 9000}))
+        DynamicModel.objects.update(attrs=ColumnAdd("attrs", {"over": 9000}))
         m = DynamicModel.objects.get()
-        assert m.attrs == {
-            'flote': 1.0,
-            'sub': {'document': 'store'},
-            'over': 9000,
-        }
+        assert m.attrs == {"flote": 1.0, "sub": {"document": "store"}, "over": 9000}
 
     def test_as_type_instantiation(self):
         with pytest.raises(ValueError) as excinfo:
-            AsType(1, 'PANTS')
+            AsType(1, "PANTS")
         assert "Invalid data_type 'PANTS'" in str(excinfo.value)
 
     def test_add_update_typed(self):
         DynamicModel.objects.update(
-            attrs=ColumnAdd('attrs', {'over': AsType(9000, 'DOUBLE')}),
+            attrs=ColumnAdd("attrs", {"over": AsType(9000, "DOUBLE")})
         )
         m = DynamicModel.objects.get()
-        assert isinstance(m.attrs['over'], float)
-        assert m.attrs['over'] == 9000.0
+        assert isinstance(m.attrs["over"], float)
+        assert m.attrs["over"] == 9000.0
 
     def test_delete(self):
-        DynamicModel.objects.update(attrs=ColumnDelete('attrs', 'sub'))
+        DynamicModel.objects.update(attrs=ColumnDelete("attrs", "sub"))
         m = DynamicModel.objects.get()
-        assert m.attrs == {'flote': 1.0}
+        assert m.attrs == {"flote": 1.0}
 
     def test_delete_subfunc(self):
-        say_sub = ConcatWS(Value('s'), Value('ub'), separator='')
-        DynamicModel.objects.update(attrs=ColumnDelete('attrs', say_sub))
+        say_sub = ConcatWS(Value("s"), Value("ub"), separator="")
+        DynamicModel.objects.update(attrs=ColumnDelete("attrs", say_sub))
         m = DynamicModel.objects.get()
-        assert m.attrs == {'flote': 1.0}
+        assert m.attrs == {"flote": 1.0}

--- a/tests/testapp/test_handler.py
+++ b/tests/testapp/test_handler.py
@@ -6,7 +6,13 @@ from django.test import TestCase
 
 from django_mysql.models.handler import Handler
 from django_mysql.utils import index_name
-from tests.testapp.models import Author, AuthorHugeName, AuthorMultiIndex, NameAuthor, VanillaAuthor
+from tests.testapp.models import (
+    Author,
+    AuthorHugeName,
+    AuthorMultiIndex,
+    NameAuthor,
+    VanillaAuthor,
+)
 
 
 def get_index_names(model):
@@ -18,7 +24,7 @@ def get_index_names(model):
             FROM INFORMATION_SCHEMA.STATISTICS
             WHERE TABLE_SCHEMA = %s AND
                   TABLE_NAME = %s""",
-            (connection.settings_dict['NAME'], model._meta.db_table),
+            (connection.settings_dict["NAME"], model._meta.db_table),
         )
 
         index_names = [x[0] for x in cursor.fetchall()]
@@ -26,9 +32,8 @@ def get_index_names(model):
 
 
 class HandlerCreationTests(TestCase):
-
     def test_bad_creation_joins_not_allowed(self):
-        qs = Author.objects.filter(tutor__name='A')
+        qs = Author.objects.filter(tutor__name="A")
         with pytest.raises(ValueError):
             qs.handler()
 
@@ -38,7 +43,7 @@ class HandlerCreationTests(TestCase):
             qs.handler()
 
     def test_bad_creation_ordering_not_allowed(self):
-        qs = Author.objects.order_by('name')
+        qs = Author.objects.order_by("name")
         with pytest.raises(ValueError):
             qs.handler()
 
@@ -60,14 +65,12 @@ class HandlerCreationTests(TestCase):
 
 
 class BaseAuthorTestCase(TestCase):
-
     def setUp(self):
-        self.jk = Author.objects.create(name='JK Rowling')
-        self.grisham = Author.objects.create(name='John Grisham')
+        self.jk = Author.objects.create(name="JK Rowling")
+        self.grisham = Author.objects.create(name="John Grisham")
 
 
 class HandlerReadTests(BaseAuthorTestCase):
-
     def test_bad_read_unopened(self):
         handler = Author.objects.all().handler()
         with pytest.raises(RuntimeError):
@@ -76,7 +79,7 @@ class HandlerReadTests(BaseAuthorTestCase):
     def test_bad_read_mode(self):
         with Author.objects.handler() as handler:
             with pytest.raises(ValueError):
-                handler.read(mode='non-existent')
+                handler.read(mode="non-existent")
 
     def test_read_does_single_by_default(self):
         with Author.objects.handler() as handler:
@@ -86,14 +89,14 @@ class HandlerReadTests(BaseAuthorTestCase):
     def test_read_limit_first(self):
         with Author.objects.handler() as handler:
             handler_first = handler.read(limit=1)[0]
-        qs_first = Author.objects.earliest('id')
+        qs_first = Author.objects.earliest("id")
 
         assert handler_first == qs_first
 
     def test_read_limit_last(self):
         with Author.objects.handler() as handler:
-            handler_last = handler.read(mode='last', limit=1)[0]
-        qs_last = Author.objects.latest('id')
+            handler_last = handler.read(mode="last", limit=1)[0]
+        qs_last = Author.objects.latest("id")
 
         assert handler_last == qs_last
 
@@ -106,23 +109,22 @@ class HandlerReadTests(BaseAuthorTestCase):
 
     def test_read_index_primary(self):
         with Author.objects.handler() as handler:
-            handler_all = list(handler.read(index='PRIMARY', limit=2))
-        qs_all = list(Author.objects.order_by('id'))
+            handler_all = list(handler.read(index="PRIMARY", limit=2))
+        qs_all = list(Author.objects.order_by("id"))
 
         assert handler_all == qs_all
 
     def test_read_index_different(self):
-        index_name = [name for name in get_index_names(Author)
-                      if name != "PRIMARY"][0]
+        index_name = [name for name in get_index_names(Author) if name != "PRIMARY"][0]
 
         with Author.objects.handler() as handler:
             handler_all = list(handler.read(index=index_name, limit=2))
-        qs_all = list(Author.objects.order_by('name').all())
+        qs_all = list(Author.objects.order_by("name").all())
 
         assert handler_all == qs_all
 
     def test_read_where_filter_read(self):
-        qs = Author.objects.filter(name__startswith='John')
+        qs = Author.objects.filter(name__startswith="John")
 
         with qs.handler() as handler:
             handler_all = list(handler.read())
@@ -131,7 +133,7 @@ class HandlerReadTests(BaseAuthorTestCase):
         assert handler_all == qs_all
 
     def test_read_where_filter_f_expression(self):
-        qs = Author.objects.filter(name=F('name'))
+        qs = Author.objects.filter(name=F("name"))
 
         with qs.handler() as handler:
             handler_all = list(handler.read(limit=100))
@@ -139,7 +141,7 @@ class HandlerReadTests(BaseAuthorTestCase):
         assert len(handler_all) == 2
 
     def test_read_where_exclude(self):
-        qs = Author.objects.filter(name__contains='JK')
+        qs = Author.objects.filter(name__contains="JK")
 
         with qs.handler() as handler:
             handler_all = list(handler.read())
@@ -158,7 +160,7 @@ class HandlerReadTests(BaseAuthorTestCase):
         assert handler_first == author
 
     def test_read_where_passed_in(self):
-        qs = Author.objects.filter(name__startswith='John')
+        qs = Author.objects.filter(name__startswith="John")
 
         with Author.objects.handler() as handler:
             handler_author = handler.read(where=qs)[0]
@@ -166,8 +168,8 @@ class HandlerReadTests(BaseAuthorTestCase):
         assert handler_author == qs[0]
 
     def test_read_where_passed_in_overrides_completely(self):
-        qs = Author.objects.filter(name='JK Rowling')
-        qs2 = Author.objects.filter(name='John Grisham')
+        qs = Author.objects.filter(name="JK Rowling")
+        qs2 = Author.objects.filter(name="John Grisham")
 
         with qs.handler() as handler:
             handler_default = handler.read()[0]
@@ -179,12 +181,12 @@ class HandlerReadTests(BaseAuthorTestCase):
     def test_read_bad_where_passed_in(self):
         with Author.objects.handler() as handler:
             with pytest.raises(ValueError):
-                handler.read(where=Author.objects.filter(tutor__name='A'))
+                handler.read(where=Author.objects.filter(tutor__name="A"))
 
     def test_read_index_value_and_mode_invalid(self):
         with Author.objects.handler() as handler:
             with pytest.raises(ValueError):
-                handler.read(value=1, mode='first')
+                handler.read(value=1, mode="first")
 
     def test_read_index_equal(self):
         with Author.objects.handler() as handler:
@@ -238,7 +240,6 @@ class HandlerReadTests(BaseAuthorTestCase):
 
 
 class HandlerIterTests(BaseAuthorTestCase):
-
     def test_iter_all(self):
         with Author.objects.handler() as handler:
             seen_ids = [author.id for author in handler.iter()]
@@ -259,8 +260,9 @@ class HandlerIterTests(BaseAuthorTestCase):
 
     def test_iter_reverse_chunk_size_1(self):
         with Author.objects.handler() as handler:
-            seen_ids = [author.id for author in
-                        handler.iter(chunk_size=1, reverse=True)]
+            seen_ids = [
+                author.id for author in handler.iter(chunk_size=1, reverse=True)
+            ]
 
         assert seen_ids == [self.grisham.id, self.jk.id]
 
@@ -270,7 +272,7 @@ class HandlerIterTests(BaseAuthorTestCase):
             sum(1 for x in handler.iter())
 
     def test_iter_where_preset(self):
-        where_qs = Author.objects.filter(name__startswith='John')
+        where_qs = Author.objects.filter(name__startswith="John")
 
         with where_qs.handler() as handler:
             seen_ids = [author.id for author in handler.iter()]
@@ -278,7 +280,7 @@ class HandlerIterTests(BaseAuthorTestCase):
         assert seen_ids == [self.grisham.id]
 
     def test_iter_where_passed_in(self):
-        where_qs = Author.objects.filter(name__startswith='John')
+        where_qs = Author.objects.filter(name__startswith="John")
 
         with Author.objects.handler() as handler:
             seen_ids = [author.id for author in handler.iter(where=where_qs)]
@@ -286,7 +288,7 @@ class HandlerIterTests(BaseAuthorTestCase):
         assert seen_ids == [self.grisham.id]
 
     def test_iter_loses_its_place(self):
-        portis = Author.objects.create(name='Charles Portis')
+        portis = Author.objects.create(name="Charles Portis")
 
         with Author.objects.handler() as handler:
             iterator = handler.iter(chunk_size=1)
@@ -304,33 +306,35 @@ class HandlerIterTests(BaseAuthorTestCase):
 
 
 class HandlerMultipartIndexTests(TestCase):
-
     def setUp(self):
         super(HandlerMultipartIndexTests, self).setUp()
-        self.smith1 = AuthorMultiIndex.objects.create(name='John Smith', country='Scotland')
-        self.smith2 = AuthorMultiIndex.objects.create(name='John Smith', country='England')
-        self.index_name = index_name(AuthorMultiIndex, 'name', 'country')
+        self.smith1 = AuthorMultiIndex.objects.create(
+            name="John Smith", country="Scotland"
+        )
+        self.smith2 = AuthorMultiIndex.objects.create(
+            name="John Smith", country="England"
+        )
+        self.index_name = index_name(AuthorMultiIndex, "name", "country")
 
     def test_read_all(self):
         with AuthorMultiIndex.objects.handler() as handler:
             handler_all = list(handler.read(index=self.index_name, limit=2))
-        qs_all = list(AuthorMultiIndex.objects.order_by('name', 'country'))
+        qs_all = list(AuthorMultiIndex.objects.order_by("name", "country"))
         assert handler_all == qs_all
 
     def test_read_index_multipart(self):
         with AuthorMultiIndex.objects.handler() as handler:
-            value = ('John Smith', 'England')
+            value = ("John Smith", "England")
             result = handler.read(index=self.index_name, value=value)[0]
 
         assert result == self.smith2
 
 
 class HandlerNestingTests(BaseAuthorTestCase):
-
     def setUp(self):
         super(HandlerNestingTests, self).setUp()
-        self.jk_name = NameAuthor.objects.create(name='JK Rowling')
-        self.grisham_name = NameAuthor.objects.create(name='John Grisham')
+        self.jk_name = NameAuthor.objects.create(name="JK Rowling")
+        self.grisham_name = NameAuthor.objects.create(name="John Grisham")
 
     def test_can_nest(self):
         ahandler = Author.objects.handler()
@@ -355,11 +359,10 @@ class HandlerNestingTests(BaseAuthorTestCase):
 
 
 class HandlerStandaloneTests(TestCase):
-
     def setUp(self):
         super(HandlerStandaloneTests, self).setUp()
-        self.jk = VanillaAuthor.objects.create(name='JK Rowling')
-        self.grisham = VanillaAuthor.objects.create(name='John Grisham')
+        self.jk = VanillaAuthor.objects.create(name="JK Rowling")
+        self.grisham = VanillaAuthor.objects.create(name="John Grisham")
 
     def test_vanilla_works(self):
         handler = Handler(VanillaAuthor.objects.all())
@@ -369,7 +372,7 @@ class HandlerStandaloneTests(TestCase):
         assert first == self.jk
 
     def test_vanilla_filters(self):
-        qs = VanillaAuthor.objects.filter(name__startswith='John')
+        qs = VanillaAuthor.objects.filter(name__startswith="John")
         with Handler(qs) as handler:
             first = handler.read()[0]
 
@@ -379,17 +382,17 @@ class HandlerStandaloneTests(TestCase):
 class HandlerMultiDBTests(TestCase):
 
     if django.VERSION >= (2, 2):
-        databases = ['default', 'other']
+        databases = ["default", "other"]
     else:
         multi_db = True
 
     def setUp(self):
         super(HandlerMultiDBTests, self).setUp()
-        self.jk = Author.objects.using('other').create(name='JK Rowling')
-        self.grisham = Author.objects.create(name='John Grisham')
+        self.jk = Author.objects.using("other").create(name="JK Rowling")
+        self.grisham = Author.objects.create(name="John Grisham")
 
     def test_queryset_db_is_used(self):
-        handler = Author.objects.using('other').handler()
+        handler = Author.objects.using("other").handler()
         with handler:
             handler_result = handler.read()[0]
 

--- a/tests/testapp/test_jsonfield.py
+++ b/tests/testapp/test_jsonfield.py
@@ -18,19 +18,16 @@ from tests.testapp.utils import print_all_queries
 
 
 class JSONFieldTestCase(TestCase):
-
     @classmethod
     def setUpClass(cls):
         if not (
-            not connection_is_mariadb(connection)
-            and connection.mysql_version >= (5, 7)
+            not connection_is_mariadb(connection) and connection.mysql_version >= (5, 7)
         ):
             raise SkipTest("JSONField requires MySQL 5.7+")
         super(JSONFieldTestCase, cls).setUpClass()
 
 
 class TestSaveLoad(JSONFieldTestCase):
-
     def test_empty_dict(self):
         m = JSONModel()
         assert m.attrs == {}
@@ -39,21 +36,21 @@ class TestSaveLoad(JSONFieldTestCase):
         assert m.attrs == {}
 
     def test_values(self):
-        m = JSONModel(attrs={'key': 'value'})
-        assert m.attrs == {'key': 'value'}
+        m = JSONModel(attrs={"key": "value"})
+        assert m.attrs == {"key": "value"}
         m.save()
         m = JSONModel.objects.get()
-        assert m.attrs == {'key': 'value'}
+        assert m.attrs == {"key": "value"}
 
     def test_string(self):
-        m = JSONModel(attrs='value')
-        assert m.attrs == 'value'
+        m = JSONModel(attrs="value")
+        assert m.attrs == "value"
         m.save()
         m = JSONModel.objects.get()
-        assert m.attrs == 'value'
+        assert m.attrs == "value"
 
     def test_json_dumps_string(self):
-        json_string = json.dumps({'foo': 'bar'})
+        json_string = json.dumps({"foo": "bar"})
         m = JSONModel(attrs=json_string)
         assert m.attrs == json_string
         m.save()
@@ -68,11 +65,11 @@ class TestSaveLoad(JSONFieldTestCase):
         assert m.attrs == '"'
 
     def test_awkward_2(self):
-        m = JSONModel(attrs='\\')
-        assert m.attrs == '\\'
+        m = JSONModel(attrs="\\")
+        assert m.attrs == "\\"
         m.save()
         m = JSONModel.objects.get()
-        assert m.attrs == '\\'
+        assert m.attrs == "\\"
 
     def test_list(self):
         m = JSONModel(attrs=[1, 2, 4])
@@ -103,7 +100,7 @@ class TestSaveLoad(JSONFieldTestCase):
         assert m.attrs is None
 
     def test_control_characters(self):
-        chars = ''.join(chr(i) for i in range(32))
+        chars = "".join(chr(i) for i in range(32))
         m = JSONModel(attrs=[chars])
         assert m.attrs == [chars]
         m.save()
@@ -111,99 +108,95 @@ class TestSaveLoad(JSONFieldTestCase):
         assert m.attrs == [chars]
 
     def test_nan_raises_valueerror(self):
-        m = JSONModel(attrs=float('nan'))
+        m = JSONModel(attrs=float("nan"))
         with pytest.raises(ValueError):
             m.save()
 
     def test_custom_json_encoder(self):
         field = JSONField(encoder=DjangoJSONEncoder(allow_nan=False))
-        value = field.get_prep_value({'a': Decimal(1)})
+        value = field.get_prep_value({"a": Decimal(1)})
         assert value == '{"a": "1"}'
 
     def test_custom_json_decoder(self):
         class CustomDecoder(json.JSONDecoder):
             def decode(self, *args, **kwargs):
-                return 'lol'
+                return "lol"
+
         field = JSONField(decoder=CustomDecoder(strict=False))
         if django.VERSION >= (2, 0):
             value = field.from_db_value('"anything"', None, None)
         else:
             value = field.from_db_value('"anything"', None, None, None)
-        assert value == 'lol'
+        assert value == "lol"
 
 
 class QueryTests(JSONFieldTestCase):
-
     def setUp(self):
         super(QueryTests, self).setUp()
-        JSONModel.objects.bulk_create([
-            JSONModel(attrs={'a': 'b'}),
-            JSONModel(attrs=1337),
-            JSONModel(attrs=['an', 'array']),
-            JSONModel(attrs=None),
-            JSONModel(attrs='foo'),
-        ])
-        self.objs = list(JSONModel.objects.all().order_by('id'))
+        JSONModel.objects.bulk_create(
+            [
+                JSONModel(attrs={"a": "b"}),
+                JSONModel(attrs=1337),
+                JSONModel(attrs=["an", "array"]),
+                JSONModel(attrs=None),
+                JSONModel(attrs="foo"),
+            ]
+        )
+        self.objs = list(JSONModel.objects.all().order_by("id"))
 
     def test_equal(self):
-        assert (
-            list(JSONModel.objects.filter(attrs={'a': 'b'}))
-            == [self.objs[0]]
-        )
+        assert list(JSONModel.objects.filter(attrs={"a": "b"})) == [self.objs[0]]
 
     def test_equal_value(self):
         assert list(JSONModel.objects.filter(attrs=1337)) == [self.objs[1]]
 
     def test_equal_string(self):
-        assert list(JSONModel.objects.filter(attrs='foo')) == [self.objs[4]]
+        assert list(JSONModel.objects.filter(attrs="foo")) == [self.objs[4]]
 
     def test_equal_array(self):
-        assert (
-            list(JSONModel.objects.filter(attrs=['an', 'array']))
-            == [self.objs[2]]
-        )
+        assert list(JSONModel.objects.filter(attrs=["an", "array"])) == [self.objs[2]]
 
     def test_equal_no_match(self):
-        assert list(JSONModel.objects.filter(attrs={'c': 'z'})) == []
+        assert list(JSONModel.objects.filter(attrs={"c": "z"})) == []
 
     def test_equal_F_attrs(self):
-        assert (
-            list(JSONModel.objects.filter(attrs=F('attrs')))
-            == [self.objs[0], self.objs[1], self.objs[2], self.objs[4]]
-        )
+        assert list(JSONModel.objects.filter(attrs=F("attrs"))) == [
+            self.objs[0],
+            self.objs[1],
+            self.objs[2],
+            self.objs[4],
+        ]
 
     def test_isnull_True(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__isnull=True))
-            == [self.objs[3]]
-        )
+        assert list(JSONModel.objects.filter(attrs__isnull=True)) == [self.objs[3]]
 
     def test_isnull_False(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__isnull=False))
-            == [self.objs[0], self.objs[1], self.objs[2], self.objs[4]]
-        )
+        assert list(JSONModel.objects.filter(attrs__isnull=False)) == [
+            self.objs[0],
+            self.objs[1],
+            self.objs[2],
+            self.objs[4],
+        ]
 
     def test_range_broken(self):
         with pytest.raises(NotImplementedError) as excinfo:
             JSONModel.objects.filter(attrs__range=[1, 2])
 
-        assert (
-            "Lookup 'range' doesn't work with JSONField" in str(excinfo.value)
-        )
+        assert "Lookup 'range' doesn't work with JSONField" in str(excinfo.value)
 
 
 class ArrayQueryTests(JSONFieldTestCase):
-
     def setUp(self):
         super(ArrayQueryTests, self).setUp()
-        JSONModel.objects.bulk_create([
-            JSONModel(attrs=[1, 3]),
-            JSONModel(attrs=[1, 3, 3]),
-            JSONModel(attrs=[1, 3, 3, 7]),
-            JSONModel(attrs=[2, 4]),
-        ])
-        self.objs = list(JSONModel.objects.all().order_by('id'))
+        JSONModel.objects.bulk_create(
+            [
+                JSONModel(attrs=[1, 3]),
+                JSONModel(attrs=[1, 3, 3]),
+                JSONModel(attrs=[1, 3, 3, 7]),
+                JSONModel(attrs=[2, 4]),
+            ]
+        )
+        self.objs = list(JSONModel.objects.all().order_by("id"))
 
     def test_lt_1(self):
         assert list(JSONModel.objects.filter(attrs__lt=[1])) == []
@@ -212,10 +205,10 @@ class ArrayQueryTests(JSONFieldTestCase):
         assert list(JSONModel.objects.filter(attrs__lt=[3])) == self.objs
 
     def test_lte_1_3_3(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__lte=[1, 3, 3]))
-            == [self.objs[0], self.objs[1]]
-        )
+        assert list(JSONModel.objects.filter(attrs__lte=[1, 3, 3])) == [
+            self.objs[0],
+            self.objs[1],
+        ]
 
     def test_lte_1(self):
         assert list(JSONModel.objects.filter(attrs__lte=[1])) == []
@@ -224,10 +217,7 @@ class ArrayQueryTests(JSONFieldTestCase):
         assert list(JSONModel.objects.filter(attrs__gt=[1])) == self.objs
 
     def test_gt_1_3(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__gt=[1, 3]))
-            == self.objs[1:]
-        )
+        assert list(JSONModel.objects.filter(attrs__gt=[1, 3])) == self.objs[1:]
 
     def test_gt_2_5(self):
         assert list(JSONModel.objects.filter(attrs__gt=[2, 5])) == []
@@ -240,223 +230,183 @@ class ArrayQueryTests(JSONFieldTestCase):
 
 
 class ExtraLookupsQueryTests(JSONFieldTestCase):
-
     def setUp(self):
         super(ExtraLookupsQueryTests, self).setUp()
 
         self.objs = [
             JSONModel.objects.create(attrs={}),
-            JSONModel.objects.create(attrs={
-                'a': 'b',
-                'c': 1,
-                9001: 9002,
-                '"': 'awkward',
-                '\n': 'super awkward',
-            }),
-            JSONModel.objects.create(attrs={
-                'a': 'b',
-                'c': 1,
-                'd': ['e', {'f': 'g'}],
-                'h': True,
-                'i': False,
-                'j': None,
-                'k': {'l': 'm'},
-            }),
+            JSONModel.objects.create(
+                attrs={
+                    "a": "b",
+                    "c": 1,
+                    9001: 9002,
+                    '"': "awkward",
+                    "\n": "super awkward",
+                }
+            ),
+            JSONModel.objects.create(
+                attrs={
+                    "a": "b",
+                    "c": 1,
+                    "d": ["e", {"f": "g"}],
+                    "h": True,
+                    "i": False,
+                    "j": None,
+                    "k": {"l": "m"},
+                }
+            ),
             JSONModel.objects.create(attrs=[1, [2]]),
-            JSONModel.objects.create(attrs={
-                'k': True,
-                'l': False,
-                '\\': 'awkward',
-            }),
+            JSONModel.objects.create(attrs={"k": True, "l": False, "\\": "awkward"}),
         ]
 
     def test_has_key_invalid_type(self):
         with pytest.raises(ValueError) as excinfo:
             JSONModel.objects.filter(attrs__has_key=1)
-        assert str(excinfo.value) == "JSONField's 'has_key' lookup only works with str values"
+        assert (
+            str(excinfo.value)
+            == "JSONField's 'has_key' lookup only works with str values"
+        )
 
     def test_has_key(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__has_key='a'))
-            == [self.objs[1], self.objs[2]]
-        )
+        assert list(JSONModel.objects.filter(attrs__has_key="a")) == [
+            self.objs[1],
+            self.objs[2],
+        ]
 
     def test_has_key_2(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__has_key='l'))
-            == [self.objs[4]]
-        )
+        assert list(JSONModel.objects.filter(attrs__has_key="l")) == [self.objs[4]]
 
     def test_has_key_awkward(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__has_key='"'))
-            == [self.objs[1]]
-        )
+        assert list(JSONModel.objects.filter(attrs__has_key='"')) == [self.objs[1]]
 
     def test_has_key_awkward_2(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__has_key='\n'))
-            == [self.objs[1]]
-        )
+        assert list(JSONModel.objects.filter(attrs__has_key="\n")) == [self.objs[1]]
 
     def test_has_key_awkward_3(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__has_key='\\'))
-            == [self.objs[4]]
-        )
+        assert list(JSONModel.objects.filter(attrs__has_key="\\")) == [self.objs[4]]
 
     def test_has_keys_invalid_type(self):
         with pytest.raises(ValueError) as excinfo:
-            JSONModel.objects.filter(attrs__has_keys={'a': 'b'})
+            JSONModel.objects.filter(attrs__has_keys={"a": "b"})
         assert "only works with Sequences" in str(excinfo.value)
 
     def test_has_keys(self):
         with print_all_queries():
-            assert (
-                list(JSONModel.objects.filter(attrs__has_keys=['a', 'c']))
-                == [self.objs[1], self.objs[2]]
-            )
+            assert list(JSONModel.objects.filter(attrs__has_keys=["a", "c"])) == [
+                self.objs[1],
+                self.objs[2],
+            ]
 
     def test_has_keys_2(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__has_keys=['l']))
-            == [self.objs[4]]
-        )
+        assert list(JSONModel.objects.filter(attrs__has_keys=["l"])) == [self.objs[4]]
 
     def test_has_keys_awkward(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__has_keys=['\n', '"']))
-            == [self.objs[1]]
-        )
+        assert list(JSONModel.objects.filter(attrs__has_keys=["\n", '"'])) == [
+            self.objs[1]
+        ]
 
     def test_has_any_keys_invalid_type(self):
         with pytest.raises(ValueError) as excinfo:
-            JSONModel.objects.filter(attrs__has_any_keys={'a': 'b'})
+            JSONModel.objects.filter(attrs__has_any_keys={"a": "b"})
         assert "only works with Sequences" in str(excinfo.value)
 
     def test_has_any_keys(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__has_any_keys=['a', 'k']))
-            == [self.objs[1], self.objs[2], self.objs[4]]
-        )
+        assert list(JSONModel.objects.filter(attrs__has_any_keys=["a", "k"])) == [
+            self.objs[1],
+            self.objs[2],
+            self.objs[4],
+        ]
 
     def test_has_any_keys_awkward(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__has_any_keys=['\\']))
-            == [self.objs[4]]
-        )
+        assert list(JSONModel.objects.filter(attrs__has_any_keys=["\\"])) == [
+            self.objs[4]
+        ]
 
     def test_contains(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__contains={'a': 'b'}))
-            == [self.objs[1], self.objs[2]]
-        )
+        assert list(JSONModel.objects.filter(attrs__contains={"a": "b"})) == [
+            self.objs[1],
+            self.objs[2],
+        ]
 
     def test_contains_2(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__contains={'l': False}))
-            == [self.objs[4]]
-        )
+        assert list(JSONModel.objects.filter(attrs__contains={"l": False})) == [
+            self.objs[4]
+        ]
 
     def test_contains_array(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__contains=[[2]]))
-            == [self.objs[3]]
-        )
+        assert list(JSONModel.objects.filter(attrs__contains=[[2]])) == [self.objs[3]]
 
     def test_contained_by(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__contained_by={
-                'k': True,
-                'l': False,
-                '\\': 'awkward',
-                'spare_key': ['unused', 'array'],
-            }))
-            == [self.objs[0], self.objs[4]]
-        )
+        assert list(
+            JSONModel.objects.filter(
+                attrs__contained_by={
+                    "k": True,
+                    "l": False,
+                    "\\": "awkward",
+                    "spare_key": ["unused", "array"],
+                }
+            )
+        ) == [self.objs[0], self.objs[4]]
 
     def test_contained_by_array(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__contained_by=[1, [2], 3]))
-            == [self.objs[3]]
-        )
+        assert list(JSONModel.objects.filter(attrs__contained_by=[1, [2], 3])) == [
+            self.objs[3]
+        ]
 
     def test_length_lookup(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__length=0))
-            == [self.objs[0]]
-        )
+        assert list(JSONModel.objects.filter(attrs__length=0)) == [self.objs[0]]
 
     def test_length_lookup_2(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__length=2))
-            == [self.objs[3]]
-        )
+        assert list(JSONModel.objects.filter(attrs__length=2)) == [self.objs[3]]
 
     def test_length_lookup_chains(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__length__range=[0, 10]))
-            == self.objs
-        )
+        assert list(JSONModel.objects.filter(attrs__length__range=[0, 10])) == self.objs
 
     def test_shallow_list_lookup(self):
         assert list(JSONModel.objects.filter(attrs__0=1)) == [self.objs[3]]
 
     def test_shallow_obj_lookup(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__a='b'))
-            == [self.objs[1], self.objs[2]]
-        )
+        assert list(JSONModel.objects.filter(attrs__a="b")) == [
+            self.objs[1],
+            self.objs[2],
+        ]
 
     def test_shallow_obj_lookup_number_key(self):
-        assert (
-            list(JSONModel.objects.filter(**{'attrs__"9001"': 9002}))
-            == [self.objs[1]]
-        )
+        assert list(JSONModel.objects.filter(**{'attrs__"9001"': 9002})) == [
+            self.objs[1]
+        ]
 
     def test_deep_lookup_objs(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__k__l='m'))
-            == [self.objs[2]]
-        )
+        assert list(JSONModel.objects.filter(attrs__k__l="m")) == [self.objs[2]]
 
     def test_shallow_lookup_obj_target(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__k={'l': 'm'}))
-            == [self.objs[2]]
-        )
+        assert list(JSONModel.objects.filter(attrs__k={"l": "m"})) == [self.objs[2]]
 
     def test_deep_lookup_array(self):
         assert list(JSONModel.objects.filter(attrs__1__0=2)) == [self.objs[3]]
 
     def test_deep_lookup_mixed(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__d__1__f='g'))
-            == [self.objs[2]]
-        )
+        assert list(JSONModel.objects.filter(attrs__d__1__f="g")) == [self.objs[2]]
 
     def test_deep_lookup_gt(self):
         assert list(JSONModel.objects.filter(attrs__c__gt=1)) == []
 
     def test_deep_lookup_lt(self):
-        assert (
-            list(JSONModel.objects.filter(attrs__c__lt=5))
-            == [self.objs[1], self.objs[2]]
-        )
+        assert list(JSONModel.objects.filter(attrs__c__lt=5)) == [
+            self.objs[1],
+            self.objs[2],
+        ]
 
     def test_usage_in_subquery(self):
-        assert (
-            list(JSONModel.objects.filter(
-                id__in=JSONModel.objects.filter(attrs__c=1),
-            ))
-            == [self.objs[1], self.objs[2]]
-        )
+        assert list(
+            JSONModel.objects.filter(id__in=JSONModel.objects.filter(attrs__c=1))
+        ) == [self.objs[1], self.objs[2]]
 
 
 class TestCheck(JSONFieldTestCase):
 
     if django.VERSION >= (2, 2):
-        databases = ['default', 'other']
+        databases = ["default", "other"]
     else:
         multi_db = True
 
@@ -466,8 +416,8 @@ class TestCheck(JSONFieldTestCase):
 
         errors = InvalidJSONModel1.check(actually_check=True)
         assert len(errors) == 1
-        assert errors[0].id == 'django_mysql.E017'
-        assert 'Do not use mutable defaults for JSONField' in errors[0].msg
+        assert errors[0].id == "django_mysql.E017"
+        assert "Do not use mutable defaults for JSONField" in errors[0].msg
 
     def test_mutable_default_dict(self):
         class InvalidJSONModel2(TemporaryModel):
@@ -475,10 +425,10 @@ class TestCheck(JSONFieldTestCase):
 
         errors = InvalidJSONModel2.check(actually_check=True)
         assert len(errors) == 1
-        assert errors[0].id == 'django_mysql.E017'
-        assert 'Do not use mutable defaults for JSONField' in errors[0].msg
+        assert errors[0].id == "django_mysql.E017"
+        assert "Do not use mutable defaults for JSONField" in errors[0].msg
 
-    @mock.patch('django_mysql.models.fields.json.connection_is_mariadb')
+    @mock.patch("django_mysql.models.fields.json.connection_is_mariadb")
     def test_db_not_mysql(self, is_mariadb):
         is_mariadb.return_value = True
 
@@ -487,22 +437,22 @@ class TestCheck(JSONFieldTestCase):
 
         errors = InvalidJSONModel3.check(actually_check=True)
         assert len(errors) == 1
-        assert errors[0].id == 'django_mysql.E016'
+        assert errors[0].id == "django_mysql.E016"
         assert "MySQL 5.7+ is required" in errors[0].msg
 
-    @mock.patch.object(connections['default'], 'mysql_version', new=(5, 5, 3))
-    @mock.patch.object(connections['other'], 'mysql_version', new=(5, 5, 1))
+    @mock.patch.object(connections["default"], "mysql_version", new=(5, 5, 3))
+    @mock.patch.object(connections["other"], "mysql_version", new=(5, 5, 1))
     def test_mysql_old_version(self):
         class InvalidJSONModel4(TemporaryModel):
             field = JSONField()
 
         errors = InvalidJSONModel4.check(actually_check=True)
         assert len(errors) == 1
-        assert errors[0].id == 'django_mysql.E016'
+        assert errors[0].id == "django_mysql.E016"
         assert "MySQL 5.7+ is required" in errors[0].msg
 
-    @mock.patch.object(connections['default'], 'mysql_version', new=(5, 5, 3))
-    @mock.patch.object(connections['other'], 'mysql_version', new=(5, 7, 1))
+    @mock.patch.object(connections["default"], "mysql_version", new=(5, 5, 3))
+    @mock.patch.object(connections["other"], "mysql_version", new=(5, 7, 1))
     def test_mysql_one_conn_old_version(self):
         class InvalidJSONModel5(TemporaryModel):
             field = JSONField()
@@ -516,8 +466,8 @@ class TestCheck(JSONFieldTestCase):
 
         errors = InvalidJSONModel6.check(actually_check=True)
         assert len(errors) == 1
-        assert errors[0].id == 'django_mysql.E018'
-        assert errors[0].msg.startswith('Custom JSON encoder should have')
+        assert errors[0].id == "django_mysql.E018"
+        assert errors[0].msg.startswith("Custom JSON encoder should have")
 
     def test_bad_custom_decoder(self):
         class InvalidJSONModel7(TemporaryModel):
@@ -525,12 +475,11 @@ class TestCheck(JSONFieldTestCase):
 
         errors = InvalidJSONModel7.check(actually_check=True)
         assert len(errors) == 1
-        assert errors[0].id == 'django_mysql.E019'
-        assert errors[0].msg.startswith('Custom JSON decoder should have')
+        assert errors[0].id == "django_mysql.E019"
+        assert errors[0].msg.startswith("Custom JSON decoder should have")
 
 
 class TestFormField(JSONFieldTestCase):
-
     def test_model_field_formfield(self):
         model_field = JSONField()
         form_field = model_field.formfield()
@@ -542,24 +491,23 @@ class JSONFieldSubclass(JSONField):
 
 
 class TestDeconstruct(JSONFieldTestCase):
-
     def test_deconstruct(self):
         field = JSONField()
         name, path, args, kwargs = field.deconstruct()
 
         new = JSONField(*args, **kwargs)
 
-        assert path == 'django_mysql.models.JSONField'
+        assert path == "django_mysql.models.JSONField"
         assert new.default == field.default
 
     def test_deconstruct_subclass(self):
         field = JSONFieldSubclass()
         name, path, args, kwargs = field.deconstruct()
-        assert path == 'tests.testapp.test_jsonfield.JSONFieldSubclass'
+        assert path == "tests.testapp.test_jsonfield.JSONFieldSubclass"
 
 
 class TestSerialization(JSONFieldTestCase):
-    test_data = '''[
+    test_data = """[
         {
             "fields": {
                 "attrs": {"a": "b", "c": null}
@@ -567,14 +515,14 @@ class TestSerialization(JSONFieldTestCase):
             "model": "testapp.jsonmodel",
             "pk": null
         }
-    ]'''
+    ]"""
 
     def test_dumping(self):
-        instance = JSONModel(attrs={'a': 'b', 'c': None})
-        data = serializers.serialize('json', [instance])
+        instance = JSONModel(attrs={"a": "b", "c": None})
+        data = serializers.serialize("json", [instance])
         assert json.loads(data) == json.loads(self.test_data)
 
     def test_loading(self):
-        instances = list(serializers.deserialize('json', self.test_data))
+        instances = list(serializers.deserialize("json", self.test_data))
         instance = instances[0].object
-        assert instance.attrs == {'a': 'b', 'c': None}
+        assert instance.attrs == {"a": "b", "c": None}

--- a/tests/testapp/test_listcharfield.py
+++ b/tests/testapp/test_listcharfield.py
@@ -13,11 +13,15 @@ from django.test import SimpleTestCase, TestCase, TransactionTestCase, override_
 from django_mysql.forms import SimpleListField
 from django_mysql.models import ListCharField, ListF
 from django_mysql.test.utils import override_mysql_variables
-from tests.testapp.models import CharListDefaultModel, CharListModel, IntListModel, TemporaryModel
+from tests.testapp.models import (
+    CharListDefaultModel,
+    CharListModel,
+    IntListModel,
+    TemporaryModel,
+)
 
 
 class TestSaveLoad(TestCase):
-
     def test_char_easy(self):
         s = CharListModel.objects.create(field=["comfy", "big"])
         assert s.field == ["comfy", "big"]
@@ -33,7 +37,7 @@ class TestSaveLoad(TestCase):
     def test_char_string_direct(self):
         s = CharListModel.objects.create(field="big,bad")
         s = CharListModel.objects.get(id=s.id)
-        assert s.field == ['big', 'bad']
+        assert s.field == ["big", "bad"]
 
     def test_is_a_list_immediately(self):
         s = CharListModel()
@@ -71,13 +75,13 @@ class TestSaveLoad(TestCase):
         assert empty.count() == 0
 
     def test_char_lookup_contains(self):
-        self.check_char_lookup('contains')
+        self.check_char_lookup("contains")
 
     def test_char_lookup_icontains(self):
-        self.check_char_lookup('icontains')
+        self.check_char_lookup("icontains")
 
     def check_char_lookup(self, lookup):
-        lname = 'field__' + lookup
+        lname = "field__" + lookup
         mymodel = CharListModel.objects.create(field=["mouldy", "rotten"])
 
         mouldy = CharListModel.objects.filter(**{lname: "mouldy"})
@@ -95,13 +99,13 @@ class TestSaveLoad(TestCase):
             list(CharListModel.objects.filter(**{lname: ["a", "b"]}))
 
         both = CharListModel.objects.filter(
-            Q(**{lname: "mouldy"}) & Q(**{lname: "rotten"}),
+            Q(**{lname: "mouldy"}) & Q(**{lname: "rotten"})
         )
         assert both.count() == 1
         assert both[0] == mymodel
 
         either = CharListModel.objects.filter(
-            Q(**{lname: "mouldy"}) | Q(**{lname: "clean"}),
+            Q(**{lname: "mouldy"}) | Q(**{lname: "clean"})
         )
         assert either.count() == 1
 
@@ -157,16 +161,14 @@ class TestSaveLoad(TestCase):
         red0 = CharListModel.objects.filter(field__0="red")
         assert list(red0) == [mymodel]
 
-        red0_red1 = CharListModel.objects.filter(field__0="red",
-                                                 field__1="red")
+        red0_red1 = CharListModel.objects.filter(field__0="red", field__1="red")
         assert red0_red1.count() == 0
 
-        red0_blue1 = CharListModel.objects.filter(field__0="red",
-                                                  field__1="blue")
+        red0_blue1 = CharListModel.objects.filter(field__0="red", field__1="blue")
         assert list(red0_blue1) == [mymodel]
 
         red0_or_blue0 = CharListModel.objects.filter(
-            Q(field__0="red") | Q(field__0="blue"),
+            Q(field__0="red") | Q(field__0="blue")
         )
         assert list(red0_or_blue0) == [mymodel]
 
@@ -209,18 +211,18 @@ class TestSaveLoad(TestCase):
             list(IntListModel.objects.filter(field__contains=[1, 2]))
 
         ones_and_twos = IntListModel.objects.filter(
-            Q(field__contains=1) & Q(field__contains=2),
+            Q(field__contains=1) & Q(field__contains=2)
         )
         assert ones_and_twos.count() == 1
         assert ones_and_twos[0] == onetwo
 
         ones_and_threes = IntListModel.objects.filter(
-            Q(field__contains=1) & Q(field__contains=3),
+            Q(field__contains=1) & Q(field__contains=3)
         )
         assert ones_and_threes.count() == 0
 
         ones_or_threes = IntListModel.objects.filter(
-            Q(field__contains=1) | Q(field__contains=3),
+            Q(field__contains=1) | Q(field__contains=3)
         )
         assert ones_or_threes.count() == 1
 
@@ -244,222 +246,208 @@ class TestSaveLoad(TestCase):
 
 
 class TestListF(TestCase):
-
     def test_append_to_none(self):
         CharListModel.objects.create(field=[])
-        CharListModel.objects.update(field=ListF('field').append('first'))
+        CharListModel.objects.update(field=ListF("field").append("first"))
         model = CharListModel.objects.get()
         assert model.field == ["first"]
 
     def test_append_to_one(self):
         CharListModel.objects.create(field=["big"])
-        CharListModel.objects.update(field=ListF('field').append('bad'))
+        CharListModel.objects.update(field=ListF("field").append("bad"))
         model = CharListModel.objects.get()
         assert model.field == ["big", "bad"]
 
     def test_append_to_some(self):
         CharListModel.objects.create(field=["big", "blue"])
-        CharListModel.objects.update(field=ListF('field').append('round'))
+        CharListModel.objects.update(field=ListF("field").append("round"))
         model = CharListModel.objects.get()
         assert model.field == ["big", "blue", "round"]
 
     def test_append_to_multiple_objects(self):
         CharListModel.objects.create(field=["mouse"])
         CharListModel.objects.create(field=["keyboard"])
-        CharListModel.objects.update(field=ListF('field').append("screen"))
+        CharListModel.objects.update(field=ListF("field").append("screen"))
         first, second = tuple(CharListModel.objects.all())
         assert first.field == ["mouse", "screen"]
         assert second.field == ["keyboard", "screen"]
 
     def test_append_exists(self):
         CharListModel.objects.create(field=["nice"])
-        CharListModel.objects.update(field=ListF('field').append("nice"))
+        CharListModel.objects.update(field=ListF("field").append("nice"))
         model = CharListModel.objects.get()
         assert model.field == ["nice", "nice"]
 
     @override_mysql_variables(SQL_MODE="ANSI")
     def test_append_works_in_ansi_mode(self):
         CharListModel.objects.create()
-        CharListModel.objects.update(field=ListF('field').append('big'))
-        CharListModel.objects.update(field=ListF('field').append('bad'))
+        CharListModel.objects.update(field=ListF("field").append("big"))
+        CharListModel.objects.update(field=ListF("field").append("bad"))
         model = CharListModel.objects.get()
         assert model.field == ["big", "bad"]
 
     def test_append_assignment(self):
         model = CharListModel.objects.create(field=["red"])
-        model.field = ListF('field').append('blue')
+        model.field = ListF("field").append("blue")
         model.save()
         model = CharListModel.objects.get()
-        assert model.field == ['red', 'blue']
+        assert model.field == ["red", "blue"]
 
     def test_appendleft_to_none(self):
         CharListModel.objects.create(field=[])
-        CharListModel.objects.update(field=ListF('field').appendleft('first'))
+        CharListModel.objects.update(field=ListF("field").appendleft("first"))
         model = CharListModel.objects.get()
         assert model.field == ["first"]
 
     def test_appendleft_to_one(self):
         CharListModel.objects.create(field=["big"])
-        CharListModel.objects.update(field=ListF('field').appendleft('bad'))
+        CharListModel.objects.update(field=ListF("field").appendleft("bad"))
         model = CharListModel.objects.get()
         assert model.field == ["bad", "big"]
 
     def test_appendleft_to_some(self):
         CharListModel.objects.create(field=["big", "blue"])
-        CharListModel.objects.update(field=ListF('field').appendleft('round'))
+        CharListModel.objects.update(field=ListF("field").appendleft("round"))
         model = CharListModel.objects.get()
         assert model.field == ["round", "big", "blue"]
 
     def test_appendleft_to_multiple_objects(self):
         CharListModel.objects.create(field=["mouse"])
         CharListModel.objects.create(field=["keyboard"])
-        CharListModel.objects.update(field=ListF('field').appendleft("screen"))
+        CharListModel.objects.update(field=ListF("field").appendleft("screen"))
         first, second = tuple(CharListModel.objects.all())
         assert first.field == ["screen", "mouse"]
         assert second.field == ["screen", "keyboard"]
 
     def test_appendleft_exists(self):
         CharListModel.objects.create(field=["nice"])
-        CharListModel.objects.update(field=ListF('field').appendleft("nice"))
+        CharListModel.objects.update(field=ListF("field").appendleft("nice"))
         model = CharListModel.objects.get()
         assert model.field == ["nice", "nice"]
 
     @override_mysql_variables(SQL_MODE="ANSI")
     def test_appendleft_works_in_ansi_mode(self):
         CharListModel.objects.create()
-        CharListModel.objects.update(field=ListF('field').appendleft('big'))
-        CharListModel.objects.update(field=ListF('field').appendleft('bad'))
+        CharListModel.objects.update(field=ListF("field").appendleft("big"))
+        CharListModel.objects.update(field=ListF("field").appendleft("bad"))
         model = CharListModel.objects.get()
         assert model.field == ["bad", "big"]
 
     def test_appendleft_assignment(self):
         model = CharListModel.objects.create(field=["red"])
-        model.field = ListF('field').appendleft('blue')
+        model.field = ListF("field").appendleft("blue")
         model.save()
         model = CharListModel.objects.get()
-        assert model.field == ['blue', 'red']
+        assert model.field == ["blue", "red"]
 
     def test_pop_none(self):
         CharListModel.objects.create(field=[])
-        CharListModel.objects.update(field=ListF('field').pop())
+        CharListModel.objects.update(field=ListF("field").pop())
         model = CharListModel.objects.get()
         assert model.field == []
 
     def test_pop_one(self):
         CharListModel.objects.create(field=["red"])
-        CharListModel.objects.update(field=ListF('field').pop())
+        CharListModel.objects.update(field=ListF("field").pop())
         model = CharListModel.objects.get()
         assert model.field == []
 
     def test_pop_two(self):
         CharListModel.objects.create(field=["red", "blue"])
-        CharListModel.objects.update(field=ListF('field').pop())
+        CharListModel.objects.update(field=ListF("field").pop())
         model = CharListModel.objects.get()
         assert model.field == ["red"]
 
     def test_pop_three(self):
         CharListModel.objects.create(field=["green", "yellow", "p"])
-        CharListModel.objects.update(field=ListF('field').pop())
+        CharListModel.objects.update(field=ListF("field").pop())
         model = CharListModel.objects.get()
         assert model.field == ["green", "yellow"]
 
     def test_popleft_none(self):
         CharListModel.objects.create(field=[])
-        CharListModel.objects.update(field=ListF('field').popleft())
+        CharListModel.objects.update(field=ListF("field").popleft())
         model = CharListModel.objects.get()
         assert model.field == []
 
     def test_popleft_one(self):
         CharListModel.objects.create(field=["red"])
-        CharListModel.objects.update(field=ListF('field').popleft())
+        CharListModel.objects.update(field=ListF("field").popleft())
         model = CharListModel.objects.get()
         assert model.field == []
 
     def test_popleft_two(self):
         CharListModel.objects.create(field=["red", "blue"])
-        CharListModel.objects.update(field=ListF('field').popleft())
+        CharListModel.objects.update(field=ListF("field").popleft())
         model = CharListModel.objects.get()
         assert model.field == ["blue"]
 
     def test_popleft_three(self):
         CharListModel.objects.create(field=["green", "yellow", "p"])
-        CharListModel.objects.update(field=ListF('field').popleft())
+        CharListModel.objects.update(field=ListF("field").popleft())
         model = CharListModel.objects.get()
         assert model.field == ["yellow", "p"]
 
 
 class TestValidation(SimpleTestCase):
-
     def test_max_length(self):
-        field = ListCharField(
-            models.CharField(max_length=32),
-            size=3,
-            max_length=32,
-        )
+        field = ListCharField(models.CharField(max_length=32), size=3, max_length=32)
 
-        field.clean({'a', 'b', 'c'}, None)
+        field.clean({"a", "b", "c"}, None)
 
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean({'a', 'b', 'c', 'd'}, None)
+            field.clean({"a", "b", "c", "d"}, None)
         assert (
             excinfo.value.messages[0]
-            == 'List contains 4 items, it should contain no more than 3.'
+            == "List contains 4 items, it should contain no more than 3."
         )
 
 
 class TestCheck(SimpleTestCase):
-
     def test_field_checks(self):
         class InvalidListCharModel1(TemporaryModel):
             field = ListCharField(models.CharField(), max_length=32)
 
         errors = InvalidListCharModel1.check(actually_check=True)
         assert len(errors) == 1
-        assert errors[0].id == 'django_mysql.E004'
-        assert 'Base field for list has errors' in errors[0].msg
-        assert 'max_length' in errors[0].msg
+        assert errors[0].id == "django_mysql.E004"
+        assert "Base field for list has errors" in errors[0].msg
+        assert "max_length" in errors[0].msg
 
     def test_invalid_base_fields(self):
         class InvalidListCharModel2(TemporaryModel):
             field = ListCharField(
-                models.ForeignKey('testapp.Author', on_delete=models.CASCADE),
+                models.ForeignKey("testapp.Author", on_delete=models.CASCADE),
                 max_length=32,
             )
 
         errors = InvalidListCharModel2.check(actually_check=True)
         assert len(errors) == 1
-        assert errors[0].id == 'django_mysql.E005'
-        assert 'Base field for list must be' in errors[0].msg
+        assert errors[0].id == "django_mysql.E005"
+        assert "Base field for list must be" in errors[0].msg
 
     def test_max_length_including_base(self):
         class InvalidListCharModel3(TemporaryModel):
             field = ListCharField(
-                models.CharField(max_length=32),
-                size=2, max_length=32)
+                models.CharField(max_length=32), size=2, max_length=32
+            )
 
         errors = InvalidListCharModel3.check(actually_check=True)
         assert len(errors) == 1
-        assert errors[0].id == 'django_mysql.E006'
-        assert 'Field can overrun' in errors[0].msg
+        assert errors[0].id == "django_mysql.E006"
+        assert "Field can overrun" in errors[0].msg
 
     def test_max_length_missing_doesnt_crash(self):
         class InvalidListCharModel4(TemporaryModel):
-            field = ListCharField(
-                models.CharField(max_length=2),
-                size=2,
-            )
+            field = ListCharField(models.CharField(max_length=2), size=2)
 
         errors = InvalidListCharModel4.check(actually_check=True)
         assert len(errors) == 1
-        assert errors[0].id == 'fields.E120'
-        assert (
-            errors[0].msg
-            == "CharFields must define a 'max_length' attribute."
-        )
+        assert errors[0].id == "fields.E120"
+        assert errors[0].msg == "CharFields must define a 'max_length' attribute."
 
 
 class TestDeconstruct(TestCase):
-
     def test_deconstruct(self):
         field = ListCharField(models.IntegerField(), max_length=32)
         name, path, args, kwargs = field.deconstruct()
@@ -480,7 +468,6 @@ class TestDeconstruct(TestCase):
 
 
 class TestMigrationWriter(TestCase):
-
     def test_makemigrations(self):
         field = ListCharField(models.CharField(max_length=5), max_length=32)
         statement, imports = MigrationWriter.serialize(field)
@@ -500,11 +487,7 @@ class TestMigrationWriter(TestCase):
         ).match(statement)
 
     def test_makemigrations_with_size(self):
-        field = ListCharField(
-            models.CharField(max_length=5),
-            max_length=32,
-            size=5,
-        )
+        field = ListCharField(models.CharField(max_length=5), max_length=32, size=5)
         statement, imports = MigrationWriter.serialize(field)
 
         # The order of the output max_length/size statements varies by
@@ -523,47 +506,51 @@ class TestMigrationWriter(TestCase):
 
 
 class TestMigrations(TransactionTestCase):
-
-    @override_settings(MIGRATION_MODULES={
-        "testapp": "tests.testapp.list_default_migrations",
-    })
+    @override_settings(
+        MIGRATION_MODULES={"testapp": "tests.testapp.list_default_migrations"}
+    )
     def test_adding_field_with_default(self):
-        table_name = 'testapp_intlistdefaultmodel'
+        table_name = "testapp_intlistdefaultmodel"
         table_names = connection.introspection.table_names
         with connection.cursor() as cursor:
             assert table_name not in table_names(cursor)
 
-        call_command('migrate', 'testapp',
-                     verbosity=0, skip_checks=True, interactive=False)
+        call_command(
+            "migrate", "testapp", verbosity=0, skip_checks=True, interactive=False
+        )
         with connection.cursor() as cursor:
             assert table_name in table_names(cursor)
 
-        call_command('migrate', 'testapp', 'zero',
-                     verbosity=0, skip_checks=True, interactive=False)
+        call_command(
+            "migrate",
+            "testapp",
+            "zero",
+            verbosity=0,
+            skip_checks=True,
+            interactive=False,
+        )
         with connection.cursor() as cursor:
             assert table_name not in table_names(cursor)
 
 
 class TestSerialization(SimpleTestCase):
-
     def test_dumping(self):
         instance = CharListModel(field=["big", "comfy"])
-        data = json.loads(serializers.serialize('json', [instance]))[0]
-        field = data['fields']['field']
-        assert sorted(field.split(',')) == ["big", "comfy"]
+        data = json.loads(serializers.serialize("json", [instance]))[0]
+        field = data["fields"]["field"]
+        assert sorted(field.split(",")) == ["big", "comfy"]
 
     def test_loading(self):
-        test_data = '''
+        test_data = """
             [{"fields": {"field": "big,leather,comfy"},
              "model": "testapp.CharListModel", "pk": null}]
-        '''
-        objs = list(serializers.deserialize('json', test_data))
+        """
+        objs = list(serializers.deserialize("json", test_data))
         instance = objs[0].object
         assert instance.field == ["big", "leather", "comfy"]
 
 
 class TestDescription(SimpleTestCase):
-
     def test_char(self):
         field = ListCharField(models.CharField(max_length=5), max_length=32)
         assert field.description == "List of String (up to %(max_length)s)"
@@ -574,7 +561,6 @@ class TestDescription(SimpleTestCase):
 
 
 class TestFormField(SimpleTestCase):
-
     def test_model_field_formfield(self):
         model_field = ListCharField(models.CharField(max_length=27))
         form_field = model_field.formfield()

--- a/tests/testapp/test_listtextfield.py
+++ b/tests/testapp/test_listtextfield.py
@@ -15,7 +15,6 @@ from tests.testapp.models import BigCharListModel, BigIntListModel, TemporaryMod
 
 
 class TestSaveLoad(TestCase):
-
     def test_char_easy(self):
         s = BigCharListModel.objects.create(field=["comfy", "big"])
         assert s.field == ["comfy", "big"]
@@ -31,7 +30,7 @@ class TestSaveLoad(TestCase):
     def test_char_string_direct(self):
         s = BigCharListModel.objects.create(field="big,bad")
         s = BigCharListModel.objects.get(id=s.id)
-        assert s.field == ['big', 'bad']
+        assert s.field == ["big", "bad"]
 
     def test_is_a_list_immediately(self):
         s = BigCharListModel()
@@ -69,13 +68,13 @@ class TestSaveLoad(TestCase):
         assert empty.count() == 0
 
     def test_char_lookup_contains(self):
-        self.check_char_lookup('contains')
+        self.check_char_lookup("contains")
 
     def test_char_lookup_icontains(self):
-        self.check_char_lookup('icontains')
+        self.check_char_lookup("icontains")
 
     def check_char_lookup(self, lookup):
-        lname = 'field__' + lookup
+        lname = "field__" + lookup
         mymodel = BigCharListModel.objects.create(field=["mouldy", "rotten"])
 
         mouldy = BigCharListModel.objects.filter(**{lname: "mouldy"})
@@ -93,13 +92,13 @@ class TestSaveLoad(TestCase):
             list(BigCharListModel.objects.filter(**{lname: ["a", "b"]}))
 
         both = BigCharListModel.objects.filter(
-            Q(**{lname: "mouldy"}) & Q(**{lname: "rotten"}),
+            Q(**{lname: "mouldy"}) & Q(**{lname: "rotten"})
         )
         assert both.count() == 1
         assert both[0] == mymodel
 
         either = BigCharListModel.objects.filter(
-            Q(**{lname: "mouldy"}) | Q(**{lname: "clean"}),
+            Q(**{lname: "mouldy"}) | Q(**{lname: "clean"})
         )
         assert either.count() == 1
 
@@ -148,16 +147,14 @@ class TestSaveLoad(TestCase):
         red0 = BigCharListModel.objects.filter(field__0="red")
         assert list(red0) == [mymodel]
 
-        red0_red1 = BigCharListModel.objects.filter(field__0="red",
-                                                    field__1="red")
+        red0_red1 = BigCharListModel.objects.filter(field__0="red", field__1="red")
         assert red0_red1.count() == 0
 
-        red0_blue1 = BigCharListModel.objects.filter(field__0="red",
-                                                     field__1="blue")
+        red0_blue1 = BigCharListModel.objects.filter(field__0="red", field__1="blue")
         assert list(red0_blue1) == [mymodel]
 
         red0_or_blue0 = BigCharListModel.objects.filter(
-            Q(field__0="red") | Q(field__0="blue"),
+            Q(field__0="red") | Q(field__0="blue")
         )
         assert list(red0_or_blue0) == [mymodel]
 
@@ -185,18 +182,18 @@ class TestSaveLoad(TestCase):
             list(BigIntListModel.objects.filter(field__contains=[1, 2]))
 
         ones_and_twos = BigIntListModel.objects.filter(
-            Q(field__contains=1) & Q(field__contains=2),
+            Q(field__contains=1) & Q(field__contains=2)
         )
         assert ones_and_twos.count() == 1
         assert ones_and_twos[0] == onetwo
 
         ones_and_threes = BigIntListModel.objects.filter(
-            Q(field__contains=1) & Q(field__contains=3),
+            Q(field__contains=1) & Q(field__contains=3)
         )
         assert ones_and_threes.count() == 0
 
         ones_or_threes = BigIntListModel.objects.filter(
-            Q(field__contains=1) | Q(field__contains=3),
+            Q(field__contains=1) | Q(field__contains=3)
         )
         assert ones_or_threes.count() == 1
 
@@ -220,47 +217,41 @@ class TestSaveLoad(TestCase):
 
 
 class TestValidation(SimpleTestCase):
-
     def test_max_length(self):
-        field = ListTextField(
-            models.CharField(max_length=32),
-            size=3,
-            max_length=32,
-        )
+        field = ListTextField(models.CharField(max_length=32), size=3, max_length=32)
 
-        field.clean({'a', 'b', 'c'}, None)
+        field.clean({"a", "b", "c"}, None)
 
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean({'a', 'b', 'c', 'd'}, None)
+            field.clean({"a", "b", "c", "d"}, None)
         assert (
             excinfo.value.messages[0]
-            == 'List contains 4 items, it should contain no more than 3.'
+            == "List contains 4 items, it should contain no more than 3."
         )
 
 
 class TestCheck(SimpleTestCase):
-
     def test_field_checks(self):
         class InvalidListTextModel1(TemporaryModel):
             field = ListTextField(models.CharField(), max_length=32)
 
         errors = InvalidListTextModel1.check(actually_check=True)
         assert len(errors) == 1
-        assert errors[0].id == 'django_mysql.E004'
-        assert 'Base field for list has errors' in errors[0].msg
-        assert 'max_length' in errors[0].msg
+        assert errors[0].id == "django_mysql.E004"
+        assert "Base field for list has errors" in errors[0].msg
+        assert "max_length" in errors[0].msg
 
     def test_invalid_base_fields(self):
         class InvalidListTextModel2(TemporaryModel):
             field = ListTextField(
-                models.ForeignKey('testapp.Author', on_delete=models.CASCADE),
+                models.ForeignKey("testapp.Author", on_delete=models.CASCADE),
                 max_length=32,
             )
 
         errors = InvalidListTextModel2.check(actually_check=True)
         assert len(errors) == 1
-        assert errors[0].id == 'django_mysql.E005'
-        assert 'Base field for list must be' in errors[0].msg
+        assert errors[0].id == "django_mysql.E005"
+        assert "Base field for list must be" in errors[0].msg
 
 
 class ListTextFieldSubclass(ListTextField):
@@ -270,7 +261,6 @@ class ListTextFieldSubclass(ListTextField):
 
 
 class TestDeconstruct(TestCase):
-
     def test_deconstruct(self):
         field = ListTextField(models.IntegerField(), max_length=32)
         name, path, args, kwargs = field.deconstruct()
@@ -291,24 +281,25 @@ class TestDeconstruct(TestCase):
 
     def test_bad_import_deconstruct(self):
         from django_mysql.models.fields import ListTextField as LTField
+
         field = LTField(models.IntegerField())
         name, path, args, kwargs = field.deconstruct()
-        assert path == 'django_mysql.models.ListTextField'
+        assert path == "django_mysql.models.ListTextField"
 
     def test_bad_import2_deconstruct(self):
         from django_mysql.models.fields.lists import ListTextField as LTField
+
         field = LTField(models.IntegerField())
         name, path, args, kwargs = field.deconstruct()
-        assert path == 'django_mysql.models.ListTextField'
+        assert path == "django_mysql.models.ListTextField"
 
     def test_subclass_deconstruct(self):
         field = ListTextFieldSubclass(models.IntegerField())
         name, path, args, kwargs = field.deconstruct()
-        assert path == 'tests.testapp.test_listtextfield.ListTextFieldSubclass'
+        assert path == "tests.testapp.test_listtextfield.ListTextFieldSubclass"
 
 
 class TestMigrationWriter(TestCase):
-
     def test_makemigrations(self):
         field = ListTextField(models.CharField(max_length=5), max_length=32)
         statement, imports = MigrationWriter.serialize(field)
@@ -328,11 +319,7 @@ class TestMigrationWriter(TestCase):
         ).match(statement)
 
     def test_makemigrations_with_size(self):
-        field = ListTextField(
-            models.CharField(max_length=5),
-            max_length=32,
-            size=5,
-        )
+        field = ListTextField(models.CharField(max_length=5), max_length=32, size=5)
         statement, imports = MigrationWriter.serialize(field)
 
         # The order of the output max_length/size statements varies by
@@ -351,32 +338,30 @@ class TestMigrationWriter(TestCase):
 
 
 class TestSerialization(SimpleTestCase):
-
     def test_dumping(self):
         instance = BigCharListModel(field=["big", "comfy"])
-        data = json.loads(serializers.serialize('json', [instance]))[0]
-        field = data['fields']['field']
-        assert sorted(field.split(',')) == ["big", "comfy"]
+        data = json.loads(serializers.serialize("json", [instance]))[0]
+        field = data["fields"]["field"]
+        assert sorted(field.split(",")) == ["big", "comfy"]
 
     def test_loading(self):
-        test_data = '''
+        test_data = """
             [{"fields": {"field": "big,leather,comfy"},
              "model": "testapp.BigCharListModel", "pk": null}]
-        '''
-        objs = list(serializers.deserialize('json', test_data))
+        """
+        objs = list(serializers.deserialize("json", test_data))
         instance = objs[0].object
         assert instance.field == ["big", "leather", "comfy"]
 
     def test_dumping_loading_empty(self):
         instance = BigCharListModel(field=[])
-        data = serializers.serialize('json', [instance])
-        objs = list(serializers.deserialize('json', data))
+        data = serializers.serialize("json", [instance])
+        objs = list(serializers.deserialize("json", data))
         instance = objs[0].object
         assert instance.field == []
 
 
 class TestDescription(SimpleTestCase):
-
     def test_char(self):
         field = ListTextField(models.CharField(max_length=5), max_length=32)
         assert field.description == "List of String (up to %(max_length)s)"
@@ -387,7 +372,6 @@ class TestDescription(SimpleTestCase):
 
 
 class TestFormField(SimpleTestCase):
-
     def test_model_field_formfield(self):
         model_field = ListTextField(models.CharField(max_length=27))
         form_field = model_field.formfield()

--- a/tests/testapp/test_lookups.py
+++ b/tests/testapp/test_lookups.py
@@ -4,7 +4,6 @@ from tests.testapp.models import Author
 
 
 class CaseExactTests(TestCase):
-
     def test_charfield(self):
         dickie = Author.objects.create(name="Dickens")
 
@@ -37,7 +36,6 @@ class CaseExactTests(TestCase):
 
 
 class SoundexTests(TestCase):
-
     def test_sounds_like_lookup(self):
         principles = ["principle", "principal", "princpl"]
         created = {Author.objects.create(name=name) for name in principles}
@@ -46,12 +44,12 @@ class SoundexTests(TestCase):
             sounding = Author.objects.filter(name__sounds_like=name)
             assert set(sounding) == created
 
-        sounding = Author.objects.filter(name__sounds_like='')
+        sounding = Author.objects.filter(name__sounds_like="")
         assert set(sounding) == set()
 
-        sounding = Author.objects.filter(name__sounds_like='nothing')
+        sounding = Author.objects.filter(name__sounds_like="nothing")
         assert set(sounding) == set()
 
     def test_soundex_strings(self):
-        author = Author.objects.create(name='Robert')
-        assert Author.objects.get(name__soundex='R163') == author
+        author = Author.objects.create(name="Robert")
+        assert Author.objects.get(name__soundex="R163") == author

--- a/tests/testapp/test_rewrite_query.py
+++ b/tests/testapp/test_rewrite_query.py
@@ -8,14 +8,15 @@ from tests.testapp.utils import CaptureLastQuery
 
 
 class RewriteQueryTests(TestCase):
-
     def test_it_doesnt_touch_normal_queries(self):
         self.check_identity("SELECT 1")
         self.check_identity("SELECT col_a, col_b FROM sometable WHERE 1")
 
     def test_bad_rewrites_ignored(self):
         assert (
-            rewrite_query("SELECT col_a FROM sometable WHERE (/*QueryRewrite':STRAY_JOIN*/1)")
+            rewrite_query(
+                "SELECT col_a FROM sometable WHERE (/*QueryRewrite':STRAY_JOIN*/1)"
+            )
             == "SELECT col_a FROM sometable WHERE (1)"
         )
         assert (
@@ -23,7 +24,10 @@ class RewriteQueryTests(TestCase):
             == "SELECT col_a FROM sometable WHERE (1)"
         )
         assert (
-            rewrite_query("UPDATE col_a SET pants='onfire' WHERE (/*QueryRewrite':STRAIGHT_JOIN*/1)")
+            rewrite_query(
+                "UPDATE col_a SET pants='onfire' WHERE "
+                + "(/*QueryRewrite':STRAIGHT_JOIN*/1)"
+            )
             == "UPDATE col_a SET pants='onfire' WHERE (1)"
         )
 
@@ -37,99 +41,105 @@ class RewriteQueryTests(TestCase):
         assert rewrite_query(query) == query
 
     def test_straight_join(self):
-        assert (
-            rewrite_query("SELECT col_a, col_b FROM sometable WHERE nothing() AND (/*QueryRewrite':STRAIGHT_JOIN*/1)")
-            == "SELECT STRAIGHT_JOIN col_a, col_b FROM sometable WHERE nothing() AND (1)"
+        assert rewrite_query(
+            "SELECT col_a, col_b FROM sometable WHERE nothing() AND "
+            + "(/*QueryRewrite':STRAIGHT_JOIN*/1)"
+        ) == (
+            "SELECT STRAIGHT_JOIN col_a, col_b FROM sometable WHERE "
+            + "nothing() AND (1)"
         )
 
     def test_straight_join_preceeding_whitespace(self):
-        assert (
-            rewrite_query("  SELECT col_a, col_b FROM sometable WHERE nothing() AND (/*QueryRewrite':STRAIGHT_JOIN*/1)")
-            == "SELECT STRAIGHT_JOIN col_a, col_b FROM sometable WHERE nothing() AND (1)"
+        assert rewrite_query(
+            "  SELECT col_a, col_b FROM sometable WHERE nothing() AND "
+            + "(/*QueryRewrite':STRAIGHT_JOIN*/1)"
+        ) == (
+            "SELECT STRAIGHT_JOIN col_a, col_b FROM sometable WHERE "
+            + "nothing() AND (1)"
         )
 
     def test_straight_join_with_comment(self):
         assert (
-            rewrite_query("SELECT /* HI MUM */ col_a FROM sometable WHERE (/*QueryRewrite':STRAIGHT_JOIN*/1)")
+            rewrite_query(
+                "SELECT /* HI MUM */ col_a FROM sometable WHERE "
+                + "(/*QueryRewrite':STRAIGHT_JOIN*/1)"
+            )
             == "SELECT /* HI MUM */ STRAIGHT_JOIN col_a FROM sometable WHERE (1)"
         )
 
     def test_straight_join_with_comments(self):
         assert (
-            rewrite_query("SELECT /* GOODBYE */ col_a FROM sometable WHERE (/*QueryRewrite':STRAIGHT_JOIN*/1)")
+            rewrite_query(
+                "SELECT /* GOODBYE */ col_a FROM sometable WHERE "
+                + "(/*QueryRewrite':STRAIGHT_JOIN*/1)"
+            )
             == "SELECT /* GOODBYE */ STRAIGHT_JOIN col_a FROM sometable WHERE (1)"
         )
 
     def test_straight_join_with_repeat_comments(self):
-        assert (
-            rewrite_query(
-                "SELECT /* A */ /* B */ /* C */ col_a FROM sometable "
-                + "WHERE (/*QueryRewrite':STRAIGHT_JOIN*/1)",
-            )
-            == (
-                "SELECT /* A */ /* B */ /* C */ STRAIGHT_JOIN col_a FROM "
-                + "sometable WHERE (1)"
-            )
+        assert rewrite_query(
+            "SELECT /* A */ /* B */ /* C */ col_a FROM sometable "
+            + "WHERE (/*QueryRewrite':STRAIGHT_JOIN*/1)"
+        ) == (
+            "SELECT /* A */ /* B */ /* C */ STRAIGHT_JOIN col_a FROM "
+            + "sometable WHERE (1)"
         )
 
     def test_straight_join_with_spaceless_comment(self):
         assert (
             rewrite_query(
                 "SELECT/* this*/col_a FROM sometable "
-                + "WHERE (/*QueryRewrite':STRAIGHT_JOIN*/1)",
+                + "WHERE (/*QueryRewrite':STRAIGHT_JOIN*/1)"
             )
             == "SELECT /* this*/ STRAIGHT_JOIN col_a FROM sometable WHERE (1)"
         )
 
     def test_straight_join_idempotent(self):
-        assert (
-            rewrite_query(
-                "SELECT col_a, col_b FROM sometable "
-                + "WHERE nothing() AND (/*QueryRewrite':STRAIGHT_JOIN*/1) "
-                + "AND (/*QueryRewrite':STRAIGHT_JOIN*/1)",
-            )
-            == (
-                "SELECT STRAIGHT_JOIN col_a, col_b FROM sometable "
-                + "WHERE nothing() AND (1) AND (1)"
-            )
+        assert rewrite_query(
+            "SELECT col_a, col_b FROM sometable "
+            + "WHERE nothing() AND (/*QueryRewrite':STRAIGHT_JOIN*/1) "
+            + "AND (/*QueryRewrite':STRAIGHT_JOIN*/1)"
+        ) == (
+            "SELECT STRAIGHT_JOIN col_a, col_b FROM sometable "
+            + "WHERE nothing() AND (1) AND (1)"
         )
 
     def test_straight_join_doesnt_affect_distinct(self):
         assert (
-            rewrite_query("SELECT DISTINCT col_a FROM sometable WHERE (/*QueryRewrite':STRAIGHT_JOIN*/1)")
+            rewrite_query(
+                "SELECT DISTINCT col_a FROM sometable WHERE "
+                + "(/*QueryRewrite':STRAIGHT_JOIN*/1)"
+            )
             == "SELECT DISTINCT STRAIGHT_JOIN col_a FROM sometable WHERE (1)"
         )
 
     def test_straight_join_doesnt_affect_all_and_highpriority(self):
         assert (
-            rewrite_query("SELECT ALL HIGH_PRIORITY col_a FROM sometable WHERE (/*QueryRewrite':STRAIGHT_JOIN*/1)")
+            rewrite_query(
+                "SELECT ALL HIGH_PRIORITY col_a FROM sometable WHERE "
+                + "(/*QueryRewrite':STRAIGHT_JOIN*/1)"
+            )
             == "SELECT ALL HIGH_PRIORITY STRAIGHT_JOIN col_a FROM sometable WHERE (1)"
         )
 
     def test_2_straight_joins_dont_affect_all_and_highpriority(self):
-        assert (
-            rewrite_query(
-                "SELECT ALL HIGH_PRIORITY col_a FROM sometable "
-                + "WHERE (/*QueryRewrite':STRAIGHT_JOIN*/1) AND "
-                + "(/*QueryRewrite':STRAIGHT_JOIN*/1)",
-            )
-            == (
-                "SELECT ALL HIGH_PRIORITY STRAIGHT_JOIN col_a FROM sometable "
-                + "WHERE (1) AND (1)"
-            )
+        assert rewrite_query(
+            "SELECT ALL HIGH_PRIORITY col_a FROM sometable "
+            + "WHERE (/*QueryRewrite':STRAIGHT_JOIN*/1) AND "
+            + "(/*QueryRewrite':STRAIGHT_JOIN*/1)"
+        ) == (
+            "SELECT ALL HIGH_PRIORITY STRAIGHT_JOIN col_a FROM sometable "
+            + "WHERE (1) AND (1)"
         )
 
     def test_multiple_hints(self):
-        assert (
-            rewrite_query(
-                "SELECT col_a FROM sometable "
-                + "WHERE (/*QueryRewrite':STRAIGHT_JOIN*/1) AND "
-                + "(/*QueryRewrite':SQL_NO_CACHE*/1)",
-            )
-            == (
-                "SELECT STRAIGHT_JOIN SQL_NO_CACHE col_a FROM sometable "
-                + "WHERE (1) AND (1)"
-            )
+        assert rewrite_query(
+            "SELECT col_a FROM sometable "
+            + "WHERE (/*QueryRewrite':STRAIGHT_JOIN*/1) AND "
+            + "(/*QueryRewrite':SQL_NO_CACHE*/1)"
+        ) == (
+            "SELECT STRAIGHT_JOIN SQL_NO_CACHE col_a FROM sometable "
+            + "WHERE (1) AND (1)"
         )
 
     def test_mutually_exclusive_latest_wins(self):
@@ -137,162 +147,138 @@ class RewriteQueryTests(TestCase):
             rewrite_query(
                 "SELECT col_a FROM sometable "
                 + "WHERE (/*QueryRewrite':SQL_CACHE*/1) AND "
-                + "(/*QueryRewrite':SQL_NO_CACHE*/1)",
+                + "(/*QueryRewrite':SQL_NO_CACHE*/1)"
             )
             == "SELECT SQL_NO_CACHE col_a FROM sometable WHERE (1) AND (1)"
         )
 
     def test_labelling(self):
         assert (
-            rewrite_query("SELECT col_a FROM sometable WHERE (/*QueryRewrite':label=himum*/1)")
+            rewrite_query(
+                "SELECT col_a FROM sometable WHERE (/*QueryRewrite':label=himum*/1)"
+            )
             == "SELECT /*himum*/ col_a FROM sometable WHERE (1)"
         )
 
     def test_labelling_mysql_57_hint(self):
-        assert (
-            rewrite_query(
-                "SELECT col_a FROM t1 "
-                + "WHERE (/*QueryRewrite':label=+ NO_RANGE_OPTIMIZATION(t1 "
-                + "PRIMARY) */1)",
-            )
-            == (
-                "SELECT /*+ NO_RANGE_OPTIMIZATION(t1 PRIMARY) */ col_a FROM "
-                + "t1 WHERE (1)"
-            )
+        assert rewrite_query(
+            "SELECT col_a FROM t1 "
+            + "WHERE (/*QueryRewrite':label=+ NO_RANGE_OPTIMIZATION(t1 "
+            + "PRIMARY) */1)"
+        ) == (
+            "SELECT /*+ NO_RANGE_OPTIMIZATION(t1 PRIMARY) */ col_a FROM "
+            + "t1 WHERE (1)"
         )
 
     def test_not_case_sensitive(self):
         assert (
-            rewrite_query("select col_a from sometable where (/*QueryRewrite':label=himum*/1)")
+            rewrite_query(
+                "select col_a from sometable where (/*QueryRewrite':label=himum*/1)"
+            )
             == "select /*himum*/ col_a from sometable where (1)"
         )
 
     def test_bad_query_not_rewritten(self):
         assert (
-            rewrite_query("SELECTSTRAIGHT_JOIN col_a FROM sometable WHERE (/*QueryRewrite':label=hi*/1)")
+            rewrite_query(
+                "SELECTSTRAIGHT_JOIN col_a FROM sometable WHERE "
+                + "(/*QueryRewrite':label=hi*/1)"
+            )
             == "SELECTSTRAIGHT_JOIN col_a FROM sometable WHERE (1)"
         )
 
     def test_index_hint_use(self):
         assert (
-            rewrite_query("SELECT col_a FROM `sometable` WHERE (/*QueryRewrite':index=`sometable` USE `col_a_idx`*/1)")
+            rewrite_query(
+                "SELECT col_a FROM `sometable` WHERE "
+                + "(/*QueryRewrite':index=`sometable` USE `col_a_idx`*/1)"
+            )
             == "SELECT col_a FROM `sometable` USE INDEX (`col_a_idx`) WHERE (1)"
         )
 
     def test_index_ignore(self):
-        assert (
-            rewrite_query(
-                "SELECT col_a FROM `sometable` WHERE "
-                + "(/*QueryRewrite':index=`sometable` IGNORE `col_a_idx`*/1)",
-            )
-            == (
-                "SELECT col_a FROM `sometable` IGNORE INDEX (`col_a_idx`) "
-                + "WHERE (1)"
-            )
-        )
+        assert rewrite_query(
+            "SELECT col_a FROM `sometable` WHERE "
+            + "(/*QueryRewrite':index=`sometable` IGNORE `col_a_idx`*/1)"
+        ) == ("SELECT col_a FROM `sometable` IGNORE INDEX (`col_a_idx`) " + "WHERE (1)")
 
     def test_index_force(self):
-        assert (
-            rewrite_query(
-                "SELECT col_a FROM `sometable` WHERE "
-                + "(/*QueryRewrite':index=`sometable` FORCE `col_a_idx`*/1)",
-            )
-            == (
-                "SELECT col_a FROM `sometable` FORCE INDEX (`col_a_idx`) "
-                + "WHERE (1)"
-            )
-        )
+        assert rewrite_query(
+            "SELECT col_a FROM `sometable` WHERE "
+            + "(/*QueryRewrite':index=`sometable` FORCE `col_a_idx`*/1)"
+        ) == ("SELECT col_a FROM `sometable` FORCE INDEX (`col_a_idx`) " + "WHERE (1)")
 
     def test_index_nonsense_does_nothing(self):
         assert (
             rewrite_query(
                 "SELECT col_a FROM `sometable` WHERE "
-                + "(/*QueryRewrite':index=`sometable` MAHOGANY `col_a_idx`*/1)",
+                + "(/*QueryRewrite':index=`sometable` MAHOGANY `col_a_idx`*/1)"
             )
             == "SELECT col_a FROM `sometable` WHERE (1)"
         )
 
     def test_index_hint_use_secondary(self):
-        assert (
-            rewrite_query(
-                "SELECT col_a, col_b FROM `sometable` INNER JOIN `othertable` "
-                + "WHERE (/*QueryRewrite':index=`othertable` USE `myindex`*/1)",
-            )
-            == (
-                "SELECT col_a, col_b FROM `sometable` INNER JOIN `othertable` "
-                + "USE INDEX (`myindex`) WHERE (1)"
-            )
+        assert rewrite_query(
+            "SELECT col_a, col_b FROM `sometable` INNER JOIN `othertable` "
+            + "WHERE (/*QueryRewrite':index=`othertable` USE `myindex`*/1)"
+        ) == (
+            "SELECT col_a, col_b FROM `sometable` INNER JOIN `othertable` "
+            + "USE INDEX (`myindex`) WHERE (1)"
         )
 
     def test_index_hint_multiple_indexes(self):
-        assert (
-            rewrite_query(
-                "SELECT col_a FROM `tabl` WHERE "
-                "(/*QueryRewrite':index=`tabl` IGNORE `idx1`,`idx2`*/1)",
-            )
-            == (
-                "SELECT col_a FROM `tabl` IGNORE INDEX (`idx1`,`idx2`) WHERE "
-                + "(1)"
-            )
-        )
+        assert rewrite_query(
+            "SELECT col_a FROM `tabl` WHERE "
+            "(/*QueryRewrite':index=`tabl` IGNORE `idx1`,`idx2`*/1)"
+        ) == ("SELECT col_a FROM `tabl` IGNORE INDEX (`idx1`,`idx2`) WHERE " + "(1)")
 
     def test_index_hint_multiple_hints(self):
-        assert (
-            rewrite_query(
-                "SELECT col_a FROM `sometable` "
-                + "WHERE (/*QueryRewrite':index=`sometable` IGNORE `idx1`*/1) "
-                + "AND (/*QueryRewrite':index=`sometable` IGNORE `idx2`*/1)",
-            )
-            == (
-                "SELECT col_a FROM `sometable` IGNORE INDEX (`idx2`) "
-                + "IGNORE INDEX (`idx1`) WHERE (1) AND (1)"
-            )
+        assert rewrite_query(
+            "SELECT col_a FROM `sometable` "
+            + "WHERE (/*QueryRewrite':index=`sometable` IGNORE `idx1`*/1) "
+            + "AND (/*QueryRewrite':index=`sometable` IGNORE `idx2`*/1)"
+        ) == (
+            "SELECT col_a FROM `sometable` IGNORE INDEX (`idx2`) "
+            + "IGNORE INDEX (`idx1`) WHERE (1) AND (1)"
         )
 
     def test_index_hint_for_join(self):
-        assert (
-            rewrite_query(
-                "SELECT `sometable`.col_a, `sometable2`.col_b "
-                + "FROM `sometable` NATURAL JOIN `sometable2` "
-                + "WHERE (/*QueryRewrite':index=`sometable` IGNORE FOR JOIN "
-                + "`idx`*/1)",
-            )
-            == (
-                "SELECT `sometable`.col_a, `sometable2`.col_b FROM "
-                + "`sometable` IGNORE INDEX FOR JOIN (`idx`) NATURAL JOIN "
-                + "`sometable2` WHERE (1)"
-            )
+        assert rewrite_query(
+            "SELECT `sometable`.col_a, `sometable2`.col_b "
+            + "FROM `sometable` NATURAL JOIN `sometable2` "
+            + "WHERE (/*QueryRewrite':index=`sometable` IGNORE FOR JOIN "
+            + "`idx`*/1)"
+        ) == (
+            "SELECT `sometable`.col_a, `sometable2`.col_b FROM "
+            + "`sometable` IGNORE INDEX FOR JOIN (`idx`) NATURAL JOIN "
+            + "`sometable2` WHERE (1)"
         )
 
     def test_index_hint_for_group_by(self):
-        assert (
-            rewrite_query(
-                "SELECT col_a, SUM(col_b) FROM `sometable` "
-                + "WHERE (/*QueryRewrite':index=`sometable` FORCE FOR GROUP BY "
-                + "`idx`*/1) GROUP BY col_a",
-            )
-            == (
-                "SELECT col_a, SUM(col_b) FROM `sometable` FORCE INDEX FOR "
-                + "GROUP BY (`idx`) WHERE (1) GROUP BY col_a"
-            )
+        assert rewrite_query(
+            "SELECT col_a, SUM(col_b) FROM `sometable` "
+            + "WHERE (/*QueryRewrite':index=`sometable` FORCE FOR GROUP BY "
+            + "`idx`*/1) GROUP BY col_a"
+        ) == (
+            "SELECT col_a, SUM(col_b) FROM `sometable` FORCE INDEX FOR "
+            + "GROUP BY (`idx`) WHERE (1) GROUP BY col_a"
         )
 
     def test_index_hint_for_order_by(self):
-        assert (
-            rewrite_query(
-                "SELECT col_a FROM `sometable` "
-                + "WHERE (/*QueryRewrite':index=`sometable` USE FOR ORDER BY "
-                + "`idx` */1) ORDER BY col_a",
-            )
-            == (
-                "SELECT col_a FROM `sometable` USE INDEX FOR ORDER BY (`idx`) "
-                + "WHERE (1) ORDER BY col_a"
-            )
+        assert rewrite_query(
+            "SELECT col_a FROM `sometable` "
+            + "WHERE (/*QueryRewrite':index=`sometable` USE FOR ORDER BY "
+            + "`idx` */1) ORDER BY col_a"
+        ) == (
+            "SELECT col_a FROM `sometable` USE INDEX FOR ORDER BY (`idx`) "
+            + "WHERE (1) ORDER BY col_a"
         )
 
     def test_it_is_monkey_patched(self):
         with CaptureLastQuery() as cap, connection.cursor() as cursor:
-            cursor.execute("SELECT 1 FROM DUAL WHERE (/*QueryRewrite':STRAIGHT_JOIN*/1)")
+            cursor.execute(
+                "SELECT 1 FROM DUAL WHERE (/*QueryRewrite':STRAIGHT_JOIN*/1)"
+            )
         assert cap.query == "SELECT STRAIGHT_JOIN 1 FROM DUAL WHERE (1)"
 
     @override_settings(DJANGO_MYSQL_REWRITE_QUERIES=False)

--- a/tests/testapp/test_setcharfield.py
+++ b/tests/testapp/test_setcharfield.py
@@ -13,11 +13,15 @@ from django.test import SimpleTestCase, TestCase, TransactionTestCase, override_
 from django_mysql.forms import SimpleSetField
 from django_mysql.models import SetCharField, SetF
 from django_mysql.test.utils import override_mysql_variables
-from tests.testapp.models import CharSetDefaultModel, CharSetModel, IntSetModel, TemporaryModel
+from tests.testapp.models import (
+    CharSetDefaultModel,
+    CharSetModel,
+    IntSetModel,
+    TemporaryModel,
+)
 
 
 class TestSaveLoad(TestCase):
-
     def test_char_easy(self):
         s = CharSetModel.objects.create(field={"big", "comfy"})
         assert s.field == {"comfy", "big"}
@@ -33,7 +37,7 @@ class TestSaveLoad(TestCase):
     def test_char_string_direct(self):
         s = CharSetModel.objects.create(field="big,bad")
         s = CharSetModel.objects.get(id=s.id)
-        assert s.field == {'big', 'bad'}
+        assert s.field == {"big", "bad"}
 
     def test_is_a_set_immediately(self):
         s = CharSetModel()
@@ -71,13 +75,13 @@ class TestSaveLoad(TestCase):
         assert empty.count() == 0
 
     def test_char_lookup_contains(self):
-        self.check_char_lookup('contains')
+        self.check_char_lookup("contains")
 
     def test_char_lookup_icontains(self):
-        self.check_char_lookup('icontains')
+        self.check_char_lookup("icontains")
 
     def check_char_lookup(self, lookup):
-        lname = 'field__' + lookup
+        lname = "field__" + lookup
         mymodel = CharSetModel.objects.create(field={"mouldy", "rotten"})
 
         mouldy = CharSetModel.objects.filter(**{lname: "mouldy"})
@@ -95,13 +99,13 @@ class TestSaveLoad(TestCase):
             list(CharSetModel.objects.filter(**{lname: {"a", "b"}}))
 
         both = CharSetModel.objects.filter(
-            Q(**{lname: "mouldy"}) & Q(**{lname: "rotten"}),
+            Q(**{lname: "mouldy"}) & Q(**{lname: "rotten"})
         )
         assert both.count() == 1
         assert both[0] == mymodel
 
         either = CharSetModel.objects.filter(
-            Q(**{lname: "mouldy"}) | Q(**{lname: "clean"}),
+            Q(**{lname: "mouldy"}) | Q(**{lname: "clean"})
         )
         assert either.count() == 1
 
@@ -172,18 +176,18 @@ class TestSaveLoad(TestCase):
             list(IntSetModel.objects.filter(field__contains={1, 2}))
 
         ones_and_twos = IntSetModel.objects.filter(
-            Q(field__contains=1) & Q(field__contains=2),
+            Q(field__contains=1) & Q(field__contains=2)
         )
         assert ones_and_twos.count() == 1
         assert ones_and_twos[0] == onetwo
 
         ones_and_threes = IntSetModel.objects.filter(
-            Q(field__contains=1) & Q(field__contains=3),
+            Q(field__contains=1) & Q(field__contains=3)
         )
         assert ones_and_threes.count() == 0
 
         ones_or_threes = IntSetModel.objects.filter(
-            Q(field__contains=1) | Q(field__contains=3),
+            Q(field__contains=1) | Q(field__contains=3)
         )
         assert ones_or_threes.count() == 1
 
@@ -195,63 +199,62 @@ class TestSaveLoad(TestCase):
 
 
 class TestSetF(TestCase):
-
     def test_add_to_none(self):
         CharSetModel.objects.create(field=set())
-        CharSetModel.objects.update(field=SetF('field').add('first'))
+        CharSetModel.objects.update(field=SetF("field").add("first"))
         model = CharSetModel.objects.get()
         assert model.field == {"first"}
 
     def test_add_to_one(self):
         CharSetModel.objects.create(field={"big"})
-        CharSetModel.objects.update(field=SetF('field').add('bad'))
+        CharSetModel.objects.update(field=SetF("field").add("bad"))
         model = CharSetModel.objects.get()
         assert model.field == {"big", "bad"}
 
     def test_add_to_some(self):
         CharSetModel.objects.create(field={"big", "blue"})
-        CharSetModel.objects.update(field=SetF('field').add('round'))
+        CharSetModel.objects.update(field=SetF("field").add("round"))
         model = CharSetModel.objects.get()
         assert model.field == {"big", "blue", "round"}
 
     def test_add_to_multiple_objects(self):
         CharSetModel.objects.create(field={"mouse"})
         CharSetModel.objects.create(field={"keyboard"})
-        CharSetModel.objects.update(field=SetF('field').add("screen"))
+        CharSetModel.objects.update(field=SetF("field").add("screen"))
         first, second = tuple(CharSetModel.objects.all())
         assert first.field == {"mouse", "screen"}
         assert second.field == {"keyboard", "screen"}
 
     def test_add_exists(self):
         CharSetModel.objects.create(field={"nice"})
-        CharSetModel.objects.update(field=SetF('field').add("nice"))
+        CharSetModel.objects.update(field=SetF("field").add("nice"))
         model = CharSetModel.objects.get()
         assert model.field == {"nice"}
 
     @override_mysql_variables(SQL_MODE="ANSI")
     def test_add_works_in_ansi_mode(self):
         CharSetModel.objects.create()
-        CharSetModel.objects.update(field=SetF('field').add('big'))
-        CharSetModel.objects.update(field=SetF('field').add('bad'))
+        CharSetModel.objects.update(field=SetF("field").add("big"))
+        CharSetModel.objects.update(field=SetF("field").add("bad"))
         model = CharSetModel.objects.get()
         assert model.field == {"big", "bad"}
 
     def test_add_assignment(self):
         model = CharSetModel.objects.create(field={"red"})
-        model.field = SetF('field').add('blue')
+        model.field = SetF("field").add("blue")
         model.save()
         model = CharSetModel.objects.get()
-        assert model.field == {'red', 'blue'}
+        assert model.field == {"red", "blue"}
 
     def test_remove_one(self):
         CharSetModel.objects.create(field={"dopey", "knifey"})
-        CharSetModel.objects.update(field=SetF('field').remove('knifey'))
+        CharSetModel.objects.update(field=SetF("field").remove("knifey"))
         model = CharSetModel.objects.get()
         assert model.field == {"dopey"}
 
     def test_remove_only_one(self):
         CharSetModel.objects.create(field={"pants"})
-        CharSetModel.objects.update(field=SetF('field').remove('pants'))
+        CharSetModel.objects.update(field=SetF("field").remove("pants"))
         model = CharSetModel.objects.get()
         assert model.field == set()
 
@@ -264,21 +267,21 @@ class TestSetF(TestCase):
     def test_remove_first(self):
         CharSetModel.objects.create()
         CharSetModel.objects.update(field="a,b,c")
-        CharSetModel.objects.update(field=SetF('field').remove('a'))
+        CharSetModel.objects.update(field=SetF("field").remove("a"))
         model = CharSetModel.objects.get()
         assert model.field == {"b", "c"}
 
     def test_remove_middle(self):
         CharSetModel.objects.create()
         CharSetModel.objects.update(field="a,b,c")
-        CharSetModel.objects.update(field=SetF('field').remove('b'))
+        CharSetModel.objects.update(field=SetF("field").remove("b"))
         model = CharSetModel.objects.get()
         assert model.field == {"a", "c"}
 
     def test_remove_last(self):
         CharSetModel.objects.create()
         CharSetModel.objects.update(field="a,b,c")
-        CharSetModel.objects.update(field=SetF('field').remove('c'))
+        CharSetModel.objects.update(field=SetF("field").remove("c"))
         model = CharSetModel.objects.get()
         assert model.field == {"a", "b"}
 
@@ -291,7 +294,7 @@ class TestSetF(TestCase):
     def test_remove_from_multiple_objects(self):
         CharSetModel.objects.create(field={"mouse", "chair"})
         CharSetModel.objects.create(field={"keyboard", "chair"})
-        CharSetModel.objects.update(field=SetF('field').remove("chair"))
+        CharSetModel.objects.update(field=SetF("field").remove("chair"))
         first, second = tuple(CharSetModel.objects.all())
         assert first.field == {"mouse"}
         assert second.field == {"keyboard"}
@@ -299,29 +302,27 @@ class TestSetF(TestCase):
     @override_mysql_variables(SQL_MODE="ANSI")
     def test_remove_works_in_ansi_mode(self):
         CharSetModel.objects.create(field={"bold"})
-        CharSetModel.objects.update(field=SetF('field').remove('big'))
-        CharSetModel.objects.update(field=SetF('field').remove('bold'))
-        CharSetModel.objects.update(field=SetF('field').remove('bad'))
+        CharSetModel.objects.update(field=SetF("field").remove("big"))
+        CharSetModel.objects.update(field=SetF("field").remove("bold"))
+        CharSetModel.objects.update(field=SetF("field").remove("bad"))
         model = CharSetModel.objects.get()
         assert model.field == set()
 
     def test_remove_assignment(self):
         model = IntSetModel.objects.create(field={24, 89})
-        model.field = SetF('field').remove(89)
+        model.field = SetF("field").remove(89)
         model.save()
         model = IntSetModel.objects.get()
         assert model.field == {24}
 
     def test_works_with_two_fields(self):
         CharSetModel.objects.create(
-            field={"snickers", "lion"},
-            field2={"apple", "orange"},
+            field={"snickers", "lion"}, field2={"apple", "orange"}
         )
 
         # Concurrent add
         CharSetModel.objects.update(
-            field=SetF('field').add("mars"),
-            field2=SetF('field2').add("banana"),
+            field=SetF("field").add("mars"), field2=SetF("field2").add("banana")
         )
         model = CharSetModel.objects.get()
         assert model.field == {"snickers", "lion", "mars"}
@@ -329,8 +330,7 @@ class TestSetF(TestCase):
 
         # Concurrent add and remove
         CharSetModel.objects.update(
-            field=SetF('field').add("reeses"),
-            field2=SetF('field2').remove("banana"),
+            field=SetF("field").add("reeses"), field2=SetF("field2").remove("banana")
         )
         model = CharSetModel.objects.get()
         assert model.field == {"snickers", "lion", "mars", "reeses"}
@@ -338,8 +338,7 @@ class TestSetF(TestCase):
 
         # Swap
         CharSetModel.objects.update(
-            field=SetF('field').remove("lion"),
-            field2=SetF('field2').remove("apple"),
+            field=SetF("field").remove("lion"), field2=SetF("field2").remove("apple")
         )
         model = CharSetModel.objects.get()
         assert model.field == {"snickers", "mars", "reeses"}
@@ -347,29 +346,26 @@ class TestSetF(TestCase):
 
 
 class TestValidation(SimpleTestCase):
-
     def test_max_length(self):
-        field = SetCharField(
-            models.CharField(max_length=32),
-            size=3,
-            max_length=32,
-        )
+        field = SetCharField(models.CharField(max_length=32), size=3, max_length=32)
 
-        field.clean({'a', 'b', 'c'}, None)
+        field.clean({"a", "b", "c"}, None)
 
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean({'a', 'b', 'c', 'd'}, None)
-        assert excinfo.value.messages[0] == 'Set contains 4 items, it should contain no more than 3.'
+            field.clean({"a", "b", "c", "d"}, None)
+        assert (
+            excinfo.value.messages[0]
+            == "Set contains 4 items, it should contain no more than 3."
+        )
 
 
 class TestCheck(SimpleTestCase):
-
     def test_model_set(self):
-        field = IntSetModel._meta.get_field('field')
+        field = IntSetModel._meta.get_field("field")
         assert field.model == IntSetModel
         # I think this is a side effect of migrations being run in tests -
         # the base_field.model is the __fake__ model
-        assert field.base_field.model.__name__ == 'IntSetModel'
+        assert field.base_field.model.__name__ == "IntSetModel"
 
     def test_base_field_checks(self):
         class InvalidSetCharFieldModel1(TemporaryModel):
@@ -377,48 +373,42 @@ class TestCheck(SimpleTestCase):
 
         errors = InvalidSetCharFieldModel1.check(actually_check=True)
         assert len(errors) == 1
-        assert errors[0].id == 'django_mysql.E001'
-        assert 'Base field for set has errors' in errors[0].msg
-        assert 'max_length' in errors[0].msg
+        assert errors[0].id == "django_mysql.E001"
+        assert "Base field for set has errors" in errors[0].msg
+        assert "max_length" in errors[0].msg
 
     def test_invalid_base_fields(self):
         class InvalidSetCharFieldModel2(TemporaryModel):
             field = SetCharField(
-                models.ForeignKey('testapp.Author', on_delete=models.CASCADE),
+                models.ForeignKey("testapp.Author", on_delete=models.CASCADE),
                 max_length=32,
             )
 
         errors = InvalidSetCharFieldModel2.check(actually_check=True)
         assert len(errors) == 1
-        assert errors[0].id == 'django_mysql.E002'
-        assert 'Base field for set must be' in errors[0].msg
+        assert errors[0].id == "django_mysql.E002"
+        assert "Base field for set must be" in errors[0].msg
 
     def test_max_length_including_base(self):
         class InvalidSetCharFieldModel3(TemporaryModel):
-            field = SetCharField(
-                models.CharField(max_length=32),
-                size=2, max_length=32)
+            field = SetCharField(models.CharField(max_length=32), size=2, max_length=32)
 
         errors = InvalidSetCharFieldModel3.check(actually_check=True)
         assert len(errors) == 1
-        assert errors[0].id == 'django_mysql.E003'
-        assert 'Field can overrun' in errors[0].msg
+        assert errors[0].id == "django_mysql.E003"
+        assert "Field can overrun" in errors[0].msg
 
     def test_max_length_missing_doesnt_crash(self):
         class InvalidSetCharFieldModel4(TemporaryModel):
-            field = SetCharField(
-                models.CharField(max_length=2),
-                size=2,
-            )
+            field = SetCharField(models.CharField(max_length=2), size=2)
 
         errors = InvalidSetCharFieldModel4.check(actually_check=True)
         assert len(errors) == 1
-        assert errors[0].id == 'fields.E120'
+        assert errors[0].id == "fields.E120"
         assert errors[0].msg == "CharFields must define a 'max_length' attribute."
 
 
 class TestDeconstruct(TestCase):
-
     def test_deconstruct(self):
         field = SetCharField(models.IntegerField(), max_length=32)
         name, path, args, kwargs = field.deconstruct()
@@ -457,13 +447,8 @@ class TestDeconstruct(TestCase):
 
 
 class TestMigrationWriter(TestCase):
-
     def test_makemigrations_with_size(self):
-        field = SetCharField(
-            models.CharField(max_length=5),
-            max_length=32,
-            size=5,
-        )
+        field = SetCharField(models.CharField(max_length=5), max_length=32, size=5)
         statement, imports = MigrationWriter.serialize(field)
 
         # The order of the output max_length/size statements varies by
@@ -482,47 +467,51 @@ class TestMigrationWriter(TestCase):
 
 
 class TestMigrations(TransactionTestCase):
-
-    @override_settings(MIGRATION_MODULES={
-        "testapp": "tests.testapp.set_default_migrations",
-    })
+    @override_settings(
+        MIGRATION_MODULES={"testapp": "tests.testapp.set_default_migrations"}
+    )
     def test_adding_field_with_default(self):
-        table_name = 'testapp_intsetdefaultmodel'
+        table_name = "testapp_intsetdefaultmodel"
         table_names = connection.introspection.table_names
         with connection.cursor() as cursor:
             assert table_name not in table_names(cursor)
 
-        call_command('migrate', 'testapp',
-                     verbosity=0, skip_checks=True, interactive=False)
+        call_command(
+            "migrate", "testapp", verbosity=0, skip_checks=True, interactive=False
+        )
         with connection.cursor() as cursor:
             assert table_name in table_names(cursor)
 
-        call_command('migrate', 'testapp', 'zero',
-                     verbosity=0, skip_checks=True, interactive=False)
+        call_command(
+            "migrate",
+            "testapp",
+            "zero",
+            verbosity=0,
+            skip_checks=True,
+            interactive=False,
+        )
         with connection.cursor() as cursor:
             assert table_name not in table_names(cursor)
 
 
 class TestSerialization(SimpleTestCase):
-
     def test_dumping(self):
         instance = CharSetModel(field={"big", "comfy"})
-        data = json.loads(serializers.serialize('json', [instance]))[0]
-        field = data['fields']['field']
-        assert sorted(field.split(',')) == ["big", "comfy"]
+        data = json.loads(serializers.serialize("json", [instance]))[0]
+        field = data["fields"]["field"]
+        assert sorted(field.split(",")) == ["big", "comfy"]
 
     def test_loading(self):
-        test_data = '''
+        test_data = """
             [{"fields": {"field": "big,leather,comfy"},
              "model": "testapp.CharSetModel", "pk": null}]
-        '''
-        objs = list(serializers.deserialize('json', test_data))
+        """
+        objs = list(serializers.deserialize("json", test_data))
         instance = objs[0].object
         assert instance.field == {"big", "leather", "comfy"}
 
 
 class TestDescription(SimpleTestCase):
-
     def test_char(self):
         field = SetCharField(models.CharField(max_length=5), max_length=32)
         assert field.description == "Set of String (up to %(max_length)s)"
@@ -533,7 +522,6 @@ class TestDescription(SimpleTestCase):
 
 
 class TestFormField(SimpleTestCase):
-
     def test_model_field_formfield(self):
         model_field = SetCharField(models.CharField(max_length=27))
         form_field = model_field.formfield()

--- a/tests/testapp/test_settextfield.py
+++ b/tests/testapp/test_settextfield.py
@@ -14,7 +14,6 @@ from tests.testapp.models import BigCharSetModel, BigIntSetModel, TemporaryModel
 
 
 class TestSaveLoad(TestCase):
-
     def test_char_easy(self):
         big_set = {str(i ** 2) for i in range(1000)}
         s = BigCharSetModel.objects.create(field=big_set)
@@ -22,7 +21,7 @@ class TestSaveLoad(TestCase):
         s = BigCharSetModel.objects.get(id=s.id)
         assert s.field == big_set
 
-        letters = set('abcdefghi')
+        letters = set("abcdefghi")
         bigger_set = big_set | letters
         s.field.update(letters)
         assert s.field == bigger_set
@@ -32,7 +31,7 @@ class TestSaveLoad(TestCase):
 
     def test_char_string_direct(self):
         big_set = {str(i ** 2) for i in range(1000)}
-        big_str = ','.join(big_set)
+        big_str = ",".join(big_set)
         s = BigCharSetModel.objects.create(field=big_str)
         s = BigCharSetModel.objects.get(id=s.id)
         assert s.field == big_set
@@ -73,13 +72,13 @@ class TestSaveLoad(TestCase):
         assert empty.count() == 0
 
     def test_char_lookup_contains(self):
-        self.check_char_lookup('contains')
+        self.check_char_lookup("contains")
 
     def test_char_lookup_icontains(self):
-        self.check_char_lookup('icontains')
+        self.check_char_lookup("icontains")
 
     def check_char_lookup(self, lookup):
-        lname = 'field__' + lookup
+        lname = "field__" + lookup
         mymodel = BigCharSetModel.objects.create(field={"mouldy", "rotten"})
 
         mouldy = BigCharSetModel.objects.filter(**{lname: "mouldy"})
@@ -97,13 +96,13 @@ class TestSaveLoad(TestCase):
             list(BigCharSetModel.objects.filter(**{lname: {"a", "b"}}))
 
         both = BigCharSetModel.objects.filter(
-            Q(**{lname: "mouldy"}) & Q(**{lname: "rotten"}),
+            Q(**{lname: "mouldy"}) & Q(**{lname: "rotten"})
         )
         assert both.count() == 1
         assert both[0] == mymodel
 
         either = BigCharSetModel.objects.filter(
-            Q(**{lname: "mouldy"}) | Q(**{lname: "clean"}),
+            Q(**{lname: "mouldy"}) | Q(**{lname: "clean"})
         )
         assert either.count() == 1
 
@@ -168,18 +167,18 @@ class TestSaveLoad(TestCase):
             list(BigIntSetModel.objects.filter(field__contains={1, 2}))
 
         ones_and_twos = BigIntSetModel.objects.filter(
-            Q(field__contains=1) & Q(field__contains=2),
+            Q(field__contains=1) & Q(field__contains=2)
         )
         assert ones_and_twos.count() == 1
         assert ones_and_twos[0] == onetwo
 
         ones_and_threes = BigIntSetModel.objects.filter(
-            Q(field__contains=1) & Q(field__contains=3),
+            Q(field__contains=1) & Q(field__contains=3)
         )
         assert ones_and_threes.count() == 0
 
         ones_or_threes = BigIntSetModel.objects.filter(
-            Q(field__contains=1) | Q(field__contains=3),
+            Q(field__contains=1) | Q(field__contains=3)
         )
         assert ones_or_threes.count() == 1
 
@@ -191,25 +190,26 @@ class TestSaveLoad(TestCase):
 
 
 class TestValidation(SimpleTestCase):
-
     def test_max_length(self):
         field = SetTextField(models.CharField(max_length=32), size=3)
 
-        field.clean({'a', 'b', 'c'}, None)
+        field.clean({"a", "b", "c"}, None)
 
         with pytest.raises(exceptions.ValidationError) as excinfo:
-            field.clean({'a', 'b', 'c', 'd'}, None)
-        assert excinfo.value.messages[0] == 'Set contains 4 items, it should contain no more than 3.'
+            field.clean({"a", "b", "c", "d"}, None)
+        assert (
+            excinfo.value.messages[0]
+            == "Set contains 4 items, it should contain no more than 3."
+        )
 
 
 class TestCheck(SimpleTestCase):
-
     def test_model_set(self):
-        field = BigIntSetModel._meta.get_field('field')
+        field = BigIntSetModel._meta.get_field("field")
         assert field.model == BigIntSetModel
         # I think this is a side effect of migrations being run in tests -
         # the base_field.model is the __fake__ model
-        assert field.base_field.model.__name__ == 'BigIntSetModel'
+        assert field.base_field.model.__name__ == "BigIntSetModel"
 
     def test_base_field_checks(self):
         class InvalidSetTextModel1(TemporaryModel):
@@ -217,20 +217,20 @@ class TestCheck(SimpleTestCase):
 
         errors = InvalidSetTextModel1.check(actually_check=True)
         assert len(errors) == 1
-        assert errors[0].id == 'django_mysql.E001'
-        assert 'Base field for set has errors' in errors[0].msg
-        assert 'max_length' in errors[0].msg
+        assert errors[0].id == "django_mysql.E001"
+        assert "Base field for set has errors" in errors[0].msg
+        assert "max_length" in errors[0].msg
 
     def test_invalid_base_fields(self):
         class InvalidSetTextModel2(TemporaryModel):
             field = SetTextField(
-                models.ForeignKey('testapp.Author', on_delete=models.CASCADE),
+                models.ForeignKey("testapp.Author", on_delete=models.CASCADE)
             )
 
         errors = InvalidSetTextModel2.check(actually_check=True)
         assert len(errors) == 1
-        assert errors[0].id == 'django_mysql.E002'
-        assert 'Base field for set must be' in errors[0].msg
+        assert errors[0].id == "django_mysql.E002"
+        assert "Base field for set must be" in errors[0].msg
 
 
 class SetTextFieldSubclass(SetTextField):
@@ -240,7 +240,6 @@ class SetTextFieldSubclass(SetTextField):
 
 
 class TestDeconstruct(TestCase):
-
     def test_deconstruct(self):
         field = SetTextField(models.IntegerField(), max_length=32)
         name, path, args, kwargs = field.deconstruct()
@@ -261,65 +260,70 @@ class TestDeconstruct(TestCase):
 
     def test_bad_import_deconstruct(self):
         from django_mysql.models.fields import SetTextField as STField
+
         field = STField(models.IntegerField())
         name, path, args, kwargs = field.deconstruct()
-        assert path == 'django_mysql.models.SetTextField'
+        assert path == "django_mysql.models.SetTextField"
 
     def test_bad_import2_deconstruct(self):
         from django_mysql.models.fields.sets import SetTextField as STField
+
         field = STField(models.IntegerField())
         name, path, args, kwargs = field.deconstruct()
-        assert path == 'django_mysql.models.SetTextField'
+        assert path == "django_mysql.models.SetTextField"
 
     def test_subclass_deconstruct(self):
         field = SetTextFieldSubclass(models.IntegerField())
         name, path, args, kwargs = field.deconstruct()
-        assert path == 'tests.testapp.test_settextfield.SetTextFieldSubclass'
+        assert path == "tests.testapp.test_settextfield.SetTextFieldSubclass"
 
 
 class TestMigrationWriter(TestCase):
-
     def test_makemigrations(self):
         field = SetTextField(models.CharField(max_length=5))
         statement, imports = MigrationWriter.serialize(field)
 
-        assert statement == "django_mysql.models.SetTextField(models.CharField(max_length=5), size=None)"
+        assert statement == (
+            "django_mysql.models.SetTextField(models.CharField(max_length=5), "
+            + "size=None)"
+        )
 
     def test_makemigrations_with_size(self):
         field = SetTextField(models.CharField(max_length=5), size=5)
         statement, imports = MigrationWriter.serialize(field)
 
-        assert statement == "django_mysql.models.SetTextField(models.CharField(max_length=5), size=5)"
+        assert statement == (
+            "django_mysql.models.SetTextField(models.CharField(max_length=5), "
+            + "size=5)"
+        )
 
 
 class TestSerialization(SimpleTestCase):
-
     def test_dumping(self):
         big_set = {str(i ** 2) for i in range(1000)}
         instance = BigCharSetModel(field=big_set)
-        data = json.loads(serializers.serialize('json', [instance]))[0]
-        field = data['fields']['field']
-        assert sorted(field.split(',')) == sorted(big_set)
+        data = json.loads(serializers.serialize("json", [instance]))[0]
+        field = data["fields"]["field"]
+        assert sorted(field.split(",")) == sorted(big_set)
 
     def test_loading(self):
-        test_data = '''
+        test_data = """
             [{"fields": {"field": "big,leather,comfy"},
              "model": "testapp.BigCharSetModel", "pk": null}]
-        '''
-        objs = list(serializers.deserialize('json', test_data))
+        """
+        objs = list(serializers.deserialize("json", test_data))
         instance = objs[0].object
         assert instance.field == {"big", "leather", "comfy"}
 
     def test_empty(self):
         instance = BigCharSetModel(field=set())
-        data = serializers.serialize('json', [instance])
-        objs = list(serializers.deserialize('json', data))
+        data = serializers.serialize("json", [instance])
+        objs = list(serializers.deserialize("json", data))
         instance = objs[0].object
         assert instance.field == set()
 
 
 class TestDescription(SimpleTestCase):
-
     def test_char(self):
         field = SetTextField(models.CharField(max_length=5), max_length=32)
         assert field.description == "Set of String (up to %(max_length)s)"
@@ -330,7 +334,6 @@ class TestDescription(SimpleTestCase):
 
 
 class TestFormField(SimpleTestCase):
-
     def test_model_field_formfield(self):
         model_field = SetTextField(models.CharField(max_length=27))
         form_field = model_field.formfield()

--- a/tests/testapp/test_status.py
+++ b/tests/testapp/test_status.py
@@ -3,120 +3,125 @@ import pytest
 from django.test import TestCase
 
 from django_mysql.exceptions import TimeoutError
-from django_mysql.status import GlobalStatus, SessionStatus, global_status, session_status
+from django_mysql.status import (
+    GlobalStatus,
+    SessionStatus,
+    global_status,
+    session_status,
+)
 
 
 class BaseStatusTests(TestCase):
-
     def test_cast_int(self):
-        val = global_status._cast('1')
+        val = global_status._cast("1")
         assert val == 1 and isinstance(val, int)
 
     def test_cast_float(self):
-        val = global_status._cast('1.0')
+        val = global_status._cast("1.0")
         assert val == 1.0 and isinstance(val, float)
 
     def test_cast_on(self):
-        val = global_status._cast('ON')
+        val = global_status._cast("ON")
         assert val and isinstance(val, bool)
 
     def test_cast_off(self):
-        val = global_status._cast('OFF')
+        val = global_status._cast("OFF")
         assert not val and isinstance(val, bool)
 
     def test_cast_string(self):
-        val = global_status._cast('something')
-        assert val == 'something'
+        val = global_status._cast("something")
+        assert val == "something"
 
 
 class GlobalStatusTests(TestCase):
 
     if django.VERSION >= (2, 2):
-        databases = ['default', 'other']
+        databases = ["default", "other"]
     else:
         multi_db = True
 
     def test_get(self):
-        running = global_status.get('Threads_running')
+        running = global_status.get("Threads_running")
         assert running >= 1 and isinstance(running, int)
 
     def test_get_bad_name(self):
         with pytest.raises(ValueError) as excinfo:
-            global_status.get('foo%')
-        assert 'wildcards' in str(excinfo.value)
+            global_status.get("foo%")
+        assert "wildcards" in str(excinfo.value)
 
     def test_get_non_existent(self):
         with pytest.raises(KeyError):
-            global_status.get('Does_not_exist')
+            global_status.get("Does_not_exist")
 
     def test_get_many_empty(self):
         myvars = global_status.get_many([])
         assert myvars == {}
 
     def test_get_many_existent(self):
-        myvars = global_status.get_many(['Threads_running', 'Uptime'])
+        myvars = global_status.get_many(["Threads_running", "Uptime"])
         assert isinstance(myvars, dict)
-        assert 'Threads_running' in myvars
-        assert isinstance(myvars['Threads_running'], int)
-        assert 'Uptime' in myvars
-        assert isinstance(myvars['Uptime'], int)
+        assert "Threads_running" in myvars
+        assert isinstance(myvars["Threads_running"], int)
+        assert "Uptime" in myvars
+        assert isinstance(myvars["Uptime"], int)
 
     def test_get_many_bad_name(self):
         with pytest.raises(ValueError) as excinfo:
-            global_status.get_many(['foo%'])
-        assert 'wildcards' in str(excinfo.value)
+            global_status.get_many(["foo%"])
+        assert "wildcards" in str(excinfo.value)
 
     def test_as_dict(self):
         status_dict = global_status.as_dict()
 
-        assert 'Aborted_clients' in status_dict  # Global-only variable
+        assert "Aborted_clients" in status_dict  # Global-only variable
 
-        assert isinstance(status_dict['Threads_running'], int)
-        assert status_dict['Threads_running'] >= 1
+        assert isinstance(status_dict["Threads_running"], int)
+        assert status_dict["Threads_running"] >= 1
 
     def test_as_dict_prefix(self):
         status_dict = global_status.as_dict()
 
-        status_dict_threads = global_status.as_dict('Threads_')
+        status_dict_threads = global_status.as_dict("Threads_")
         assert len(status_dict_threads) < len(status_dict)
         for key in status_dict_threads:
-            assert key.startswith('Threads_')
+            assert key.startswith("Threads_")
 
-        status_dict_foo = global_status.as_dict('Foo_Non_Existent')
+        status_dict_foo = global_status.as_dict("Foo_Non_Existent")
         assert len(status_dict_foo) == 0
 
     def test_wait_until_load_low(self):
         # Assume tests are running on a non-busy server
         global_status.wait_until_load_low()
-        global_status.wait_until_load_low({'Threads_running': 50, 'Threads_connected': 100})
+        global_status.wait_until_load_low(
+            {"Threads_running": 50, "Threads_connected": 100}
+        )
 
         with pytest.raises(TimeoutError) as excinfo:
             global_status.wait_until_load_low(
-                {'Threads_running': -1},  # obviously impossible
+                {"Threads_running": -1},  # obviously impossible
                 timeout=0.001,
                 sleep=0.0005,
             )
         message = str(excinfo.value)
-        assert 'Threads_running' in message
-        assert '-1' in message
+        assert "Threads_running" in message
+        assert "-1" in message
 
         with pytest.raises(TimeoutError) as excinfo:
             global_status.wait_until_load_low(
-                {'Threads_running': 1000000,
-                 'Uptime': -1},  # obviously impossible
+                {"Threads_running": 1000000, "Uptime": -1},  # obviously impossible
                 timeout=0.001,
                 sleep=0.0005,
             )
         message = str(excinfo.value)
-        assert 'Uptime' in message
-        assert '-1' in message
-        assert 'Threads_running' not in message
-        assert '1000000' not in message
+        assert "Uptime" in message
+        assert "-1" in message
+        assert "Threads_running" not in message
+        assert "1000000" not in message
 
     def test_other_databases(self):
-        status = GlobalStatus(using='other')
+        status = GlobalStatus(using="other")
 
-        running = status.get('Threads_running')
+        running = status.get("Threads_running")
         assert isinstance(running, int)
         assert running >= 1
 
@@ -124,40 +129,40 @@ class GlobalStatusTests(TestCase):
 class SessionStatusTests(TestCase):
 
     if django.VERSION >= (2, 2):
-        databases = ['default', 'other']
+        databases = ["default", "other"]
     else:
         multi_db = True
 
     def test_get_bytes_received(self):
-        bytes_received = session_status.get('Bytes_received')
+        bytes_received = session_status.get("Bytes_received")
         assert bytes_received >= 0 and isinstance(bytes_received, int)
 
-        bytes_received_2 = session_status.get('Bytes_received')
+        bytes_received_2 = session_status.get("Bytes_received")
         assert bytes_received_2 >= bytes_received
 
     def test_get_last_query_cost(self):
-        cost = session_status.get('Last_query_cost')
+        cost = session_status.get("Last_query_cost")
         assert cost >= 0.0 and isinstance(cost, float)
 
     def test_get_bad_name(self):
         with pytest.raises(ValueError) as excinfo:
-            session_status.get('foo%')
-        assert 'wildcards' in str(excinfo.value)
+            session_status.get("foo%")
+        assert "wildcards" in str(excinfo.value)
 
     def test_get_non_existent(self):
         with pytest.raises(KeyError):
-            session_status.get('Does_not_exist')
+            session_status.get("Does_not_exist")
 
     def test_as_dict(self):
         status_dict = session_status.as_dict()
 
-        assert 'Compression' in status_dict  # status only variable (on 5.7+)
+        assert "Compression" in status_dict  # status only variable (on 5.7+)
 
-        assert isinstance(status_dict['Threads_running'], int)
-        assert status_dict['Threads_running'] >= 1
+        assert isinstance(status_dict["Threads_running"], int)
+        assert status_dict["Threads_running"] >= 1
 
     def test_other_databases(self):
-        status = SessionStatus(using='other')
-        running = status.get('Threads_running')
+        status = SessionStatus(using="other")
+        running = status.get("Threads_running")
         assert isinstance(running, int)
         assert running >= 1

--- a/tests/testapp/test_test_utils.py
+++ b/tests/testapp/test_test_utils.py
@@ -7,17 +7,16 @@ from django_mysql.test.utils import override_mysql_variables
 
 
 class OverrideVarsMethodTest(TestCase):
-
     @override_mysql_variables(SQL_MODE="MSSQL")
     def test_method_sets_mssql(self):
         self.check_sql_mode("MSSQL")
 
-    def check_sql_mode(self, expected, using='default'):
+    def check_sql_mode(self, expected, using="default"):
         with connections[using].cursor() as cursor:
             cursor.execute("SELECT @@SQL_MODE")
             mode = cursor.fetchone()[0]
 
-        mode = mode.split(',')
+        mode = mode.split(",")
         assert expected in mode
 
 
@@ -25,20 +24,21 @@ class OverrideVarsMethodTest(TestCase):
 class OverrideVarsClassTest(OverrideVarsMethodTest):
 
     if django.VERSION >= (2, 2):
-        databases = ['default', 'other']
+        databases = ["default", "other"]
     else:
         multi_db = True
 
     def test_class_sets_ansi(self):
         self.check_sql_mode("ANSI")
 
-    @override_mysql_variables(using='other', SQL_MODE='MSSQL')
+    @override_mysql_variables(using="other", SQL_MODE="MSSQL")
     def test_other_connection(self):
         self.check_sql_mode("ANSI")
-        self.check_sql_mode("MSSQL", using='other')
+        self.check_sql_mode("MSSQL", using="other")
 
     def test_it_fails_on_non_test_classes(self):
         with pytest.raises(Exception):
+
             @override_mysql_variables(SQL_MODE="ANSI")
             class MyClass(object):
                 pass

--- a/tests/testapp/test_utils.py
+++ b/tests/testapp/test_utils.py
@@ -7,14 +7,19 @@ from django.db import DEFAULT_DB_ALIAS, connection, connections
 from django.test import SimpleTestCase, TestCase
 
 from django_mysql.utils import (
-    PTFingerprintThread, WeightedAverageRate, _is_mariadb_cache, connection_is_mariadb, format_duration, have_program,
-    index_name, pt_fingerprint,
+    PTFingerprintThread,
+    WeightedAverageRate,
+    _is_mariadb_cache,
+    connection_is_mariadb,
+    format_duration,
+    have_program,
+    index_name,
+    pt_fingerprint,
 )
 from tests.testapp.models import Author, AuthorMultiIndex
 
 
 class ConnectionIsMariaDBTests(TestCase):
-
     def setUp(self):
         super(ConnectionIsMariaDBTests, self).setUp()
         _is_mariadb_cache.clear()
@@ -26,29 +31,26 @@ class ConnectionIsMariaDBTests(TestCase):
         connection_is_mariadb(connections[DEFAULT_DB_ALIAS])
 
     def test_non_mysql(self):
-        conn = mock.MagicMock(vendor='sqlite3')
+        conn = mock.MagicMock(vendor="sqlite3")
         assert not connection_is_mariadb(conn)
 
     def test_oracle_mysql(self):
-        conn = mock.MagicMock(vendor='mysql')
-        conn.connection.get_server_info.return_value = '5.7.19'
+        conn = mock.MagicMock(vendor="mysql")
+        conn.connection.get_server_info.return_value = "5.7.19"
         assert not connection_is_mariadb(conn)
         # check cached
-        conn.connection.get_server_info.side_effect = ValueError('re-called')
+        conn.connection.get_server_info.side_effect = ValueError("re-called")
         assert not connection_is_mariadb(conn)
 
     def test_mariadb(self):
-        conn = mock.MagicMock(vendor='mysql')
-        conn.connection.get_server_info.return_value = (
-            '10.0.3-MariaDB-1~precise-log'
-        )
+        conn = mock.MagicMock(vendor="mysql")
+        conn.connection.get_server_info.return_value = "10.0.3-MariaDB-1~precise-log"
         assert connection_is_mariadb(conn)
-        conn.connection.get_server_info.side_effect = ValueError('re-called')
+        conn.connection.get_server_info.side_effect = ValueError("re-called")
         assert connection_is_mariadb(conn)
 
 
 class WeightedAverageRateTests(SimpleTestCase):
-
     def test_constant(self):
         # If we keep achieving a rate of 100 rows in 0.5 seconds, it should
         # recommend that we keep there
@@ -87,31 +89,28 @@ class WeightedAverageRateTests(SimpleTestCase):
 
 
 class FormatDurationTests(SimpleTestCase):
-
     def test_seconds(self):
-        assert format_duration(0) == '0s'
-        assert format_duration(1) == '1s'
-        assert format_duration(30) == '30s'
-        assert format_duration(59) == '59s'
+        assert format_duration(0) == "0s"
+        assert format_duration(1) == "1s"
+        assert format_duration(30) == "30s"
+        assert format_duration(59) == "59s"
 
     def test_minutes(self):
-        assert format_duration(60) == '1m0s'
-        assert format_duration(61) == '1m1s'
-        assert format_duration(120) == '2m0s'
-        assert format_duration(3599) == '59m59s'
+        assert format_duration(60) == "1m0s"
+        assert format_duration(61) == "1m1s"
+        assert format_duration(120) == "2m0s"
+        assert format_duration(3599) == "59m59s"
 
     def test_hours(self):
-        assert format_duration(3600) == '1h0m0s'
-        assert format_duration(3601) == '1h0m1s'
+        assert format_duration(3600) == "1h0m0s"
+        assert format_duration(3601) == "1h0m1s"
 
 
-@skipUnless(have_program('pt-fingerprint'),
-            "pt-fingerprint must be installed")
+@skipUnless(have_program("pt-fingerprint"), "pt-fingerprint must be installed")
 class PTFingerprintTests(SimpleTestCase):
-
     def test_basic(self):
-        assert pt_fingerprint('SELECT 5') == 'select ?'
-        assert pt_fingerprint('SELECT 5;') == 'select ?'
+        assert pt_fingerprint("SELECT 5") == "select ?"
+        assert pt_fingerprint("SELECT 5;") == "select ?"
 
     def test_long(self):
         query = """
@@ -134,19 +133,16 @@ class PTFingerprintTests(SimpleTestCase):
                 rental_date + INTERVAL film.rental_duration DAY <
                     CURRENT_DATE()
             LIMIT 5"""
-        assert (
-            pt_fingerprint(query)
-            == (
-                "select concat(customer.last_name, ?, customer.first_name) as "
-                + "customer, address.phone, film.title from rental inner join "
-                + "customer on rental.customer_id = customer.customer_id "
-                + "inner join address on customer.address_id = "
-                + "address.address_id inner join inventory on "
-                + "rental.inventory_id = inventory.inventory_id inner join "
-                + "film on inventory.film_id = film.film_id where "
-                + "rental.return_date is ? and rental_date ? interval "
-                + "film.rental_duration day < current_date() limit ?"
-            )
+        assert pt_fingerprint(query) == (
+            "select concat(customer.last_name, ?, customer.first_name) as "
+            + "customer, address.phone, film.title from rental inner join "
+            + "customer on rental.customer_id = customer.customer_id "
+            + "inner join address on customer.address_id = "
+            + "address.address_id inner join inventory on "
+            + "rental.inventory_id = inventory.inventory_id inner join "
+            + "film on inventory.film_id = film.film_id where "
+            + "rental.return_date is ? and rental_date ? interval "
+            + "film.rental_duration day < current_date() limit ?"
         )
 
     def test_the_thread_shuts_on_time_out(self):
@@ -160,7 +156,7 @@ class PTFingerprintTests(SimpleTestCase):
 class IndexNameTests(TestCase):
 
     if django.VERSION >= (2, 2):
-        databases = ['default', 'other']
+        databases = ["default", "other"]
     else:
         multi_db = True
 
@@ -171,38 +167,38 @@ class IndexNameTests(TestCase):
 
     def test_requires_real_field_names(self):
         with pytest.raises(ValueError) as excinfo:
-            index_name(Author, 'nonexistent')
+            index_name(Author, "nonexistent")
         assert "Fields do not exist: nonexistent" in str(excinfo.value)
 
     def test_invalid_kwarg(self):
         with pytest.raises(ValueError) as excinfo:
-            index_name(Author, 'name', nonexistent_kwarg=True)
+            index_name(Author, "name", nonexistent_kwarg=True)
         assert "The only supported keyword argument is 'using'" in str(excinfo.value)
 
     def test_primary_key(self):
-        assert index_name(Author, 'id') == 'PRIMARY'
+        assert index_name(Author, "id") == "PRIMARY"
 
     def test_primary_key_using_other(self):
-        assert index_name(Author, 'id', using='other') == 'PRIMARY'
+        assert index_name(Author, "id", using="other") == "PRIMARY"
 
     def test_secondary_single_field(self):
-        name = index_name(Author, 'name')
-        assert name.startswith('testapp_author_')
+        name = index_name(Author, "name")
+        assert name.startswith("testapp_author_")
 
     def test_index_does_not_exist(self):
         with pytest.raises(KeyError) as excinfo:
-            index_name(Author, 'bio')
+            index_name(Author, "bio")
         assert "There is no index on (bio)" in str(excinfo.value)
 
     def test_secondary_multiple_fields(self):
-        name = index_name(AuthorMultiIndex, 'name', 'country')
-        assert name.startswith('testapp_authormultiindex')
+        name = index_name(AuthorMultiIndex, "name", "country")
+        assert name.startswith("testapp_authormultiindex")
 
     def test_secondary_multiple_fields_non_existent_reversed_existent(self):
         # Checks that order is preserved
         with pytest.raises(KeyError):
-            index_name(AuthorMultiIndex, 'country', 'name')
+            index_name(AuthorMultiIndex, "country", "name")
 
     def test_secondary_multiple_fields_non_existent(self):
         with pytest.raises(KeyError):
-            index_name(AuthorMultiIndex, 'country', 'id')
+            index_name(AuthorMultiIndex, "country", "id")

--- a/tests/testapp/utils.py
+++ b/tests/testapp/utils.py
@@ -30,7 +30,7 @@ class CaptureLastQuery(object):
 
     @property
     def query(self):
-        return self.capturer.captured_queries[-1]['sql']
+        return self.capturer.captured_queries[-1]["sql"]
 
 
 class print_all_queries(object):
@@ -48,7 +48,7 @@ class print_all_queries(object):
     def __exit__(self, a, b, c):
         self.capturer.__exit__(a, b, c)
         for q in self.capturer.captured_queries:
-            print(q['sql'])
+            print(q["sql"])
 
 
 def used_indexes(query, using=DEFAULT_DB_ALIAS):
@@ -59,15 +59,12 @@ def used_indexes(query, using=DEFAULT_DB_ALIAS):
     with connection.cursor() as cursor:
         cursor.execute("EXPLAIN " + query)
 
-        return {row['key'] for row in fetchall_dicts(cursor)
-                if row['key'] is not None}
+        return {row["key"] for row in fetchall_dicts(cursor) if row["key"] is not None}
 
 
 def fetchall_dicts(cursor):
     columns = [x[0] for x in cursor.description]
     rows = []
     for row in cursor.fetchall():
-        rows.append(
-            dict(zip(columns, row)),
-        )
+        rows.append(dict(zip(columns, row)))
     return rows


### PR DESCRIPTION
* Add black and flake8-bugbear - automatically picked up by multilint
* Add pyproject.toml black configuration to target Python 3.5
* Reconfigure isort and flake8
* Drop flake8-commas and rely on Black's trailing comma insertion only
* Run black on the code
* Add README badge