### PR TITLE
Fix one more django.utils.translation RemovedInDjango40Warning

### DIFF
--- a/src/django_mysql/apps.py
+++ b/src/django_mysql/apps.py
@@ -1,7 +1,7 @@
 from django.apps import AppConfig
 from django.conf import settings
 from django.db.backends.signals import connection_created
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django_mysql.checks import register_checks
 from django_mysql.rewrite_query import REWRITE_MARKER, rewrite_query

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ passenv =
     DB_PASSWORD
     DB_HOST
     DB_PORT
-commands = coverage run --parallel -m pytest {posargs}
+commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m coverage run --parallel -m pytest {posargs}
 
 [testenv:py35-django22]
 deps = -rrequirements/py35-django22.txt


### PR DESCRIPTION
Missed in #700.

Also make any deprecation warning error so these get found in the future.