### PR TITLE
Fix docs warnings

### DIFF
--- a/docs/aggregates.rst
+++ b/docs/aggregates.rst
@@ -21,8 +21,8 @@ The following can be imported from ``django_mysql.models``.
 
     Docs:
     `MySQL
-    <https://dev.mysql.com/doc/refman/en/group-by-functions.html#function_bit-and>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/bit_and/>`_.
+    <https://dev.mysql.com/doc/refman/en/group-by-functions.html#function_bit-and>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/bit_and/>`__.
 
     Example usage:
 
@@ -41,8 +41,8 @@ The following can be imported from ``django_mysql.models``.
 
     Docs:
     `MySQL
-    <https://dev.mysql.com/doc/refman/en/group-by-functions.html#function_bit-or>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/bit_or/>`_.
+    <https://dev.mysql.com/doc/refman/en/group-by-functions.html#function_bit-or>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/bit_or/>`__.
 
     Example usage:
 
@@ -61,8 +61,8 @@ The following can be imported from ``django_mysql.models``.
 
     Docs:
     `MySQL
-    <https://dev.mysql.com/doc/refman/en/group-by-functions.html#function_bit-xor>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/bit_xor/>`_.
+    <https://dev.mysql.com/doc/refman/en/group-by-functions.html#function_bit-xor>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/bit_xor/>`__.
 
     Example usage:
 
@@ -80,8 +80,8 @@ The following can be imported from ``django_mysql.models``.
     Useful mostly for bringing back lists of ids in a single query.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/group-by-functions.html#function_group-concat>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/group_concat/>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/en/group-by-functions.html#function_group-concat>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/group_concat/>`__.
 
     Example usage:
 
@@ -101,8 +101,8 @@ The following can be imported from ``django_mysql.models``.
         increase it if you're using this for any sizeable groups.
 
         ``group_concat_max_len`` docs:
-        `MySQL <https://dev.mysql.com/doc/refman/en/server-system-variables.html#sysvar_group_concat_max_len>`_ /
-        `MariaDB <https://mariadb.com/kb/en/server-system-variables/#group_concat_max_len>`_.
+        `MySQL <https://dev.mysql.com/doc/refman/en/server-system-variables.html#sysvar_group_concat_max_len>`__ /
+        `MariaDB <https://mariadb.com/kb/en/server-system-variables/#group_concat_max_len>`__.
 
     Optional arguments:
 

--- a/docs/cache.rst
+++ b/docs/cache.rst
@@ -108,7 +108,7 @@ Multiple Databases
 If you use this with multiple databases, you'll also need to set up routing
 instructions for the cache table. This can be done with the same method
 that is described for ``DatabaseCache`` in the `Django manual
-<https://docs.djangoproject.com/en/1.8/topics/cache/#database-caching>`_, apart
+<https://docs.djangoproject.com/en/1.8/topics/cache/#database-caching>`__, apart
 from the application name is ``django_mysql``.
 
 .. note::
@@ -204,7 +204,7 @@ ways:
    ``cull()`` on all of your ``MySQLCache`` instances, or you can give it names
    to just cull those. For example, this:
 
-   .. code-block:: python
+   .. code-block:: console
 
        $ python manage.py cull_mysql_caches default other_cache
 

--- a/docs/checks.rst
+++ b/docs/checks.rst
@@ -29,8 +29,8 @@ truncation upon insertion, by escalating warnings into errors. It is strongly
 recommended you activate it.
 
 Docs:
-`MySQL <https://dev.mysql.com/doc/refman/en/sql-mode.html#sql-mode-strict>`_ /
-`MariaDB <https://mariadb.com/kb/en/mariadb/sql_mode/#strict-mode>`_.
+`MySQL <https://dev.mysql.com/doc/refman/en/sql-mode.html#sql-mode-strict>`__ /
+`MariaDB <https://mariadb.com/kb/en/mariadb/sql_mode/#strict-mode>`__.
 
 It is configured as part of ``sql_mode``, a system variable contains a list of
 comma-separated modes to activate. Please check the value of your install and
@@ -73,8 +73,8 @@ Normally this just affects per-table settings for compression. It's recommended
 you activate this, but it's not very likely to affect you if you don't.
 
 Docs:
-`MySQL <https://dev.mysql.com/doc/refman/en/innodb-parameters.html#sysvar_innodb_strict_mode>`_ /
-`MariaDB <https://mariadb.com/kb/en/mariadb/xtradbinnodb-strict-mode/>`_.
+`MySQL <https://dev.mysql.com/doc/refman/en/innodb-parameters.html#sysvar_innodb_strict_mode>`__ /
+`MariaDB <https://mariadb.com/kb/en/mariadb/xtradbinnodb-strict-mode/>`__.
 
 As above, the easiest way to set this is to add ``SET`` to ``init_command`` in
 your ``DATABASES`` setting:
@@ -115,8 +115,8 @@ you'll never see any of these 'supplementary' Unicode characters (note: it's
 very easy for users to type emoji on phone keyboards these days!).
 
 Docs:
-`MySQL <https://dev.mysql.com/doc/refman/en/charset-unicode-utf8mb4.html>`_ /
-`MariaDB <https://mariadb.com/kb/en/mariadb/unicode/>`_.
+`MySQL <https://dev.mysql.com/doc/refman/en/charset-unicode-utf8mb4.html>`__ /
+`MariaDB <https://mariadb.com/kb/en/mariadb/unicode/>`__.
 
 Also see this classic blogpost:
 `How to support full Unicode in MySQL databases <https://mathiasbynens.be/notes/mysql-utf8mb4>`_.
@@ -149,4 +149,4 @@ Note this does not transform the database, tables, and columns that already
 exist. Follow the examples in the 'How to' blog post link above to fix your
 database, tables, and character set. It's planned to add a command to
 Django-MySQL to help you do this, see
-`Issue 216 <https://github.com/adamchainz/django-mysql/issues/216>`_.
+`Issue 216 <https://github.com/adamchainz/django-mysql/issues/216>`__.

--- a/docs/database_functions.rst
+++ b/docs/database_functions.rst
@@ -32,8 +32,8 @@ Comparison Functions
     With two or more arguments, returns the largest (maximum-valued) argument.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/comparison-operators.html#function_greatest>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/greatest/>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/en/comparison-operators.html#function_greatest>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/greatest/>`__.
 
     Usage example:
 
@@ -53,8 +53,8 @@ Comparison Functions
     With two or more arguments, returns the smallest (minimum-valued) argument.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/comparison-operators.html#function_least>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/least/>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/en/comparison-operators.html#function_least>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/least/>`__.
 
     Usage example:
 
@@ -64,7 +64,7 @@ Comparison Functions
 
 
 Control Flow Functions
---------------------
+----------------------
 
 
 .. class:: If(condition, true, false=None)
@@ -75,8 +75,8 @@ Control Flow Functions
     ``NULL``.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/control-flow-functions.html#function_if>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/if-function/>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/en/control-flow-functions.html#function_if>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/if-function/>`__.
 
     Usage example:
 
@@ -100,8 +100,8 @@ Numeric Functions
     ``expression`` is not a number, it is converted to a numeric type.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/mathematical-functions.html#function_abs>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/abs/>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/en/mathematical-functions.html#function_abs>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/abs/>`__.
 
     Usage example:
 
@@ -115,8 +115,8 @@ Numeric Functions
     Returns the smallest integer value not less than `expression`.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/mathematical-functions.html#function_ceiling>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/ceiling/>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/en/mathematical-functions.html#function_ceiling>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/ceiling/>`__.
 
     Usage example:
 
@@ -132,8 +132,8 @@ Numeric Functions
     expected to be a string and (if possible) is treated as one if it is not.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/mathematical-functions.html#function_crc32>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/crc32/>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/en/mathematical-functions.html#function_crc32>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/crc32/>`__.
 
     Usage example:
 
@@ -147,8 +147,8 @@ Numeric Functions
     Returns the largest integer value not greater than ``expression``.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/mathematical-functions.html#function_floor>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/floor/>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/en/mathematical-functions.html#function_floor>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/floor/>`__.
 
     Usage example:
 
@@ -166,8 +166,8 @@ Numeric Functions
     become zero.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/mathematical-functions.html#function_round>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/round/>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/en/mathematical-functions.html#function_round>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/round/>`__.
 
     Usage example:
 
@@ -182,8 +182,8 @@ Numeric Functions
     ``expression`` is negative, zero, or positive.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/mathematical-functions.html#function_sign>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/sign/>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/en/mathematical-functions.html#function_sign>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/sign/>`__.
 
     Usage example:
 
@@ -210,8 +210,8 @@ String Functions
     field.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/string-functions.html#function_concat-ws>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/concat_ws/>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/en/string-functions.html#function_concat-ws>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/concat_ws/>`__.
 
     Usage example:
 
@@ -234,8 +234,8 @@ String Functions
     column, use Django's ``F()`` class.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/string-functions.html#function_elt>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/elt/>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/en/string-functions.html#function_elt>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/elt/>`__.
 
     Usage example:
 
@@ -261,8 +261,8 @@ String Functions
     use Django's ``F()`` class.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/string-functions.html#function_field>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/field/>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/en/string-functions.html#function_field>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/field/>`__.
 
     Usage example:
 
@@ -292,8 +292,8 @@ XML Functions
     to refer to columns, use Django's ``F()`` class.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/xml-functions.html#function_updatexml>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/updatexml/>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/en/xml-functions.html#function_updatexml>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/updatexml/>`__.
 
     Usage example:
 
@@ -318,8 +318,8 @@ XML Functions
     want ``xpath_expr`` to refer to a column, use Django's ``F()`` class.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/xml-functions.html#function_extractvalue>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/extractvalue/>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/en/xml-functions.html#function_extractvalue>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/extractvalue/>`__.
 
     Usage example:
 
@@ -351,7 +351,7 @@ Regexp Functions
     column, whilst if ``regex`` is a string, it will be used as a string. If
     you want ``regex`` to refer to a column, use Django's ``F()`` class.
 
-    Docs: `MariaDB <https://mariadb.com/kb/en/mariadb/regexp_instr/>`_.
+    Docs: `MariaDB <https://mariadb.com/kb/en/mariadb/regexp_instr/>`__.
 
     Usage example:
 
@@ -373,7 +373,7 @@ Regexp Functions
     used as strings. If you want ``regex`` or ``replace`` to refer to columns,
     use Django's ``F()`` class.
 
-    Docs: `MariaDB <https://mariadb.com/kb/en/mariadb/regexp_replace/>`_.
+    Docs: `MariaDB <https://mariadb.com/kb/en/mariadb/regexp_replace/>`__.
 
     Usage example:
 
@@ -400,7 +400,7 @@ Regexp Functions
     column, whilst if ``regex`` is a string, it will be used as a string. If
     you want ``regex`` to refer to a column, use Django's ``F()`` class.
 
-    Docs: `MariaDB <https://mariadb.com/kb/en/mariadb/regexp_substr/>`_.
+    Docs: `MariaDB <https://mariadb.com/kb/en/mariadb/regexp_substr/>`__.
 
     Usage example:
 
@@ -423,8 +423,8 @@ Encryption Functions
     Calculates an MD5 128-bit checksum for the string ``expression``.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/encryption-functions.html#function_md5>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/md5/>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/en/encryption-functions.html#function_md5>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/md5/>`__.
 
     Usage example:
 
@@ -439,8 +439,8 @@ Encryption Functions
     described in RFC 3174 (Secure Hash Algorithm).
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/encryption-functions.html#function_sha1>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/sha1/>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/en/encryption-functions.html#function_sha1>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/sha1/>`__.
 
     Usage example:
 
@@ -458,8 +458,8 @@ Encryption Functions
     The default for ``hash_len`` is 512.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/encryption-functions.html#function_sha2>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/sha2/>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/en/encryption-functions.html#function_sha2>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/sha2/>`__.
 
     Usage example:
 
@@ -497,8 +497,8 @@ Information Functions
             ``delete()`` with cascading.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/information-functions.html#function_last-insert-id>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/last_insert_id/>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/en/information-functions.html#function_last-insert-id>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/last_insert_id/>`__.
 
     Usage examples:
 
@@ -551,7 +551,7 @@ more information on their syntax, refer to the MySQL documentation.
     ``paths`` to refer to a field, use Django's ``F()`` class.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/5.7/en/json-search-functions.html#function_json-extract>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/5.7/en/json-search-functions.html#function_json-extract>`__.
 
     Usage examples:
 
@@ -583,7 +583,7 @@ more information on their syntax, refer to the MySQL documentation.
     field, use Django's ``F()`` class.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/5.7/en/json-search-functions.html#function_json-keys>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/5.7/en/json-search-functions.html#function_json-keys>`__.
 
     .. code-block:: pycon
 
@@ -620,7 +620,7 @@ more information on their syntax, refer to the MySQL documentation.
     field, use Django's ``F()`` class.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/5.7/en/json-attribute-functions.html#function_json-length>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/5.7/en/json-attribute-functions.html#function_json-length>`__.
 
     .. code-block:: pycon
 
@@ -645,7 +645,7 @@ more information on their syntax, refer to the MySQL documentation.
     want a key or value to refer to a field, use Django's ``F()`` class.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html#function_json-insert>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html#function_json-insert>`__.
 
     .. code-block:: pycon
 
@@ -669,7 +669,7 @@ more information on their syntax, refer to the MySQL documentation.
     want a key or value to refer to a field, use Django's ``F()`` class.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html#function_json-replace>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html#function_json-replace>`__.
 
     .. code-block:: pycon
 
@@ -693,7 +693,7 @@ more information on their syntax, refer to the MySQL documentation.
     want a key or value to refer to a field, use Django's ``F()`` class.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html#function_json-set>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html#function_json-set>`__.
 
     .. code-block:: pycon
 
@@ -719,7 +719,7 @@ more information on their syntax, refer to the MySQL documentation.
     want a key or value to refer to a field, use Django's ``F()`` class.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html#function_json-array-append>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html#function_json-array-append>`__.
 
     .. code-block:: pycon
 
@@ -759,7 +759,7 @@ These are MariaDB 10.0+ only, and for use with ``DynamicField``.
     examples below.
 
     Docs:
-    `MariaDB <https://mariadb.com/kb/en/mariadb/column_add/>`_.
+    `MariaDB <https://mariadb.com/kb/en/mariadb/column_add/>`__.
 
     Usage examples:
 
@@ -788,7 +788,7 @@ These are MariaDB 10.0+ only, and for use with ``DynamicField``.
     column". If you do mean that, use ``F('fieldname')``.
 
     Docs:
-    `MariaDB <https://mariadb.com/kb/en/mariadb/column_delete/>`_.
+    `MariaDB <https://mariadb.com/kb/en/mariadb/column_delete/>`__.
 
     Usage examples:
 
@@ -810,7 +810,7 @@ These are MariaDB 10.0+ only, and for use with ``DynamicField``.
     documented for the ``DynamicField`` lookups.
 
     Docs:
-    `MariaDB <https://mariadb.com/kb/en/mariadb/column_get/>`_.
+    `MariaDB <https://mariadb.com/kb/en/mariadb/column_get/>`__.
 
     Usage examples:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,6 @@ action, or get started with :doc:`installation`. Otherwise, take your pick:
    management_commands/index
    utilities
    test_utilities
-   monkey_patches
    exceptions
    contributing
    history

--- a/docs/locks.rst
+++ b/docs/locks.rst
@@ -36,8 +36,8 @@ The following can be imported from ``django_mysql.locks``.
 
     For more information on user locks refer to the ``GET_LOCK`` documentation
     on `MySQL
-    <https://dev.mysql.com/doc/refman/5.6/en/miscellaneous-functions.html#function_get-lock>`_
-    or `MariaDB <https://mariadb.com/kb/en/mariadb/get_lock/>`_.
+    <https://dev.mysql.com/doc/refman/5.6/en/miscellaneous-functions.html#function_get-lock>`__
+    or `MariaDB <https://mariadb.com/kb/en/mariadb/get_lock/>`__.
 
     .. warning::
 

--- a/docs/migration_operations.rst
+++ b/docs/migration_operations.rst
@@ -21,8 +21,8 @@ Install Plugin
     plugin is already installed to make it more idempotent.
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/install-plugin.html>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/install-plugin/>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/en/install-plugin.html>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/install-plugin/>`__.
 
     .. attribute:: name
 

--- a/docs/model_fields/json_field.rst
+++ b/docs/model_fields/json_field.rst
@@ -11,7 +11,7 @@ queryable and updatable in place. This is ideal for data that varies widely, or
 very sparse columns, or just for storing API responses that you don't have time
 to turn into the relational format.
 
-Docs: `MySQL <https://dev.mysql.com/doc/refman/5.7/en/json.html>`_.
+Docs: `MySQL <https://dev.mysql.com/doc/refman/5.7/en/json.html>`__.
 
 Django-MySQL supports the JSON data type and related functions through
 ``JSONField`` plus some
@@ -129,7 +129,7 @@ Ordering Lookups
 ~~~~~~~~~~~~~~~~
 
 MySQL defines an ordering on JSON objects - see
-`the docs <https://dev.mysql.com/doc/refman/5.7/en/json.html#json-comparison>`_
+`the docs <https://dev.mysql.com/doc/refman/5.7/en/json.html#json-comparison>`__
 for more details. The ordering rules can make sense for some types (e.g.
 strings, arrays), however they can also be confusing if your data is of mixed
 types, so be careful. You can use the ordering by querying with Django's
@@ -234,7 +234,7 @@ follows:
 * The length does not count the length of nested arrays or objects.
 
 Docs:
-`MySQL <https://dev.mysql.com/doc/refman/5.7/en/json-attribute-functions.html#function_json-length>`_.
+`MySQL <https://dev.mysql.com/doc/refman/5.7/en/json-attribute-functions.html#function_json-length>`__.
 
 For example:
 
@@ -275,7 +275,7 @@ The definition of containment is, as per the MySQL docs:
   with the target key.
 
 Docs:
-`MySQL <https://dev.mysql.com/doc/refman/5.7/en/json-search-functions.html#function_json-contains>`_.
+`MySQL <https://dev.mysql.com/doc/refman/5.7/en/json-search-functions.html#function_json-contains>`__.
 
 For example:
 

--- a/docs/queryset_extensions.rst
+++ b/docs/queryset_extensions.rst
@@ -179,8 +179,8 @@ Once you’ve done this, the following methods will work.
         Author.objects.distinct().straight_join().filter(books__age=12)[:10]
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/select.html>`_ /
-    `MariaDB <https://mariadb.com/kb/en/mariadb/select/#straight_join>`_.
+    `MySQL <https://dev.mysql.com/doc/refman/en/select.html>`__ /
+    `MariaDB <https://mariadb.com/kb/en/mariadb/select/#straight_join>`__.
 
     The MariaDB docs also have a good page `Index Hints: How to Force Query
     Plans”
@@ -201,9 +201,9 @@ Once you’ve done this, the following methods will work.
         Author.objects.values('birthday').distinct().sql_small_result()
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/select.html>`_ /
+    `MySQL <https://dev.mysql.com/doc/refman/en/select.html>`__ /
     `MariaDB
-    <https://mariadb.com/kb/en/mariadb/select/#sql_small_result-sql_big_result>`_.
+    <https://mariadb.com/kb/en/mariadb/select/#sql_small_result-sql_big_result>`__.
 
 .. method:: sql_big_result()
 
@@ -219,9 +219,9 @@ Once you’ve done this, the following methods will work.
         Author.objects.distinct().sql_big_result()
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/select.html>`_ /
+    `MySQL <https://dev.mysql.com/doc/refman/en/select.html>`__ /
     `MariaDB
-    <https://mariadb.com/kb/en/mariadb/select/#sql_small_result-sql_big_result>`_.
+    <https://mariadb.com/kb/en/mariadb/select/#sql_small_result-sql_big_result>`__.
 
 .. method:: sql_buffer_result()
 
@@ -238,9 +238,9 @@ Once you’ve done this, the following methods will work.
         HighThroughputModel.objects.filter(x=y).sql_buffer_result()
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/select.html>`_ /
+    `MySQL <https://dev.mysql.com/doc/refman/en/select.html>`__ /
     `MariaDB
-    <https://mariadb.com/kb/en/mariadb/select/#sql_buffer_result>`_.
+    <https://mariadb.com/kb/en/mariadb/select/#sql_buffer_result>`__.
 
 .. method:: sql_cache()
 
@@ -258,9 +258,9 @@ Once you’ve done this, the following methods will work.
         recent_posts = BlogPost.objects.sql_cache().order_by('-created')[:5]
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/select.html>`_ /
+    `MySQL <https://dev.mysql.com/doc/refman/en/select.html>`__ /
     `MariaDB
-    <https://mariadb.com/kb/en/mariadb/select/#sql_cache-sql_no_cache>`_.
+    <https://mariadb.com/kb/en/mariadb/select/#sql_cache-sql_no_cache>`__.
 
 .. method:: sql_no_cache()
 
@@ -283,9 +283,9 @@ Once you’ve done this, the following methods will work.
         )
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/select.html>`_ /
+    `MySQL <https://dev.mysql.com/doc/refman/en/select.html>`__ /
     `MariaDB
-    <https://mariadb.com/kb/en/mariadb/select/#sql_cache-sql_no_cache>`_.
+    <https://mariadb.com/kb/en/mariadb/select/#sql_cache-sql_no_cache>`__.
 
 .. method:: sql_calc_found_rows()
 
@@ -308,9 +308,9 @@ Once you’ve done this, the following methods will work.
         1942
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/select.html>`_ /
+    `MySQL <https://dev.mysql.com/doc/refman/en/select.html>`__ /
     `MariaDB
-    <https://mariadb.com/kb/en/mariadb/select/#sql_calc_found_rows>`_.
+    <https://mariadb.com/kb/en/mariadb/select/#sql_calc_found_rows>`__.
 
 .. method:: use_index(*index_names, for_=None, table_name=None)
 
@@ -357,9 +357,9 @@ Once you’ve done this, the following methods will work.
         >>> Book.objects.select_related('author').use_index('authbook', table_name='author')
 
     Docs:
-    `MySQL <https://dev.mysql.com/doc/refman/en/index-hints.html>`_ /
+    `MySQL <https://dev.mysql.com/doc/refman/en/index-hints.html>`__ /
     `MariaDB
-    <https://mariadb.com/kb/en/mariadb/index-hints-how-to-force-query-plans/>`_.
+    <https://mariadb.com/kb/en/mariadb/index-hints-how-to-force-query-plans/>`__.
 
 
 .. method:: force_index(*index_names, for_=None)
@@ -631,8 +631,8 @@ Integration with pt-visual-explain
 ----------------------------------
 
 How does MySQL *really* execute a query? The ``EXPLAIN`` statement
-(docs: `MySQL <https://dev.mysql.com/doc/refman/5.6/en/explain.html>`_ /
-`MariaDB <https://mariadb.com/kb/en/mariadb/explain/>`_),
+(docs: `MySQL <https://dev.mysql.com/doc/refman/5.6/en/explain.html>`__ /
+`MariaDB <https://mariadb.com/kb/en/mariadb/explain/>`__),
 gives a description of the execution plan, and the ``pt-visual-explain``
 `tool <https://www.percona.com/doc/percona-toolkit/2.2/pt-visual-explain.html>`_
 can format this in an understandable tree.
@@ -683,8 +683,8 @@ Handler
 MySQL's ``HANDLER`` commands give you simple NoSQL-style read access, faster
 than full SQL queries, with the ability to perform index lookups or paginated
 scans (docs:
-`MySQL <https://dev.mysql.com/doc/refman/5.6/en/handler.html>`_ /
-`MariaDB <https://mariadb.com/kb/en/mariadb/handler-commands/>`_).
+`MySQL <https://dev.mysql.com/doc/refman/5.6/en/handler.html>`__ /
+`MariaDB <https://mariadb.com/kb/en/mariadb/handler-commands/>`__).
 
 This extension adds an ORM-based API for handlers. You can instantiate them
 from a ``QuerySet`` (and thus from `.objects`), and open/close them as context


### PR DESCRIPTION
Mostly around duplicate target names, fixed by using the anonymous link syntax on RST (two underscores).