### PR TITLE
Ensure wheel installed on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,8 +60,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools
-        python -m pip install --upgrade codecov setuptools tox tox-py
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade codecov tox tox-py
 
     - name: Install percona-toolkit
       run: |


### PR DESCRIPTION
This means for non-wheel packages, pip can compile a wheel that will get cached and reused between runs.