### PR TITLE
Stop testing on MariaDB 10.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,6 @@ jobs:
         - mysql:5.6
         - mysql:5.7
         - mysql:8.0
-        # - mariadb:5.5
-        - mariadb:10.0
         - mariadb:10.1
         - mariadb:10.2
         - mariadb:10.3

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 
 * Drop Django 2.0 and 2.1 support.
 * Test with MariaDB 10.5.
+* Drop testing with MariaDB 10.0 (Django only officially supports MariaDB
+  10.1+ anyway).
 
 3.7.1 (2020-06-24)
 ------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,7 +9,7 @@ These are the supported, tested versions of Django-MySQL's requirements:
 
 * Python: 3.5, 3.6, 3.7, 3.8
 * Django: 2.2, 3.0
-* MySQL: 5.6, 5.7, 8.0 / MariaDB: 10.0, 10.1, 10.2, 10.3, 10.4, 10.5
+* MySQL: 5.6, 5.7, 8.0 / MariaDB: 10.1, 10.2, 10.3, 10.4, 10.5
 * mysqlclient: 1.3, 1.4
 
 Installation

--- a/tests/testapp/test_utils.py
+++ b/tests/testapp/test_utils.py
@@ -48,7 +48,7 @@ class ConnectionIsMariaDBTests(TestCase):
 
     def test_mariadb(self):
         conn = mock.MagicMock(vendor="mysql")
-        conn.connection.get_server_info.return_value = "10.0.3-MariaDB-1~precise-log"
+        conn.connection.get_server_info.return_value = "10.4.3-MariaDB-1~precise-log"
         assert connection_is_mariadb(conn)
         conn.connection.get_server_info.side_effect = ValueError("re-called")
         assert connection_is_mariadb(conn)


### PR DESCRIPTION
Django 3.0 was the first to add official MariaDB support, and only for 10.1+, so stop testing with 10.0 (no known compatibility differences though).