### PR TITLE
Implement JSONIn lookup.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 
 * Changed query rewriting to use Django's database instrumentation.
   (`Issue #644 <https://github.com/adamchainz/django-mysql/issues/644>`__)
+* Added ``JSONIn`` lookup which only works with literal values (not with
+  expressions nor subqueries).
 
 3.5.0 (2020-05-04)
 ------------------

--- a/docs/model_fields/json_field.rst
+++ b/docs/model_fields/json_field.rst
@@ -295,3 +295,17 @@ For example:
         'smelliness': 5,
     })
     [<ShopItem: Feta>]
+
+"In" Lookup
+~~~~~~~~~~~
+
+The ``in`` lookup is supported, for iterables of JSON-serializable literal
+values.
+
+For example:
+
+.. code-block:: python
+
+    # Find all ShopItems with a crumbliness of either 0 or 10
+    >>> ShopItems.objects.filter(attrs__crumbliness__in=[0, 10])
+    [<ShopItem: Feta>, <ShopItem: Cheddar>]

--- a/src/django_mysql/models/fields/json.py
+++ b/src/django_mysql/models/fields/json.py
@@ -14,6 +14,7 @@ from django_mysql.models.lookups import (
     JSONHasAnyKeys,
     JSONHasKey,
     JSONHasKeys,
+    JSONIn,
     JSONLessThan,
     JSONLessThanOrEqual,
 )
@@ -157,7 +158,6 @@ class JSONField(Field):
         # Have to 'unregister' some incompatible lookups
         if lookup_name in {
             "range",
-            "in",
             "iexact",
             "icontains",
             "startswith",
@@ -198,6 +198,7 @@ JSONField.register_lookup(JSONGreaterThanOrEqual)
 JSONField.register_lookup(JSONHasAnyKeys)
 JSONField.register_lookup(JSONHasKey)
 JSONField.register_lookup(JSONHasKeys)
+JSONField.register_lookup(JSONIn)
 JSONField.register_lookup(JSONLength)
 JSONField.register_lookup(JSONLessThan)
 JSONField.register_lookup(JSONLessThanOrEqual)

--- a/src/django_mysql/models/lookups.py
+++ b/src/django_mysql/models/lookups.py
@@ -8,6 +8,7 @@ from django.db.models.lookups import (
     Exact,
     GreaterThan,
     GreaterThanOrEqual,
+    In,
     LessThan,
     LessThanOrEqual,
 )
@@ -73,6 +74,46 @@ class JSONLookupMixin:
 
 class JSONExact(JSONLookupMixin, Exact):
     pass
+
+
+class JSONIn(In):
+    lookup_name = "in"
+
+    if django.VERSION >= (3, 0):
+
+        def get_prep_lookup(self):
+            if hasattr(self.rhs, "resolve_expression"):
+                raise ValueError(
+                    "JSONField's 'in' lookup only works with literal values"
+                )
+            prepared_values = []
+            for rhs_value in self.rhs:
+                if hasattr(rhs_value, "resolve_expression"):
+                    raise ValueError(
+                        "JSONField's 'in' lookup only works with literal values"
+                    )
+                else:
+                    rhs_value = JSONValue(rhs_value)
+                prepared_values.append(rhs_value)
+            return prepared_values
+
+    else:
+
+        def get_prep_lookup(self):
+            if hasattr(self.rhs, "_prepare"):
+                raise ValueError(
+                    "JSONField's 'in' lookup only works with literal values"
+                )
+            prepared_values = []
+            for rhs_value in self.rhs:
+                if hasattr(rhs_value, "resolve_expression"):
+                    raise ValueError(
+                        "JSONField's 'in' lookup only works with literal values"
+                    )
+                else:
+                    rhs_value = JSONValue(rhs_value)
+                prepared_values.append(rhs_value)
+            return prepared_values
 
 
 class JSONGreaterThan(JSONLookupMixin, GreaterThan):

--- a/tests/testapp/test_jsonfield.py
+++ b/tests/testapp/test_jsonfield.py
@@ -200,6 +200,35 @@ class QueryTests(JSONFieldTestCase):
 
         assert "Lookup 'range' doesn't work with JSONField" in str(excinfo.value)
 
+    def test_in_lookup(self):
+        objs = list(
+            JSONModel.objects.filter(attrs__in=[{"a": "c"}, {"a": "b"}, {"c": "b"}])
+        )
+        assert objs == [self.objs[0]]
+
+        objs = list(JSONModel.objects.filter(attrs__in=[111, 1337, 333]))
+        assert objs == [self.objs[1]]
+
+        objs = list(
+            JSONModel.objects.filter(
+                attrs__in=[["array"], ["an", "array"], ["another", "array"]]
+            )
+        )
+        assert objs == [self.objs[2]]
+
+        objs = list(JSONModel.objects.filter(attrs__in=["bar", "foo", "baz"]))
+        assert objs == [self.objs[4]]
+
+        objs = list(
+            JSONModel.objects.filter(
+                attrs__in=[{"a": "b"}, 1337, "foo", ["an", "array"]]
+            )
+        )
+        assert objs == [self.objs[0], self.objs[1], self.objs[2], self.objs[4]]
+
+        objs = list(JSONModel.objects.filter(attrs__in=["bar"]))
+        assert objs == []
+
 
 class ArrayQueryTests(JSONFieldTestCase):
     def setUp(self):
@@ -252,15 +281,17 @@ class ExtraLookupsQueryTests(JSONFieldTestCase):
         self.objs = [
             JSONModel.objects.create(attrs={}),
             JSONModel.objects.create(
+                name='"b"',
                 attrs={
                     "a": "b",
                     "c": 1,
                     9001: 9002,
                     '"': "awkward",
                     "\n": "super awkward",
-                }
+                },
             ),
             JSONModel.objects.create(
+                name="b",
                 attrs={
                     "a": "b",
                     "c": 1,
@@ -269,10 +300,11 @@ class ExtraLookupsQueryTests(JSONFieldTestCase):
                     "i": False,
                     "j": None,
                     "k": {"l": "m"},
-                }
+                },
             ),
             JSONModel.objects.create(attrs=[1, [2]]),
             JSONModel.objects.create(attrs={"k": True, "l": False, "\\": "awkward"}),
+            JSONModel.objects.create(attrs={"a": "n"}, name="x"),
         ]
 
     def test_has_key_invalid_type(self):
@@ -287,6 +319,7 @@ class ExtraLookupsQueryTests(JSONFieldTestCase):
         assert list(JSONModel.objects.filter(attrs__has_key="a")) == [
             self.objs[1],
             self.objs[2],
+            self.objs[5],
         ]
 
     def test_has_key_2(self):
@@ -331,6 +364,7 @@ class ExtraLookupsQueryTests(JSONFieldTestCase):
             self.objs[1],
             self.objs[2],
             self.objs[4],
+            self.objs[5],
         ]
 
     def test_has_any_keys_awkward(self):
@@ -417,6 +451,41 @@ class ExtraLookupsQueryTests(JSONFieldTestCase):
         assert list(
             JSONModel.objects.filter(id__in=JSONModel.objects.filter(attrs__c=1))
         ) == [self.objs[1], self.objs[2]]
+
+    def test_in_lookup(self):
+        objs = list(JSONModel.objects.filter(attrs__a__in=["x", "b", "y"]))
+        assert objs == [self.objs[1], self.objs[2]]
+
+        objs = list(
+            JSONModel.objects.filter(
+                attrs__d__1__in=[{"x": "g"}, {"f": "g"}, {"f": "x"}]
+            )
+        )
+        assert objs == [self.objs[2]]
+
+        objs = list(JSONModel.objects.filter(attrs__k__in=[True, {"l": "m"}, "x"]))
+        assert objs == [self.objs[2], self.objs[4]]
+
+        objs = list(JSONModel.objects.filter(attrs__k__in=[{"l": "m"}, "x"]))
+        assert objs == [self.objs[2]]
+
+        objs = list(JSONModel.objects.filter(attrs__k__in=[True, "x"]))
+        assert objs == [self.objs[4]]
+
+        with pytest.raises(ValueError) as excinfo:
+            JSONModel.objects.filter(attrs__a__in=[F("name"), "n"])
+        assert (
+            str(excinfo.value)
+            == "JSONField's 'in' lookup only works with literal values"
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            subquery = JSONModel.objects.filter(name="b").values_list("attrs")
+            JSONModel.objects.filter(attrs__in=subquery)
+        assert (
+            str(excinfo.value)
+            == "JSONField's 'in' lookup only works with literal values"
+        )
 
 
 class TestCheck(JSONFieldTestCase):

--- a/tests/testapp/test_jsonfield.py
+++ b/tests/testapp/test_jsonfield.py
@@ -206,6 +206,9 @@ class QueryTests(JSONFieldTestCase):
         )
         assert objs == [self.objs[0]]
 
+        objs = list(JSONModel.objects.filter(attrs__a__in=["b"]))
+        assert objs == [self.objs[0]]
+
         objs = list(JSONModel.objects.filter(attrs__in=[111, 1337, 333]))
         assert objs == [self.objs[1]]
 


### PR DESCRIPTION
In both [mysql5.7](https://dev.mysql.com/doc/refman/5.7/en/json.html) and [mysql8.0](https://dev.mysql.com/doc/refman/8.0/en/json.html) documentation says:

> The following comparison operators and functions are not yet supported with JSON values: BETWEEN, **IN()**, GREATEST(), LEAST(). A **workaround** for the comparison operators and functions just listed is to cast JSON values to a native MySQL numeric or string data type so they have a consistent non-JSON scalar type.

In this PR I've implemented this workaround for the **In** operator.

Note that the workaround is achieved by doing `json.dumps` to the values in the right-hand-side. This is not possible if the values are expressions or subqueries.