### PR TITLE
Remove tox-gh-actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,9 +62,11 @@ jobs:
     - name: Install percona-toolkit
       run: sudo apt-get install -y percona-toolkit
     - name: Install dependencies
-      run: python -m pip install --upgrade coveralls tox tox-gh-actions
+      run: python -m pip install --upgrade coveralls tox
     - name: Run tox targets for ${{ matrix.python-version }}
-      run: python -m tox
+      run: |
+        ENV_PREFIX=$(tr -C -d "0-9" <<< "${{ matrix.python-version }}")
+        TOXENV=$(tox --listenvs | grep "^py$ENV_PREFIX" | tr '\n' ',') python -m tox
     - name: Upload coverage
       run: |
         coverage combine

--- a/tox.ini
+++ b/tox.ini
@@ -8,14 +8,6 @@ envlist =
     py38-codestyle
     py39-django{22,30,31}
 
-[gh-actions]
-python =
-    3.5: py35
-    3.6: py36
-    3.7: py37
-    3.8: py38, py38-codestyle
-    3.9: py39
-
 [testenv]
 passenv =
     DB_USER


### PR DESCRIPTION
Use a couple of lines of shell instead. This removes the need to maintain the `[gh-actions]` section of tox.ini.
