### PR TITLE
Fix RemovedInDjango40Warning messages for django.utils.translation

### DIFF
--- a/src/django_mysql/forms.py
+++ b/src/django_mysql/forms.py
@@ -4,7 +4,7 @@ from django import forms
 from django.core import validators
 from django.core.exceptions import ValidationError
 from django.utils.text import format_lazy
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django_mysql.validators import (
     ListMaxLengthValidator,

--- a/src/django_mysql/models/fields/dynamic.py
+++ b/src/django_mysql/models/fields/dynamic.py
@@ -12,7 +12,7 @@ from django.db.models import (
     TimeField,
     Transform,
 )
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django_mysql.checks import mysql_connections
 from django_mysql.models.lookups import DynColHasKey

--- a/src/django_mysql/models/fields/enum.py
+++ b/src/django_mysql/models/fields/enum.py
@@ -1,6 +1,6 @@
 from django.db.models import CharField
 from django.utils.encoding import force_str
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class EnumField(CharField):

--- a/src/django_mysql/validators.py
+++ b/src/django_mysql/validators.py
@@ -1,9 +1,9 @@
 from django.core.validators import MaxLengthValidator, MinLengthValidator
-from django.utils.translation import ungettext_lazy
+from django.utils.translation import ngettext_lazy
 
 
 class ListMaxLengthValidator(MaxLengthValidator):
-    message = ungettext_lazy(
+    message = ngettext_lazy(
         "List contains %(show_value)d item, "
         "it should contain no more than %(limit_value)d.",
         "List contains %(show_value)d items, "
@@ -13,7 +13,7 @@ class ListMaxLengthValidator(MaxLengthValidator):
 
 
 class ListMinLengthValidator(MinLengthValidator):
-    message = ungettext_lazy(
+    message = ngettext_lazy(
         "List contains %(show_value)d item, "
         "it should contain no fewer than %(limit_value)d.",
         "List contains %(show_value)d items, "
@@ -23,7 +23,7 @@ class ListMinLengthValidator(MinLengthValidator):
 
 
 class SetMaxLengthValidator(MaxLengthValidator):
-    message = ungettext_lazy(
+    message = ngettext_lazy(
         "Set contains %(show_value)d item, "
         "it should contain no more than %(limit_value)d.",
         "Set contains %(show_value)d items, "
@@ -33,7 +33,7 @@ class SetMaxLengthValidator(MaxLengthValidator):
 
 
 class SetMinLengthValidator(MinLengthValidator):
-    message = ungettext_lazy(
+    message = ngettext_lazy(
         "Set contains %(show_value)d item, "
         "it should contain no fewer than %(limit_value)d.",
         "Set contains %(show_value)d items, "


### PR DESCRIPTION
small adjustment to remove the warning since all supported versions have this as the favored usage.