### PR TITLE
Improve Flake8 config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,5 @@ source =
 show_missing = True
 
 [flake8]
-max-line-length = 80
-select = E,F,W,B,B950,C,I,TYP
-ignore = E203,E501,W503
+max-line-length = 88
+extend-ignore = E203

--- a/src/django_mysql/checks.py
+++ b/src/django_mysql/checks.py
@@ -52,7 +52,8 @@ def innodb_strict_mode_warning(alias: str) -> checks.Warning:
             + "InnoDB-specific statements into errors. It's recommended you "
             + "activate this, but it's not very likely to affect you if you "
             + "don't. See: "
-            + "https://django-mysql.readthedocs.io/en/latest/checks.html#django-mysql-w002-innodb-strict-mode"  # noqa: B950
+            + "https://django-mysql.readthedocs.io/en/latest/checks.html"
+            + "#django-mysql-w002-innodb-strict-mode"
         ),
         id="django_mysql.W002",
     )
@@ -65,7 +66,8 @@ def utf8mb4_warning(alias: str) -> checks.Warning:
             "The default 'utf8' character set does not include support for "
             + "all Unicode characters. It's strongly recommended you move to "
             + "use 'utf8mb4'. See: "
-            + "https://django-mysql.readthedocs.io/en/latest/checks.html#django-mysql-w003-utf8mb4"  # noqa: B950
+            + "https://django-mysql.readthedocs.io/en/latest/checks.html"
+            + "#django-mysql-w003-utf8mb4"  # noqa: B950
         ),
         id="django_mysql.W003",
     )


### PR DESCRIPTION
Use only Black compat options. Removing 'select' declaration means that plugin error codes are selected by default.
