### PR TITLE
Fix form JSONField for to not use the ensure_ascii flag

### DIFF
--- a/src/django_mysql/forms.py
+++ b/src/django_mysql/forms.py
@@ -283,4 +283,4 @@ class JSONField(forms.CharField):
     def prepare_value(self, value):
         if isinstance(value, InvalidJSONInput):
             return value
-        return json.dumps(value)
+        return json.dumps(value, ensure_ascii=False)

--- a/tests/testapp/test_forms.py
+++ b/tests/testapp/test_forms.py
@@ -269,11 +269,14 @@ class TestJSONField(SimpleTestCase):
         field = JSONField()
         assert field.prepare_value({"a": "b"}) == '{"a": "b"}'
         assert field.prepare_value(["a", "b"]) == '["a", "b"]'
+        assert field.prepare_value(["你好，世界", "😀🐱"]) == '["你好，世界", "😀🐱"]'
         assert field.prepare_value(True) == "true"
         assert field.prepare_value(False) == "false"
         assert field.prepare_value(3.14) == "3.14"
         assert field.prepare_value(None) == "null"
         assert field.prepare_value("foo") == '"foo"'
+        assert field.prepare_value("你好，世界") == '"你好，世界"'
+        assert field.prepare_value("😀🐱") == '"😀🐱"'
 
     def test_redisplay_wrong_input(self):
         """


### PR DESCRIPTION
```python
>>> import json
>>> print json.dumps('中国')
"\u4e2d\u56fd"
```
`json.dumps` use ASCII encoding by default when serializing Chinese.
So when we edit a `JsonField` which contains Chinese character in Django admin,it will appear in ASCII characters.
Adding `ensure_ascii=False` param will fix this problem.