### PR TITLE
docs: Fix simple typo, overriden -> overridden

### DIFF
--- a/docs/model_fields/json_field.rst
+++ b/docs/model_fields/json_field.rst
@@ -250,7 +250,7 @@ For example:
 Containment Lookups
 ~~~~~~~~~~~~~~~~~~~
 
-The ``contains`` lookup is overriden on ``JSONField`` to support the MySQL
+The ``contains`` lookup is overridden on ``JSONField`` to support the MySQL
 ``JSON_CONTAINS`` function. This allows you to search, for example, JSON
 objects that contain at least a given set of key-value pairs. Additionally you
 can do the inverse with ``contained_by``, i.e. find values where the objects


### PR DESCRIPTION
There is a small typo in docs/model_fields/json_field.rst.

Should read `overridden` rather than `overriden`.

