### PR TITLE
Remove skip_install = true in tox codestyle environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,6 @@ deps = -rrequirements/py37-django22.txt
 
 [testenv:py37-codestyle]
 deps = -rrequirements/py37-django22.txt
-skip_install = true
 commands =
     multilint
     twine check .tox/dist/*


### PR DESCRIPTION
This is needed for `twine check` to work when only this environment runs.