### PR TITLE
Prevent JSONField from adding CAST(... AS JSON) for str/int/float

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Pending
 
 * Prevent ``collections.abc.Sequence`` warning.
 * Drop Django 1.11 support. Only Django 2.0+ is supported now.
+* Prevent ``JSONField`` from adding ``CAST(... AS JSON)`` to queries against
+  ``str``, ``int``, and ``float`` types.
 
 3.3.0 (2019-12-10)
 ------------------

--- a/src/django_mysql/models/lookups.py
+++ b/src/django_mysql/models/lookups.py
@@ -2,7 +2,7 @@ import json
 from collections.abc import Sequence
 
 import django
-from django.db.models import CharField, Lookup, Transform
+from django.db.models import CharField, Lookup, Transform, Value
 from django.db.models.lookups import (
     BuiltinLookup,
     Exact,
@@ -53,7 +53,10 @@ class JSONLookupMixin:
         def get_prep_lookup(self):
             value = self.rhs
             if not hasattr(value, "resolve_expression") and value is not None:
-                return JSONValue(value)
+                if isinstance(value, (str, int, float)) and not isinstance(value, bool):
+                    return Value(value)
+                else:
+                    return JSONValue(value)
             return super().get_prep_lookup()
 
     else:
@@ -61,7 +64,10 @@ class JSONLookupMixin:
         def get_prep_lookup(self):
             value = self.rhs
             if not hasattr(value, "_prepare") and value is not None:
-                return JSONValue(value)
+                if isinstance(value, (str, int, float)) and not isinstance(value, bool):
+                    return Value(value)
+                else:
+                    return JSONValue(value)
             return super().get_prep_lookup()
 
 

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -280,6 +280,8 @@ class JSONModel(Model):
     ) and connection._nodb_connection.mysql_version >= (5, 7):
         attrs = JSONField(null=True)
 
+    name = CharField(max_length=3)
+
     def __unicode__(self):
         return str(json.dumps(self.attrs))
 


### PR DESCRIPTION
Fixes #480 .
Only cast to json the right hand side expression if it is a dict, a list or a tuple.

Example:
Before:
`WHERE JSON_EXTRACT(tabledoc.field, '$.sub_field') = (CAST('\"value\"' AS JSON));`
After:
`WHERE JSON_EXTRACT(tabledoc.field, '$.sub_field') = ("value");`
