### PR TITLE
Switch 'pip install' for 'python -m pip install'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
 
 before_script: .travis/before_script.sh
 
-install: pip install coveralls tox-travis
+install: python -m pip install coveralls tox-travis
 
 script:
 - coverage erase

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -105,7 +105,7 @@ Ready to contribute? Here's how to set up Django-MySQL for local development.
 
    .. code-block:: sh
 
-       $ pip install tox
+       $ python -m pip install tox
        $ tox -e py36-django21
 
    The ``tox.ini`` file defines a large number of test environments, for

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,7 +19,7 @@ Install it with **pip**:
 
 .. code-block:: console
 
-    $ pip install django-mysql
+    $ python -m pip install django-mysql
 
 Or add it to your project's ``requirements.txt``.
 

--- a/docs/model_fields/dynamic_field.rst
+++ b/docs/model_fields/dynamic_field.rst
@@ -44,7 +44,7 @@ to pack and unpack Dynamic Columns blobs in Python rather than in MariaDB
     To use this field, you'll need to:
 
     1. Use MariaDB 10.0.2+
-    2. Install ``mariadb-dyncol`` (``pip install mariadb-dyncol``)
+    2. Install ``mariadb-dyncol`` (``python -m pip install mariadb-dyncol``)
     3. Use either the ``utf8mb4`` or ``utf8`` character set for your
        database connection.
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ passenv =
     DB_PASSWORD
     DB_HOST
     DB_PORT
-install_command = pip install --no-deps {opts} {packages} --no-cache-dir
+install_command = python -m pip install --no-deps {opts} {packages} --no-cache-dir
 commands = coverage run --parallel -m pytest {posargs}
 
 [testenv:py35-django111]


### PR DESCRIPTION
As per [Brett Cannon's article](https://snarky.ca/why-you-should-use-python-m-pip/).