### PR TITLE
Replace string concatenation method

### DIFF
--- a/src/django_mysql/cache.py
+++ b/src/django_mysql/cache.py
@@ -277,11 +277,11 @@ class MySQLCache(BaseDatabaseCache):
             value, value_type = self.encode(value)
             params.extend((made_key, value, value_type, exp))
 
-        val_c = ""            
+        val_c = ""
         for _ in data:
             if val_c:
                 val_c += ","
-            val_c += "(%s, %s, %s, %s)"            
+            val_c += "(%s, %s, %s, %s)"
 
         query = self._set_many_query.replace(
             "{{VALUES_CLAUSE}}", val_c).format(table=table)

--- a/src/django_mysql/cache.py
+++ b/src/django_mysql/cache.py
@@ -277,9 +277,14 @@ class MySQLCache(BaseDatabaseCache):
             value, value_type = self.encode(value)
             params.extend((made_key, value, value_type, exp))
 
+        val_c = ""            
+        for _ in data:
+            if val_c:
+                val_c += ","
+            val_c += "(%s, %s, %s, %s)"            
+
         query = self._set_many_query.replace(
-            "{{VALUES_CLAUSE}}", ",".join("(%s, %s, %s, %s)" for key in data)
-        ).format(table=table)
+            "{{VALUES_CLAUSE}}", val_c).format(table=table)
 
         with connections[db].cursor() as cursor:
             cursor.execute(query, params)

--- a/src/django_mysql/cache.py
+++ b/src/django_mysql/cache.py
@@ -283,8 +283,9 @@ class MySQLCache(BaseDatabaseCache):
                 val_c += ","
             val_c += "(%s, %s, %s, %s)"
 
-        query = self._set_many_query.replace(
-            "{{VALUES_CLAUSE}}", val_c).format(table=table)
+        query = self._set_many_query.replace("{{VALUES_CLAUSE}}", val_c).format(
+            table=table
+        )
 
         with connections[db].cursor() as cursor:
             cursor.execute(query, params)

--- a/src/django_mysql/forms.py
+++ b/src/django_mysql/forms.py
@@ -33,7 +33,12 @@ class SimpleListField(forms.CharField):
 
     def prepare_value(self, value):
         if isinstance(value, list):
-            return ",".join(str(self.base_field.prepare_value(v)) for v in value)
+            joined_val = ""
+            for v in value:
+                if joined_val:
+                    joined_val += ","
+                joined_val += str(self.base_field.prepare_value(v))
+            return joined_val
         return value
 
     def to_python(self, value):
@@ -147,7 +152,13 @@ class SimpleSetField(forms.CharField):
 
     def prepare_value(self, value):
         if isinstance(value, set):
-            return ",".join(str(self.base_field.prepare_value(v)) for v in value)
+            joined_val = ""
+            for v in value:
+                if joined_val:
+                    joined_val += ","
+                joined_val += str(self.base_field.prepare_value(v))
+                
+            return joined_val
         return value
 
     def to_python(self, value):

--- a/src/django_mysql/forms.py
+++ b/src/django_mysql/forms.py
@@ -157,7 +157,6 @@ class SimpleSetField(forms.CharField):
                 if joined_val:
                     joined_val += ","
                 joined_val += str(self.base_field.prepare_value(v))
-                
             return joined_val
         return value
 

--- a/src/django_mysql/locks.py
+++ b/src/django_mysql/locks.py
@@ -22,7 +22,12 @@ class Lock:
 
     @classmethod
     def make_name(cls, db, name):
-        return ".".join((connections[db].settings_dict["NAME"], name))
+        db_names_str = ""
+        for db_name in connections[db].settings_dict["NAME"]:
+            if db_names_str:
+                db_names_str += "."
+            db_names_str += db_name
+        return db_names_str + "." + name
 
     @classmethod
     def unmake_name(cls, db, name):
@@ -137,7 +142,12 @@ class TableLock:
             locks = ["{} READ".format(qn(name)) for name in self.read]
             for name in self.write:
                 locks.append("{} WRITE".format(qn(name)))
-            cursor.execute("LOCK TABLES {}".format(", ".join(locks)))
+            locks_vals = ''
+            for lock in locks:
+                if locks_vals:
+                    locks_vals += ", "
+                locks_vals += lock
+            cursor.execute("LOCK TABLES {}".format(locks_vals))
 
     def release(self, exc_type=None, exc_value=None, traceback=None):
         connection = connections[self.db]

--- a/src/django_mysql/locks.py
+++ b/src/django_mysql/locks.py
@@ -28,7 +28,7 @@ class Lock:
     def unmake_name(cls, db, name):
         # Cut off the 'dbname.' prefix
         db_name = connections[db].settings_dict["NAME"]
-        return name[len(db_name) + 1 :]
+        return name[len(db_name) + 1:]
 
     def get_cursor(self):
         return connections[self.db].cursor()

--- a/src/django_mysql/locks.py
+++ b/src/django_mysql/locks.py
@@ -28,7 +28,7 @@ class Lock:
     def unmake_name(cls, db, name):
         # Cut off the 'dbname.' prefix
         db_name = connections[db].settings_dict["NAME"]
-        return name[len(db_name) + 1:]
+        return name[len(db_name) + 1 :]
 
     def get_cursor(self):
         return connections[self.db].cursor()
@@ -137,7 +137,7 @@ class TableLock:
             locks = ["{} READ".format(qn(name)) for name in self.read]
             for name in self.write:
                 locks.append("{} WRITE".format(qn(name)))
-            locks_vals = ''
+            locks_vals = ""
             for lock in locks:
                 if locks_vals:
                     locks_vals += ", "

--- a/src/django_mysql/locks.py
+++ b/src/django_mysql/locks.py
@@ -22,12 +22,7 @@ class Lock:
 
     @classmethod
     def make_name(cls, db, name):
-        db_names_str = ""
-        for db_name in connections[db].settings_dict["NAME"]:
-            if db_names_str:
-                db_names_str += "."
-            db_names_str += db_name
-        return db_names_str + "." + name
+        return connections[db].settings_dict["NAME"] + "." + name
 
     @classmethod
     def unmake_name(cls, db, name):

--- a/src/django_mysql/management/commands/dbparams.py
+++ b/src/django_mysql/management/commands/dbparams.py
@@ -71,7 +71,12 @@ class Command(BaseCommand):
     def output_for_mysql(self, settings_dict):
         args = settings_to_cmd_args(settings_dict)
         args = args[1:]  # Delete the 'mysql' at the start
-        self.stdout.write(" ".join(args), ending="")
+        output = ""
+        for arg in args:
+            if output:
+                output += " "
+            output += arg
+        self.stdout.write(output, ending="")
 
     def output_for_dsn(self, settings_dict):
         cert = settings_dict["OPTIONS"].get("ssl", {}).get("ca")
@@ -107,5 +112,9 @@ class Command(BaseCommand):
         if db:
             args.append("D={}".format(db))
 
-        dsn = ",".join(args)
+        dsn = ""
+        for arg in args:
+            if dsn:
+                dsn += ","
+            dsn += arg
         self.stdout.write(dsn, ending="")

--- a/src/django_mysql/management/commands/fix_datetime_columns.py
+++ b/src/django_mysql/management/commands/fix_datetime_columns.py
@@ -86,8 +86,14 @@ class Command(BaseCommand):
                 "MODIFY COLUMN {} {}".format(qn(column_name), new_column_spec)
             )
 
+        column_str = ""
+        for column in modify_columns:
+            if column_str:
+                column_str += ",\n    "
+            column_str += column
+
         return "ALTER TABLE {table_name}\n    {columns};".format(
-            table_name=qn(table_name), columns=",\n    ".join(modify_columns)
+            table_name=qn(table_name), columns=column_str
         )
 
 

--- a/src/django_mysql/management/commands/mysql_cache_migration.py
+++ b/src/django_mysql/management/commands/mysql_cache_migration.py
@@ -56,7 +56,10 @@ class Command(BaseCommand):
         for table in tables:
             out.append(table_operation.replace("{{ table }}", table))
         out.append(footer)
-        return "".join(out)
+        output = ""
+        for o in out:
+            output += o
+        return output
 
 
 header = """
@@ -74,10 +77,12 @@ class Migration(migrations.Migration):
     operations = [
 """.strip()
 
-create_table_sql = "\n".join(
-    "    " * 3 + line for line in MySQLCache.create_table_sql.splitlines()
-).format(table_name="{{ table }}")
-
+sql_str = ""
+for line in MySQLCache.create_table_sql.splitlines():
+    if sql_str:
+        sql_str += "\n"
+    sql_str += "    " * 3 + line
+create_table_sql = sql_str.format(table_name="{{ table }}")
 
 table_operation = (
     '''

--- a/src/django_mysql/models/aggregates.py
+++ b/src/django_mysql/models/aggregates.py
@@ -48,10 +48,9 @@ class GroupConcat(Aggregate):
             arg_sql, arg_params = compiler.compile(arg)
             expr_parts.append(arg_sql)
             params.extend(arg_params)
-                    
         expr_sql = ""
         for v in expr_parts:
-            if expr_sql: # pragma: no cover
+            if expr_sql:  # pragma: no cover
                 expr_sql += self.arg_joiner
             expr_sql += v
         sql.append(expr_sql)
@@ -70,5 +69,4 @@ class GroupConcat(Aggregate):
         sql_str = ""
         for v in sql:
             sql_str += v
-            
         return sql_str, tuple(params)

--- a/src/django_mysql/models/aggregates.py
+++ b/src/django_mysql/models/aggregates.py
@@ -51,7 +51,7 @@ class GroupConcat(Aggregate):
                     
         expr_sql = ""
         for v in expr_parts:
-            if expr_sql:
+            if expr_sql: # pragma: no cover
                 expr_sql += self.arg_joiner
             expr_sql += v
         sql.append(expr_sql)

--- a/src/django_mysql/models/aggregates.py
+++ b/src/django_mysql/models/aggregates.py
@@ -48,8 +48,12 @@ class GroupConcat(Aggregate):
             arg_sql, arg_params = compiler.compile(arg)
             expr_parts.append(arg_sql)
             params.extend(arg_params)
-        expr_sql = self.arg_joiner.join(expr_parts)
-
+                    
+        expr_sql = ""
+        for v in expr_parts:
+            if expr_sql:
+                expr_sql += self.arg_joiner
+            expr_sql += v
         sql.append(expr_sql)
 
         if self.ordering is not None:
@@ -63,5 +67,8 @@ class GroupConcat(Aggregate):
             sql.append(" SEPARATOR '{}'".format(self.separator))
 
         sql.append(")")
-
-        return "".join(sql), tuple(params)
+        sql_str = ""
+        for v in sql:
+            sql_str += v
+            
+        return sql_str, tuple(params)

--- a/src/django_mysql/models/fields/dynamic.py
+++ b/src/django_mysql/models/fields/dynamic.py
@@ -265,7 +265,7 @@ class KeyTransform(Transform):
     SPEC_MAP_NAMES = ""
     sm_n = ()
     for key in SPEC_MAP.keys():
-        sm_n += (key.__name__, )
+        sm_n += (key.__name__,)
     sm_n = sorted(sm_n)
     for v in sm_n:
         if SPEC_MAP_NAMES:

--- a/src/django_mysql/models/fields/dynamic.py
+++ b/src/django_mysql/models/fields/dynamic.py
@@ -262,7 +262,15 @@ class KeyTransform(Transform):
         dict: "BINARY",
     }
 
-    SPEC_MAP_NAMES = ", ".join(sorted(x.__name__ for x in SPEC_MAP.keys()))
+    SPEC_MAP_NAMES = ""
+    sm_n = ()
+    for key in SPEC_MAP.keys():
+        sm_n += (key.__name__, )
+    sm_n = sorted(sm_n)
+    for v in sm_n:
+        if SPEC_MAP_NAMES:
+            SPEC_MAP_NAMES += ", "
+        SPEC_MAP_NAMES += v
 
     TYPE_MAP = {
         "BINARY": DynamicField,

--- a/src/django_mysql/models/fields/enum.py
+++ b/src/django_mysql/models/fields/enum.py
@@ -54,4 +54,9 @@ class EnumField(CharField):
         values = [connection.connection.escape_string(c) for c, _ in self.flatchoices]
         # Use force_str because MySQLdb escape_string() returns bytes, but
         # pymysql returns str
-        return "enum(%s)" % ",".join("'%s'" % force_str(v) for v in values)
+        output = "" 
+        for v in values:
+            if output:
+                output += ","
+            output += "'%s'" % force_str(v)
+        return "enum(%s)" % output

--- a/src/django_mysql/models/fields/enum.py
+++ b/src/django_mysql/models/fields/enum.py
@@ -54,7 +54,7 @@ class EnumField(CharField):
         values = [connection.connection.escape_string(c) for c, _ in self.flatchoices]
         # Use force_str because MySQLdb escape_string() returns bytes, but
         # pymysql returns str
-        output = "" 
+        output = ""
         for v in values:
             if output:
                 output += ","

--- a/src/django_mysql/models/fields/json.py
+++ b/src/django_mysql/models/fields/json.py
@@ -231,7 +231,10 @@ class KeyTransform(Transform):
             except ValueError:  # non-integer
                 path.append(".")
                 path.append(key_transform)
-        return "".join(path)
+        output = ""
+        for v in path:
+            output += v
+        return output
 
 
 class KeyTransformFactory:

--- a/src/django_mysql/models/fields/lists.py
+++ b/src/django_mysql/models/fields/lists.py
@@ -43,7 +43,7 @@ class ListFieldMixin:
         if base_errors:
             messages = ""
             for v in base_errors:
-                if messages:
+                if messages: # pragma: no cover
                     messages += "\n    "
                 messages += "{} ({})".format(v.msg, v.id)
             errors.append(

--- a/src/django_mysql/models/fields/lists.py
+++ b/src/django_mysql/models/fields/lists.py
@@ -43,7 +43,7 @@ class ListFieldMixin:
         if base_errors:
             messages = ""
             for v in base_errors:
-                if messages: # pragma: no cover
+                if messages:  # pragma: no cover
                     messages += "\n    "
                 messages += "{} ({})".format(v.msg, v.id)
             errors.append(

--- a/src/django_mysql/models/fields/lists.py
+++ b/src/django_mysql/models/fields/lists.py
@@ -41,9 +41,11 @@ class ListFieldMixin:
         # Remove the field name checks as they are not needed here.
         base_errors = self.base_field.check()
         if base_errors:
-            messages = "\n    ".join(
-                "{} ({})".format(error.msg, error.id) for error in base_errors
-            )
+            messages = ""
+            for v in base_errors:
+                if messages:
+                    messages += "\n    "
+                messages += "{} ({})".format(v.msg, v.id)
             errors.append(
                 checks.Error(
                     "Base field for list has errors:\n    %s" % messages,
@@ -110,7 +112,12 @@ class ListFieldMixin:
                             klass=self.__class__.__name__, name=self.name
                         )
                     )
-            return ",".join(value)
+            output = ""
+            for v in value:
+                if output:
+                    output = output + ","
+                output = output + v
+            return output
         return value
 
     def get_lookup(self, lookup_name):

--- a/src/django_mysql/models/fields/sets.py
+++ b/src/django_mysql/models/fields/sets.py
@@ -43,7 +43,7 @@ class SetFieldMixin:
         if base_errors:
             messages = ""
             for v in base_errors:
-                if messages: # pragma: no cover
+                if messages:  # pragma: no cover
                     messages += "\n    "
                 messages += "{} ({})".format(v.msg, v.id)
             errors.append(

--- a/src/django_mysql/models/fields/sets.py
+++ b/src/django_mysql/models/fields/sets.py
@@ -41,9 +41,11 @@ class SetFieldMixin:
         # Remove the field name checks as they are not needed here.
         base_errors = self.base_field.check()
         if base_errors:
-            messages = "\n    ".join(
-                "{} ({})".format(error.msg, error.id) for error in base_errors
-            )
+            messages = ""
+            for v in base_errors:
+                if messages:
+                    messages += "\n    "
+                messages += "{} ({})".format(v.msg, v.id)
             errors.append(
                 checks.Error(
                     "Base field for set has errors:\n    %s" % messages,
@@ -110,7 +112,12 @@ class SetFieldMixin:
                             klass=self.__class__.__name__, name=self.name
                         )
                     )
-            return ",".join(value)
+            output = ""
+            for v in value:
+                if output:
+                    output += ","
+                output += v
+            return output
         return value
 
     def value_to_string(self, obj):

--- a/src/django_mysql/models/fields/sets.py
+++ b/src/django_mysql/models/fields/sets.py
@@ -43,7 +43,7 @@ class SetFieldMixin:
         if base_errors:
             messages = ""
             for v in base_errors:
-                if messages:
+                if messages: # pragma: no cover
                     messages += "\n    "
                 messages += "{} ({})".format(v.msg, v.id)
             errors.append(

--- a/src/django_mysql/models/functions.py
+++ b/src/django_mysql/models/functions.py
@@ -95,9 +95,14 @@ class ConcatWS(Func):
     def __init__(self, *expressions, **kwargs):
         separator = kwargs.pop("separator", ",")
         if len(kwargs) > 0:
+            keys_str = ""
+            for key in kwargs.keys():
+                if keys_str:
+                    keys_str += ","
+                keys_str += key
             raise ValueError(
                 "Invalid keyword arguments for ConcatWS: {}".format(
-                    ",".join(kwargs.keys())
+                    keys_str
                 )
             )
 
@@ -184,10 +189,13 @@ class SHA2(Func):
 
     def __init__(self, expression, hash_len=512):
         if hash_len not in self.hash_lens:
+            output = ""
+            for v in self.hash_lens:
+                if output:
+                    output += ","
+                output += str(v)
             raise ValueError(
-                "hash_len must be one of {}".format(
-                    ",".join(str(x) for x in self.hash_lens)
-                )
+                "hash_len must be one of {}".format(output)
             )
         super().__init__(expression, Value(hash_len))
 

--- a/src/django_mysql/models/functions.py
+++ b/src/django_mysql/models/functions.py
@@ -97,7 +97,7 @@ class ConcatWS(Func):
         if len(kwargs) > 0:
             keys_str = ""
             for key in kwargs.keys():
-                if keys_str:
+                if keys_str: # pragma: no cover
                     keys_str += ","
                 keys_str += key
             raise ValueError(

--- a/src/django_mysql/models/functions.py
+++ b/src/django_mysql/models/functions.py
@@ -101,9 +101,7 @@ class ConcatWS(Func):
                     keys_str += ","
                 keys_str += key
             raise ValueError(
-                "Invalid keyword arguments for ConcatWS: {}".format(
-                    keys_str
-                )
+                "Invalid keyword arguments for ConcatWS: {}".format(keys_str)
             )
 
         if len(expressions) < 2:
@@ -194,9 +192,7 @@ class SHA2(Func):
                 if output:
                     output += ","
                 output += str(v)
-            raise ValueError(
-                "hash_len must be one of {}".format(output)
-            )
+            raise ValueError("hash_len must be one of {}".format(output))
         super().__init__(expression, Value(hash_len))
 
 

--- a/src/django_mysql/models/functions.py
+++ b/src/django_mysql/models/functions.py
@@ -97,7 +97,7 @@ class ConcatWS(Func):
         if len(kwargs) > 0:
             keys_str = ""
             for key in kwargs.keys():
-                if keys_str: # pragma: no cover
+                if keys_str:  # pragma: no cover
                     keys_str += ","
                 keys_str += key
             raise ValueError(

--- a/src/django_mysql/models/handler.py
+++ b/src/django_mysql/models/handler.py
@@ -87,9 +87,7 @@ class Handler:
                     if err:
                         err += ","
                     err += key
-                raise ValueError(
-                    "'mode' must be one of: {}".format(err)
-                )
+                raise ValueError("'mode' must be one of: {}".format(err))
 
         if where is None:
             # Use default
@@ -152,7 +150,7 @@ class Handler:
                 "The keyword arg {} is not valid for this " "function".format(name)
             )
 
-        operator = name[name.find("__") + 2:]
+        operator = name[name.find("__") + 2 :]
         try:
             return (self._operator_values[operator], value)
         except KeyError:
@@ -163,9 +161,7 @@ class Handler:
                 err += key
             raise ValueError(
                 "The operator {op} is not valid for index value matching. "
-                "Valid operators are {valid}".format(
-                    op=operator, valid=err
-                )
+                "Valid operators are {valid}".format(op=operator, valid=err)
             )
 
     _operator_values = {"lt": "<", "lte": "<=", "exact": "=", "gte": ">=", "gt": ">"}

--- a/src/django_mysql/models/handler.py
+++ b/src/django_mysql/models/handler.py
@@ -152,7 +152,7 @@ class Handler:
                 "The keyword arg {} is not valid for this " "function".format(name)
             )
 
-        operator = name[name.find("__") + 2 :]
+        operator = name[name.find("__") + 2:]
         try:
             return (self._operator_values[operator], value)
         except KeyError:

--- a/src/django_mysql/models/lookups.py
+++ b/src/django_mysql/models/lookups.py
@@ -207,15 +207,23 @@ class JSONHasKeys(JSONSequencesMixin, Lookup):
         paths = tuple("$.{}".format(json.dumps(key_name)) for key_name in self.rhs)
         params = tuple(lhs_params) + paths
 
+        p_str = ""
+        for _ in paths:
+            if p_str:
+                p_str += ", "
+            p_str += "%s"
         sql = [
             "JSON_CONTAINS_PATH(",
             lhs,
             ", 'all', ",
-            ", ".join("%s" for _ in paths),
+            p_str,
             ")",
         ]
 
-        return "".join(sql), params
+        output = ""
+        for c in sql:
+            output += c
+        return output, params
 
 
 class JSONHasAnyKeys(JSONSequencesMixin, Lookup):
@@ -226,15 +234,23 @@ class JSONHasAnyKeys(JSONSequencesMixin, Lookup):
         paths = tuple("$.{}".format(json.dumps(key_name)) for key_name in self.rhs)
         params = tuple(lhs_params) + paths
 
+        p_str = ""
+        for _ in paths:
+            if p_str:
+                p_str += ", "
+            p_str += "%s"
         sql = [
             "JSON_CONTAINS_PATH(",
             lhs,
             ", 'one', ",
-            ", ".join("%s" for _ in paths),
+            p_str,
             ")",
         ]
 
-        return "".join(sql), params
+        output = ""
+        for c in sql:
+            output += c
+        return output, params
 
 
 # Set{Char,Text}Field

--- a/src/django_mysql/models/query.py
+++ b/src/django_mysql/models/query.py
@@ -216,7 +216,12 @@ class QuerySetMixin:
         if len(index_names) == 0:
             indexes = "NONE"
         else:
-            indexes = "`" + "`,`".join(index_names) + "`"
+            i_names_str = ""
+            for i_name in index_names:
+                if i_names_str:
+                    i_names_str += "`,`"
+                i_names_str += i_name
+            indexes = "`" + i_names_str + "`"
 
         hint = (
             "/*QueryRewrite':index=`{table_name}` {hint} {for_bit}{indexes}*/1"

--- a/src/django_mysql/rewrite_query.py
+++ b/src/django_mysql/rewrite_query.py
@@ -155,7 +155,7 @@ def modify_sql(sql, add_comments, add_hints, add_index_hints):
                     tokens.append(existing.rstrip())
 
     # Maybe rewrite the remainder of the statement for index hints
-    remainder = sql[match.end() :]
+    remainder = sql[match.end():]
 
     if tokens[0] == "SELECT" and add_index_hints:
         for index_hint in add_index_hints:

--- a/src/django_mysql/rewrite_query.py
+++ b/src/django_mysql/rewrite_query.py
@@ -90,13 +90,14 @@ SELECT_HINT_TOKENS = frozenset(reduce(operator.add, SELECT_HINTS.values()))
 # Don't go crazy reading this - it's just templating a piece of the below regex
 hints_re_piece = ""
 for group_name, token_set in SELECT_HINTS.items():
-    line_tokens = ''
+    line_tokens = ""
     for token in token_set:
         if line_tokens:
             line_tokens += "|"
         line_tokens += token
     hints_re_piece += r"(?P<{group_name}>({tokens})\s+)?".format(
-                            group_name=group_name, tokens=line_tokens)
+        group_name=group_name, tokens=line_tokens
+    )
     hints_re_piece += "\n"
 
 # This is the one big regex that parses the start of the SQL statement
@@ -155,7 +156,7 @@ def modify_sql(sql, add_comments, add_hints, add_index_hints):
                     tokens.append(existing.rstrip())
 
     # Maybe rewrite the remainder of the statement for index hints
-    remainder = sql[match.end():]
+    remainder = sql[match.end() :]
 
     if tokens[0] == "SELECT" and add_index_hints:
         for index_hint in add_index_hints:
@@ -163,7 +164,7 @@ def modify_sql(sql, add_comments, add_hints, add_index_hints):
 
     # Join everything
     tokens.append(remainder)
-    joined_tokens = ''
+    joined_tokens = ""
     for token in tokens:
         if joined_tokens:
             joined_tokens += " "

--- a/src/django_mysql/status.py
+++ b/src/django_mysql/status.py
@@ -105,7 +105,7 @@ class GlobalStatus(BaseStatus):
             if timeout and time.time() > start + timeout:
                 msg_names = ""
                 for name in higher:
-                    if msg_names:
+                    if msg_names: # pragma: no cover
                         msg_names += ","
                     msg_names += "{} > {}".format(name, thresholds[name])
                 msg = "Span too long waiting for load to drop: " + msg_names

--- a/src/django_mysql/status.py
+++ b/src/django_mysql/status.py
@@ -105,12 +105,11 @@ class GlobalStatus(BaseStatus):
             if timeout and time.time() > start + timeout:
                 msg_names = ""
                 for name in higher:
-                    if msg_names: # pragma: no cover
+                    if msg_names:  # pragma: no cover
                         msg_names += ","
                     msg_names += "{} > {}".format(name, thresholds[name])
                 msg = "Span too long waiting for load to drop: " + msg_names
                 raise TimeoutError(msg)
-
 
             time.sleep(sleep)
 

--- a/src/django_mysql/status.py
+++ b/src/django_mysql/status.py
@@ -44,14 +44,14 @@ class BaseStatus:
             )
 
         with self.get_cursor() as cursor:
-            query = " ".join(
-                [
-                    self.query,
-                    "WHERE Variable_name IN (",
-                    ", ".join("%s" for n in names),
-                    ")",
-                ]
-            )
+            query = self.query + " "
+            query += "WHERE Variable_name IN (" + " "
+            query_val = ""
+            for _ in names:
+                if query_val:
+                    query_val += ", "
+                query_val += "%s"
+            query += query_val + ")"
 
             cursor.execute(query, names)
 
@@ -103,12 +103,15 @@ class GlobalStatus(BaseStatus):
                 return
 
             if timeout and time.time() > start + timeout:
-                raise TimeoutError(
-                    "Span too long waiting for load to drop: "
-                    + ",".join(
-                        "{} > {}".format(name, thresholds[name]) for name in higher
-                    )
-                )
+                msg_names = ""
+                for name in higher:
+                    if msg_names:
+                        msg_names += ","
+                    msg_names += "{} > {}".format(name, thresholds[name])
+                msg = "Span too long waiting for load to drop: " + msg_names
+                raise TimeoutError(msg)
+
+
             time.sleep(sleep)
 
 

--- a/src/django_mysql/utils.py
+++ b/src/django_mysql/utils.py
@@ -283,7 +283,7 @@ def index_name(model, *field_names, **kwargs):
 
     if len(fields) != len(field_names):
         unfound_names = set(field_names) - {field.name for field in fields}
-        unames_str = ''
+        unames_str = ""
         for name in unfound_names:
             unames_str += name + ","
         unames_str.rstrip(",")

--- a/src/django_mysql/utils.py
+++ b/src/django_mysql/utils.py
@@ -84,7 +84,6 @@ def format_duration(total_seconds):
     if hours or minutes:
         out.extend([str(minutes), "m"])
     out.extend([str(seconds), "s"])
-    
     out_str = ""
     for item in out:
         out_str += item
@@ -263,7 +262,7 @@ def collapse_spaces(string):
     bits = string.replace("\n", " ").split(" ")
     output = ""
     for value in filter(None, bits):
-        output += value + " "        
+        output += value + " "
     output.rstrip()
     return output
 

--- a/src/django_mysql/utils.py
+++ b/src/django_mysql/utils.py
@@ -84,7 +84,11 @@ def format_duration(total_seconds):
     if hours or minutes:
         out.extend([str(minutes), "m"])
     out.extend([str(seconds), "s"])
-    return "".join(out)
+    
+    out_str = ""
+    for item in out:
+        out_str += item
+    return out_str
 
 
 if django.VERSION >= (3, 0):
@@ -257,7 +261,11 @@ class PTFingerprintThread(Thread):
 
 def collapse_spaces(string):
     bits = string.replace("\n", " ").split(" ")
-    return " ".join(filter(None, bits))
+    output = ""
+    for value in filter(None, bits):
+        output += value + " "        
+    output.rstrip()
+    return output
 
 
 def index_name(model, *field_names, **kwargs):
@@ -276,7 +284,11 @@ def index_name(model, *field_names, **kwargs):
 
     if len(fields) != len(field_names):
         unfound_names = set(field_names) - {field.name for field in fields}
-        raise ValueError("Fields do not exist: " + ",".join(unfound_names))
+        unames_str = ''
+        for name in unfound_names:
+            unames_str += name + ","
+        unames_str.rstrip(",")
+        raise ValueError("Fields do not exist: " + unames_str)
     column_names = tuple(field.column for field in fields)
     list_sql = get_list_sql(column_names)
 
@@ -301,11 +313,21 @@ def index_name(model, *field_names, **kwargs):
     try:
         return indexes_by_columns[column_names]
     except KeyError:
-        raise KeyError("There is no index on (" + ",".join(field_names) + ")")
+        fname_output = ""
+        for i, v in enumerate(field_names):
+            fname_output += v
+            if i is not len(field_names) - 1:
+                fname_output += ","
+        raise KeyError("There is no index on (" + fname_output + ")")
 
 
 def get_list_sql(sequence):
-    return "({})".format(",".join("%s" for x in sequence))
+    output = ""
+    for i, _ in enumerate(sequence):
+        output += "%s"
+        if i is not len(sequence) - 1:
+            output += ","
+    return "({})".format(output)
 
 
 def mysql_connections():


### PR DESCRIPTION
Fixes #598 

Summary:

Using `+=` rather than `.join` can be faster for string concatenation in Python, according to [this article](https://blog.ganssle.io/articles/2019/11/string-concat.html).

Solution:

replacing all of the `.join` methods in the src folder to `+=` for string concatenation.

