### PR TITLE
Fix bug in JSONContains lookup related with scalar values.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 
 * Changed query rewriting to use Django's database instrumentation.
   (`Issue #644 <https://github.com/adamchainz/django-mysql/issues/644>`__)
+* Fix ``JSONContains`` to make it work with scalar values again.
+  (`PR #668 <https://github.com/adamchainz/django-mysql/pull/668>`__).
 
 3.5.0 (2020-05-04)
 ------------------

--- a/src/django_mysql/models/lookups.py
+++ b/src/django_mysql/models/lookups.py
@@ -101,8 +101,28 @@ class JSONContainedBy(Lookup):
         return "JSON_CONTAINS({}, {})".format(rhs, lhs), params
 
 
-class JSONContains(JSONLookupMixin, Lookup):
+class JSONContains(Lookup):
     lookup_name = "contains"
+
+    if django.VERSION >= (3, 0):
+
+        def get_prep_lookup(self):
+            value = self.rhs
+            if hasattr(value, "resolve_expression"):
+                raise ValueError(
+                    "JSONField's 'contains' lookup only works with literal values"
+                )
+            return JSONValue(value)
+
+    else:
+
+        def get_prep_lookup(self):
+            value = self.rhs
+            if hasattr(value, "_prepare"):
+                raise ValueError(
+                    "JSONField's 'contains' lookup only works with literal values"
+                )
+            return JSONValue(value)
 
     def as_sql(self, qn, connection):
         lhs, lhs_params = self.process_lhs(qn, connection)

--- a/tests/testapp/test_jsonfield.py
+++ b/tests/testapp/test_jsonfield.py
@@ -252,24 +252,26 @@ class ExtraLookupsQueryTests(JSONFieldTestCase):
         self.objs = [
             JSONModel.objects.create(attrs={}),
             JSONModel.objects.create(
+                name='"b"',
                 attrs={
                     "a": "b",
                     "c": 1,
                     9001: 9002,
                     '"': "awkward",
                     "\n": "super awkward",
-                }
+                },
             ),
             JSONModel.objects.create(
+                name="b",
                 attrs={
                     "a": "b",
                     "c": 1,
-                    "d": ["e", {"f": "g"}],
+                    "d": ["e", {"f": "g"}, 1],
                     "h": True,
                     "i": False,
                     "j": None,
                     "k": {"l": "m"},
-                }
+                },
             ),
             JSONModel.objects.create(attrs=[1, [2]]),
             JSONModel.objects.create(attrs={"k": True, "l": False, "\\": "awkward"}),
@@ -338,19 +340,79 @@ class ExtraLookupsQueryTests(JSONFieldTestCase):
             self.objs[4]
         ]
 
-    def test_contains(self):
+    def test_contains_scalar_in_scalar(self):
+        assert list(JSONModel.objects.filter(attrs__a__contains="b")) == [
+            self.objs[1],
+            self.objs[2],
+        ]
+        assert list(JSONModel.objects.filter(attrs__c__contains=1)) == [
+            self.objs[1],
+            self.objs[2],
+        ]
+        assert list(JSONModel.objects.filter(attrs__l__contains=False)) == [
+            self.objs[4],
+        ]
+        assert list(JSONModel.objects.filter(attrs__h__contains=True)) == [
+            self.objs[2],
+        ]
+        assert list(JSONModel.objects.filter(attrs__j__contains=None)) == [
+            self.objs[2],
+        ]
+
+        assert list(JSONModel.objects.filter(attrs__a__contains=1)) == []
+        assert list(JSONModel.objects.filter(attrs__c__contains="b")) == []
+        assert list(JSONModel.objects.filter(attrs__l__contains=True)) == []
+        assert list(JSONModel.objects.filter(attrs__h__contains=False)) == []
+
+    def test_contains_object_in_object(self):
         assert list(JSONModel.objects.filter(attrs__contains={"a": "b"})) == [
             self.objs[1],
             self.objs[2],
         ]
-
-    def test_contains_2(self):
-        assert list(JSONModel.objects.filter(attrs__contains={"l": False})) == [
-            self.objs[4]
+        assert list(JSONModel.objects.filter(attrs__contains={"c": 1})) == [
+            self.objs[1],
+            self.objs[2],
         ]
+        assert list(JSONModel.objects.filter(attrs__contains={"l": False})) == [
+            self.objs[4],
+        ]
+        assert list(JSONModel.objects.filter(attrs__contains={"h": True})) == [
+            self.objs[2],
+        ]
+        assert list(JSONModel.objects.filter(attrs__contains={"j": None})) == [
+            self.objs[2],
+        ]
+
+        assert list(JSONModel.objects.filter(attrs__contains={"a": 1})) == []
+        assert list(JSONModel.objects.filter(attrs__contains={"c": "b"})) == []
+        assert list(JSONModel.objects.filter(attrs__contains={"l": True})) == []
+        assert list(JSONModel.objects.filter(attrs__contains={"h": False})) == []
 
     def test_contains_array(self):
         assert list(JSONModel.objects.filter(attrs__contains=[[2]])) == [self.objs[3]]
+        assert list(JSONModel.objects.filter(attrs__contains=1)) == [self.objs[3]]
+        assert list(JSONModel.objects.filter(attrs__d__contains="e")) == [self.objs[2]]
+        assert list(JSONModel.objects.filter(attrs__d__contains=1)) == [self.objs[2]]
+        assert list(JSONModel.objects.filter(attrs__d__contains={"f": "g"})) == [
+            self.objs[2]
+        ]
+        assert list(JSONModel.objects.filter(attrs__d__contains=2)) == []
+
+    def test_contains_expression_and_subqueries(self):
+        with pytest.raises(ValueError) as excinfo:
+            list(JSONModel.objects.filter(attrs__a__contains=F("name")))
+        assert (
+            str(excinfo.value)
+            == "JSONField's 'contains' lookup only works with literal values"
+        )
+
+        subquery = JSONModel.objects.filter(name="b").values_list("attrs")
+        with pytest.raises(ValueError) as excinfo:
+            JSONModel.objects.filter(attrs__contains=subquery)
+        assert (
+            str(excinfo.value)
+            == "JSONField's 'contains' lookup only works with literal values"
+        )
 
     def test_contained_by(self):
         assert list(


### PR DESCRIPTION
#621 broke the "contains" lookup, as the mysql fuction "JSON_CONTAINS" needs all values to be casted to json, even scalar values.

Example (mysql 5.7)
```mysql
SET @doc1 = '{"a": "x", "b": 2, "c": {"d": 3}}';
SELECT JSON_CONTAINS(@doc1, cast('"x"' as json), '$.a');  #  returns 1
SELECT JSON_CONTAINS(@doc1, 'x', '$.a');  # ERROR
```
The error raised by the second SELECT is:
> Error Code: 3141. Invalid JSON text in argument 2 to function json_contains: "Invalid value." at position 0.


This behavior differs from the one from the `=` mysql operator, which works with both versions:
```mysql
SET @doc1 = '{"a": "x", "b": 2, "c": {"d": 3}}';
SELECT JSON_EXTRACT(@doc1, '$.a') = cast('"x" as json');  # returns 1
SELECT JSON_EXTRACT(@doc1, '$.a') = 'x';  # returns 1
```
