### PR TITLE
Fix index hints for tables with aliases

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+* Fix index hints for tables with aliases.
+
+  Thanks to Henrik Aarnio in `PR #786 <https://github.com/adamchainz/django-mysql/pull/786>`__.
+
 * Stop distributing tests to reduce package size. Tests are not intended to be
   run outside of the tox setup in the repository. Repackagers can use GitHub's
   tarballs per tag.

--- a/src/django_mysql/rewrite_query.py
+++ b/src/django_mysql/rewrite_query.py
@@ -166,12 +166,12 @@ def modify_sql(sql, add_comments, add_hints, add_index_hints):
 table_spec_re_template = r"""
     \b(?P<operator>FROM|JOIN)
     \s+
-    {table_name}
+    (?P<table_name_with_alias>{table_name}(\s+[A-Z]+[0-9]+)?)
     \s+
 """
 
 replacement_template = (
-    r"\g<operator> {table_name} " r"{rule} INDEX {for_section}({index_names}) "
+    r"\g<operator> \g<table_name_with_alias> " r"{rule} INDEX {for_section}({index_names}) "
 )
 
 
@@ -182,7 +182,6 @@ def modify_sql_index_hints(sql, table_name, rule, index_names, for_what):
     else:
         for_section = ""
     replacement = replacement_template.format(
-        table_name=table_name,
         rule=rule,
         for_section=for_section,
         index_names=("" if index_names == "NONE" else index_names),

--- a/src/django_mysql/rewrite_query.py
+++ b/src/django_mysql/rewrite_query.py
@@ -171,7 +171,8 @@ table_spec_re_template = r"""
 """
 
 replacement_template = (
-    r"\g<operator> \g<table_name_with_alias> " r"{rule} INDEX {for_section}({index_names}) "
+    r"\g<operator> \g<table_name_with_alias> "
+    r"{rule} INDEX {for_section}({index_names}) "
 )
 
 

--- a/tests/testapp/test_models.py
+++ b/tests/testapp/test_models.py
@@ -245,11 +245,9 @@ class QueryHintTests(TestCase):
                     has_books=Exists(
                         Book.objects.filter(
                             author_id=OuterRef("id"), title__gt=""
-                        )
-                        .use_index(title_idx, table_name="testapp_book")
+                        ).use_index(title_idx, table_name="testapp_book")
                     )
-                )
-                .filter(has_books=True)
+                ).filter(has_books=True)
             )
         assert ("USE INDEX (`" + title_idx + "`)") in cap.query
         used = used_indexes(cap.query)
@@ -277,11 +275,9 @@ class QueryHintTests(TestCase):
                     has_books=Exists(
                         Book.objects.filter(
                             author_id=OuterRef("id"), title__gt=""
-                        )
-                        .force_index(title_idx, table_name="testapp_book")
+                        ).force_index(title_idx, table_name="testapp_book")
                     )
-                )
-                .filter(has_books=True)
+                ).filter(has_books=True)
             )
         assert ("FORCE INDEX (`" + title_idx + "`)") in cap.query
         used = used_indexes(cap.query)

--- a/tests/testapp/test_models.py
+++ b/tests/testapp/test_models.py
@@ -5,6 +5,8 @@ from unittest import mock, skipUnless
 import pytest
 from django.contrib.contenttypes.models import ContentType
 from django.db import DEFAULT_DB_ALIAS, connections
+from django.db.models import OuterRef
+from django.db.models import Exists
 from django.db.models.query import QuerySet
 from django.template import Context, Template
 from django.test import TestCase
@@ -235,6 +237,16 @@ class QueryHintTests(TestCase):
         assert ("USE INDEX (`PRIMARY`)") in cap.query
         used = used_indexes(cap.query)
         assert len(used) == 0 or "PRIMARY" in used
+
+    def test_use_index_inner_query(self):
+        title_idx = index_name(Book, "title")
+        with CaptureLastQuery() as cap:
+            list(Author.objects.annotate(has_books=Exists(
+                Book.objects.filter(author_id=OuterRef('id'), title__gt="")
+            )).filter(has_books=True).use_index(title_idx, table_name="testapp_book"))
+        assert ("USE INDEX (`" + title_idx + "`)") in cap.query
+        used = used_indexes(cap.query)
+        assert len(used) == 0 or title_idx in used
 
     def test_force_index(self):
         name_idx = index_name(Author, "name")

--- a/tests/testapp/test_models.py
+++ b/tests/testapp/test_models.py
@@ -5,8 +5,7 @@ from unittest import mock, skipUnless
 import pytest
 from django.contrib.contenttypes.models import ContentType
 from django.db import DEFAULT_DB_ALIAS, connections
-from django.db.models import OuterRef
-from django.db.models import Exists
+from django.db.models import Exists, OuterRef
 from django.db.models.query import QuerySet
 from django.template import Context, Template
 from django.test import TestCase
@@ -241,11 +240,17 @@ class QueryHintTests(TestCase):
     def test_use_index_inner_query(self):
         title_idx = index_name(Book, "title")
         with CaptureLastQuery() as cap:
-            list(Author.objects.annotate(has_books=Exists(
-                Book.objects.filter(
-                    author_id=OuterRef('id'), title__gt=""
-                ).use_index(title_idx)
-            )).filter(has_books=True))
+            list(
+                Author.objects.annotate(
+                    has_books=Exists(
+                        Book.objects.filter(
+                            author_id=OuterRef("id"), title__gt=""
+                        )
+                        .use_index(title_idx, table_name="testapp_book")
+                    )
+                )
+                .filter(has_books=True)
+            )
         assert ("USE INDEX (`" + title_idx + "`)") in cap.query
         used = used_indexes(cap.query)
         assert len(used) == 0 or title_idx in used
@@ -267,11 +272,17 @@ class QueryHintTests(TestCase):
     def test_force_index_inner_query(self):
         title_idx = index_name(Book, "title")
         with CaptureLastQuery() as cap:
-            list(Author.objects.annotate(has_books=Exists(
-                Book.objects.filter(
-                    author_id=OuterRef('id'), title__gt=""
-                ).force_index(title_idx)
-            )).filter(has_books=True))
+            list(
+                Author.objects.annotate(
+                    has_books=Exists(
+                        Book.objects.filter(
+                            author_id=OuterRef("id"), title__gt=""
+                        )
+                        .force_index(title_idx, table_name="testapp_book")
+                    )
+                )
+                .filter(has_books=True)
+            )
         assert ("FORCE INDEX (`" + title_idx + "`)") in cap.query
         used = used_indexes(cap.query)
         assert title_idx in used

--- a/tests/testapp/test_rewrite_query.py
+++ b/tests/testapp/test_rewrite_query.py
@@ -225,6 +225,15 @@ class RewriteQueryTests(TestCase):
             + "USE INDEX (`myindex`) WHERE (1)"
         )
 
+    def test_index_hint_with_alias(self):
+        assert (
+            rewrite_query(
+                "SELECT col_a, col_b FROM `sometable` U1"
+                + "WHERE (/*QueryRewrite':index=`sometable` USE `col_a_idx`*/1)"
+            )
+            == "SELECT col_a, col_b FROM `sometable` U1 USE INDEX (`col_a_idx`) WHERE (1)"
+        )
+
     def test_index_hint_multiple_indexes(self):
         assert rewrite_query(
             "SELECT col_a FROM `tabl` WHERE "

--- a/tests/testapp/test_rewrite_query.py
+++ b/tests/testapp/test_rewrite_query.py
@@ -226,12 +226,12 @@ class RewriteQueryTests(TestCase):
         )
 
     def test_index_hint_with_alias(self):
-        assert (
-            rewrite_query(
-                "SELECT col_a, col_b FROM `sometable` U1 "
-                + "WHERE (/*QueryRewrite':index=`sometable` USE `col_a_idx`*/1)"
-            )
-            == "SELECT col_a, col_b FROM `sometable` U1 USE INDEX (`col_a_idx`) WHERE (1)"
+        assert rewrite_query(
+            "SELECT col_a, col_b FROM `sometable` U1 "
+            + "WHERE (/*QueryRewrite':index=`sometable` USE `col_a_idx`*/1)"
+        ) == (
+            "SELECT col_a, col_b FROM `sometable` U1 "
+            + "USE INDEX (`col_a_idx`) WHERE (1)"
         )
 
     def test_index_hint_multiple_indexes(self):

--- a/tests/testapp/test_rewrite_query.py
+++ b/tests/testapp/test_rewrite_query.py
@@ -228,7 +228,7 @@ class RewriteQueryTests(TestCase):
     def test_index_hint_with_alias(self):
         assert (
             rewrite_query(
-                "SELECT col_a, col_b FROM `sometable` U1"
+                "SELECT col_a, col_b FROM `sometable` U1 "
                 + "WHERE (/*QueryRewrite':index=`sometable` USE `col_a_idx`*/1)"
             )
             == "SELECT col_a, col_b FROM `sometable` U1 USE INDEX (`col_a_idx`) WHERE (1)"


### PR DESCRIPTION
If django added an alias to a table in subquery or join the SQL produced was invalid.
eg.
```
WHERE (EXISTS (
    SELECT (1) FROM `table_name` U0
    WHERE U0.`outer_id` = `outer_table`.`id`
))
```
the USE INDEX hint would be added between `table_name` and U0, which is
invalid SQL.
Change to put USE_INDEX after the U0 part