### PR TITLE
Fix GroupConcat to put ORDER BY before SEPARATOR

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,8 @@ Pending
   ``importlib.metadata.version("django-mysql")``
   (`docs <https://docs.python.org/3.8/library/importlib.metadata.html#distribution-versions>`__ /
   `backport <https://pypi.org/project/importlib-metadata/>`__).
+* Fix ``GroupConcat`` to work with both ``separator`` and ``ordering`` set.
+  (`PR #596 <https://github.com/adamchainz/django-mysql/pull/596>`__).
 
 3.2.0 (2019-06-14)
 ------------------

--- a/src/django_mysql/models/aggregates.py
+++ b/src/django_mysql/models/aggregates.py
@@ -52,15 +52,15 @@ class GroupConcat(Aggregate):
 
         sql.append(expr_sql)
 
-        if self.separator is not None:
-            sql.append(" SEPARATOR '{}'".format(self.separator))
-
         if self.ordering is not None:
             sql.append(" ORDER BY ")
             sql.append(expr_sql)
             params.extend(params[:])
             sql.append(" ")
             sql.append(self.ordering.upper())
+
+        if self.separator is not None:
+            sql.append(" SEPARATOR '{}'".format(self.separator))
 
         sql.append(")")
 

--- a/tests/testapp/test_aggregates.py
+++ b/tests/testapp/test_aggregates.py
@@ -134,9 +134,11 @@ class GroupConcatTests(TestCase):
         assert out == {"tids": ",".join(reversed(self.str_tutee_ids))}
 
     def test_separator_big_ordering_asc(self):
-        out = self.shakes.tutees.aggregate(tids=GroupConcat("id", separator="BIG", ordering="asc"))
+        big_asc = GroupConcat("id", separator="BIG", ordering="asc")
+        out = self.shakes.tutees.aggregate(tids=big_asc)
         assert out == {"tids": "BIG".join(self.str_tutee_ids)}
 
     def test_separator_big_ordering_desc(self):
-        out = self.shakes.tutees.aggregate(tids=GroupConcat("id", separator="BIG", ordering="desc"))
+        big_desc = GroupConcat("id", separator="BIG", ordering="desc")
+        out = self.shakes.tutees.aggregate(tids=big_desc)
         assert out == {"tids": "BIG".join(reversed(self.str_tutee_ids))}

--- a/tests/testapp/test_aggregates.py
+++ b/tests/testapp/test_aggregates.py
@@ -132,3 +132,11 @@ class GroupConcatTests(TestCase):
     def test_ordering_desc(self):
         out = self.shakes.tutees.aggregate(tids=GroupConcat("id", ordering="desc"))
         assert out == {"tids": ",".join(reversed(self.str_tutee_ids))}
+
+    def test_separator_big_ordering_asc(self):
+        out = self.shakes.tutees.aggregate(tids=GroupConcat("id", separator="BIG", ordering="asc"))
+        assert out == {"tids": "BIG".join(self.str_tutee_ids)}
+
+    def test_separator_big_ordering_desc(self):
+        out = self.shakes.tutees.aggregate(tids=GroupConcat("id", separator="BIG", ordering="desc"))
+        assert out == {"tids": "BIG".join(reversed(self.str_tutee_ids))}

--- a/tests/testapp/test_aggregates.py
+++ b/tests/testapp/test_aggregates.py
@@ -133,12 +133,8 @@ class GroupConcatTests(TestCase):
         out = self.shakes.tutees.aggregate(tids=GroupConcat("id", ordering="desc"))
         assert out == {"tids": ",".join(reversed(self.str_tutee_ids))}
 
-    def test_separator_big_ordering_asc(self):
-        big_asc = GroupConcat("id", separator="BIG", ordering="asc")
-        out = self.shakes.tutees.aggregate(tids=big_asc)
-        assert out == {"tids": "BIG".join(self.str_tutee_ids)}
-
-    def test_separator_big_ordering_desc(self):
-        big_desc = GroupConcat("id", separator="BIG", ordering="desc")
-        out = self.shakes.tutees.aggregate(tids=big_desc)
-        assert out == {"tids": "BIG".join(reversed(self.str_tutee_ids))}
+    def test_separator_ordering(self):
+        concat = GroupConcat("id", separator=":", ordering="asc")
+        out = self.shakes.tutees.aggregate(tids=concat)
+        concatted_ids = ":".join(self.str_tutee_ids)
+        assert out == {"tids": concatted_ids}


### PR DESCRIPTION
Otherwise you end up with a syntax error if you set both, `separator` and `ordering`!

https://dev.mysql.com/doc/refman/5.7/en/group-by-functions.html#function_group-concat