### PR TITLE
Drop changelog marker from HISTORY.rst

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,5 +1,4 @@
-.. :changelog:
-
+=======
 History
 =======
 


### PR DESCRIPTION
No longer needed as the file is not contatenated with README.