### PR TITLE
Drop not_skip = __init__.py from isort config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ known_first_party = django_mysql
 known_third_party = pytest,django
 line_length = 88
 multi_line_output = 3
-not_skip = __init__.py
 use_parentheses = True
 
 [metadata]


### PR DESCRIPTION
It was removed from the default ignore list in [Version 4.3.5](https://github.com/timothycrosley/isort/blob/develop/CHANGELOG.md#435---february-24-2019---last-python-27-maintenance-release).