### PR TITLE
Allow callable for rewrite setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ output/*/index.html
 
 # Sphinx
 docs/_build
+
+# Mac
+.DS_Store
+


### PR DESCRIPTION
This was touched on in #643. The response to that was looking into middleware for performance/flow reasons. This MR addresses the programmatic enabling/disabling of rewriting queries so that a callable can be provided instead.