### PR TITLE
Fix a few warnings from test run

### DIFF
--- a/requirements/py310-django32.txt
+++ b/requirements/py310-django32.txt
@@ -79,7 +79,7 @@ django-testdata==1.0.3 \
 flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
-    # via pytest-flake8dir
+    # via pytest-flake8-path
 iniconfig==1.1.1 \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
@@ -133,16 +133,16 @@ pytest==6.2.5 \
     # via
     #   -r requirements.in
     #   pytest-django
-    #   pytest-flake8dir
+    #   pytest-flake8-path
     #   pytest-randomly
     #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
     # via -r requirements.in
-pytest-flake8dir==2.6.1 \
-    --hash=sha256:a368d1f9366b9f8084da24f324a65d312ca129d363f1a0cbdc7409376bb9e66f \
-    --hash=sha256:f37df8b9e11cdb5c6f2d8c907ce145c686e31d80b2a1f6a887534bda3288ac66
+pytest-flake8-path==1.2.0 \
+    --hash=sha256:74055e7f71d65f137e308f9d0b516f1de06997d988fab938edaf3a71f4d24d88 \
+    --hash=sha256:cc9252310fb42e8530447aeacd4adf087e24f90b2cca6daeebf04e33d2b492ab
     # via -r requirements.in
 pytest-randomly==3.10.3 \
     --hash=sha256:22154cdcff7ba44e0599596490e6b75278ca973a33812ea6a54bf14d0b042ef1 \

--- a/requirements/py310-django40.txt
+++ b/requirements/py310-django40.txt
@@ -79,7 +79,7 @@ django-testdata==1.0.3 \
 flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
-    # via pytest-flake8dir
+    # via pytest-flake8-path
 iniconfig==1.1.1 \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
@@ -133,16 +133,16 @@ pytest==6.2.5 \
     # via
     #   -r requirements.in
     #   pytest-django
-    #   pytest-flake8dir
+    #   pytest-flake8-path
     #   pytest-randomly
     #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
     # via -r requirements.in
-pytest-flake8dir==2.6.1 \
-    --hash=sha256:a368d1f9366b9f8084da24f324a65d312ca129d363f1a0cbdc7409376bb9e66f \
-    --hash=sha256:f37df8b9e11cdb5c6f2d8c907ce145c686e31d80b2a1f6a887534bda3288ac66
+pytest-flake8-path==1.2.0 \
+    --hash=sha256:74055e7f71d65f137e308f9d0b516f1de06997d988fab938edaf3a71f4d24d88 \
+    --hash=sha256:cc9252310fb42e8530447aeacd4adf087e24f90b2cca6daeebf04e33d2b492ab
     # via -r requirements.in
 pytest-randomly==3.10.3 \
     --hash=sha256:22154cdcff7ba44e0599596490e6b75278ca973a33812ea6a54bf14d0b042ef1 \

--- a/requirements/py37-django22.txt
+++ b/requirements/py37-django22.txt
@@ -75,7 +75,7 @@ django-testdata==1.0.3 \
 flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
-    # via pytest-flake8dir
+    # via pytest-flake8-path
 importlib-metadata==4.2.0 \
     --hash=sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b \
     --hash=sha256:b7e52a1f8dec14a75ea73e0891f3060099ca1d8e6a462a4dff11c3e119ea1b31
@@ -137,16 +137,16 @@ pytest==6.2.5 \
     # via
     #   -r requirements.in
     #   pytest-django
-    #   pytest-flake8dir
+    #   pytest-flake8-path
     #   pytest-randomly
     #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
     # via -r requirements.in
-pytest-flake8dir==2.6.1 \
-    --hash=sha256:a368d1f9366b9f8084da24f324a65d312ca129d363f1a0cbdc7409376bb9e66f \
-    --hash=sha256:f37df8b9e11cdb5c6f2d8c907ce145c686e31d80b2a1f6a887534bda3288ac66
+pytest-flake8-path==1.2.0 \
+    --hash=sha256:74055e7f71d65f137e308f9d0b516f1de06997d988fab938edaf3a71f4d24d88 \
+    --hash=sha256:cc9252310fb42e8530447aeacd4adf087e24f90b2cca6daeebf04e33d2b492ab
     # via -r requirements.in
 pytest-randomly==3.10.3 \
     --hash=sha256:22154cdcff7ba44e0599596490e6b75278ca973a33812ea6a54bf14d0b042ef1 \

--- a/requirements/py37-django30.txt
+++ b/requirements/py37-django30.txt
@@ -79,7 +79,7 @@ django-testdata==1.0.3 \
 flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
-    # via pytest-flake8dir
+    # via pytest-flake8-path
 importlib-metadata==4.2.0 \
     --hash=sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b \
     --hash=sha256:b7e52a1f8dec14a75ea73e0891f3060099ca1d8e6a462a4dff11c3e119ea1b31
@@ -141,16 +141,16 @@ pytest==6.2.5 \
     # via
     #   -r requirements.in
     #   pytest-django
-    #   pytest-flake8dir
+    #   pytest-flake8-path
     #   pytest-randomly
     #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
     # via -r requirements.in
-pytest-flake8dir==2.6.1 \
-    --hash=sha256:a368d1f9366b9f8084da24f324a65d312ca129d363f1a0cbdc7409376bb9e66f \
-    --hash=sha256:f37df8b9e11cdb5c6f2d8c907ce145c686e31d80b2a1f6a887534bda3288ac66
+pytest-flake8-path==1.2.0 \
+    --hash=sha256:74055e7f71d65f137e308f9d0b516f1de06997d988fab938edaf3a71f4d24d88 \
+    --hash=sha256:cc9252310fb42e8530447aeacd4adf087e24f90b2cca6daeebf04e33d2b492ab
     # via -r requirements.in
 pytest-randomly==3.10.3 \
     --hash=sha256:22154cdcff7ba44e0599596490e6b75278ca973a33812ea6a54bf14d0b042ef1 \

--- a/requirements/py37-django31.txt
+++ b/requirements/py37-django31.txt
@@ -79,7 +79,7 @@ django-testdata==1.0.3 \
 flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
-    # via pytest-flake8dir
+    # via pytest-flake8-path
 importlib-metadata==4.2.0 \
     --hash=sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b \
     --hash=sha256:b7e52a1f8dec14a75ea73e0891f3060099ca1d8e6a462a4dff11c3e119ea1b31
@@ -141,16 +141,16 @@ pytest==6.2.5 \
     # via
     #   -r requirements.in
     #   pytest-django
-    #   pytest-flake8dir
+    #   pytest-flake8-path
     #   pytest-randomly
     #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
     # via -r requirements.in
-pytest-flake8dir==2.6.1 \
-    --hash=sha256:a368d1f9366b9f8084da24f324a65d312ca129d363f1a0cbdc7409376bb9e66f \
-    --hash=sha256:f37df8b9e11cdb5c6f2d8c907ce145c686e31d80b2a1f6a887534bda3288ac66
+pytest-flake8-path==1.2.0 \
+    --hash=sha256:74055e7f71d65f137e308f9d0b516f1de06997d988fab938edaf3a71f4d24d88 \
+    --hash=sha256:cc9252310fb42e8530447aeacd4adf087e24f90b2cca6daeebf04e33d2b492ab
     # via -r requirements.in
 pytest-randomly==3.10.3 \
     --hash=sha256:22154cdcff7ba44e0599596490e6b75278ca973a33812ea6a54bf14d0b042ef1 \

--- a/requirements/py37-django32.txt
+++ b/requirements/py37-django32.txt
@@ -79,7 +79,7 @@ django-testdata==1.0.3 \
 flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
-    # via pytest-flake8dir
+    # via pytest-flake8-path
 importlib-metadata==4.2.0 \
     --hash=sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b \
     --hash=sha256:b7e52a1f8dec14a75ea73e0891f3060099ca1d8e6a462a4dff11c3e119ea1b31
@@ -141,16 +141,16 @@ pytest==6.2.5 \
     # via
     #   -r requirements.in
     #   pytest-django
-    #   pytest-flake8dir
+    #   pytest-flake8-path
     #   pytest-randomly
     #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
     # via -r requirements.in
-pytest-flake8dir==2.6.1 \
-    --hash=sha256:a368d1f9366b9f8084da24f324a65d312ca129d363f1a0cbdc7409376bb9e66f \
-    --hash=sha256:f37df8b9e11cdb5c6f2d8c907ce145c686e31d80b2a1f6a887534bda3288ac66
+pytest-flake8-path==1.2.0 \
+    --hash=sha256:74055e7f71d65f137e308f9d0b516f1de06997d988fab938edaf3a71f4d24d88 \
+    --hash=sha256:cc9252310fb42e8530447aeacd4adf087e24f90b2cca6daeebf04e33d2b492ab
     # via -r requirements.in
 pytest-randomly==3.10.3 \
     --hash=sha256:22154cdcff7ba44e0599596490e6b75278ca973a33812ea6a54bf14d0b042ef1 \

--- a/requirements/py38-django22.txt
+++ b/requirements/py38-django22.txt
@@ -75,7 +75,7 @@ django-testdata==1.0.3 \
 flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
-    # via pytest-flake8dir
+    # via pytest-flake8-path
 importlib-metadata==4.10.0 \
     --hash=sha256:92a8b58ce734b2a4494878e0ecf7d79ccd7a128b5fc6014c401e0b61f006f0f6 \
     --hash=sha256:b7cf7d3fef75f1e4c80a96ca660efbd51473d7e8f39b5ab9210febc7809012a4
@@ -133,16 +133,16 @@ pytest==6.2.5 \
     # via
     #   -r requirements.in
     #   pytest-django
-    #   pytest-flake8dir
+    #   pytest-flake8-path
     #   pytest-randomly
     #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
     # via -r requirements.in
-pytest-flake8dir==2.6.1 \
-    --hash=sha256:a368d1f9366b9f8084da24f324a65d312ca129d363f1a0cbdc7409376bb9e66f \
-    --hash=sha256:f37df8b9e11cdb5c6f2d8c907ce145c686e31d80b2a1f6a887534bda3288ac66
+pytest-flake8-path==1.2.0 \
+    --hash=sha256:74055e7f71d65f137e308f9d0b516f1de06997d988fab938edaf3a71f4d24d88 \
+    --hash=sha256:cc9252310fb42e8530447aeacd4adf087e24f90b2cca6daeebf04e33d2b492ab
     # via -r requirements.in
 pytest-randomly==3.10.3 \
     --hash=sha256:22154cdcff7ba44e0599596490e6b75278ca973a33812ea6a54bf14d0b042ef1 \

--- a/requirements/py38-django30.txt
+++ b/requirements/py38-django30.txt
@@ -79,7 +79,7 @@ django-testdata==1.0.3 \
 flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
-    # via pytest-flake8dir
+    # via pytest-flake8-path
 importlib-metadata==4.10.0 \
     --hash=sha256:92a8b58ce734b2a4494878e0ecf7d79ccd7a128b5fc6014c401e0b61f006f0f6 \
     --hash=sha256:b7cf7d3fef75f1e4c80a96ca660efbd51473d7e8f39b5ab9210febc7809012a4
@@ -137,16 +137,16 @@ pytest==6.2.5 \
     # via
     #   -r requirements.in
     #   pytest-django
-    #   pytest-flake8dir
+    #   pytest-flake8-path
     #   pytest-randomly
     #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
     # via -r requirements.in
-pytest-flake8dir==2.6.1 \
-    --hash=sha256:a368d1f9366b9f8084da24f324a65d312ca129d363f1a0cbdc7409376bb9e66f \
-    --hash=sha256:f37df8b9e11cdb5c6f2d8c907ce145c686e31d80b2a1f6a887534bda3288ac66
+pytest-flake8-path==1.2.0 \
+    --hash=sha256:74055e7f71d65f137e308f9d0b516f1de06997d988fab938edaf3a71f4d24d88 \
+    --hash=sha256:cc9252310fb42e8530447aeacd4adf087e24f90b2cca6daeebf04e33d2b492ab
     # via -r requirements.in
 pytest-randomly==3.10.3 \
     --hash=sha256:22154cdcff7ba44e0599596490e6b75278ca973a33812ea6a54bf14d0b042ef1 \

--- a/requirements/py38-django31.txt
+++ b/requirements/py38-django31.txt
@@ -79,7 +79,7 @@ django-testdata==1.0.3 \
 flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
-    # via pytest-flake8dir
+    # via pytest-flake8-path
 importlib-metadata==4.10.0 \
     --hash=sha256:92a8b58ce734b2a4494878e0ecf7d79ccd7a128b5fc6014c401e0b61f006f0f6 \
     --hash=sha256:b7cf7d3fef75f1e4c80a96ca660efbd51473d7e8f39b5ab9210febc7809012a4
@@ -137,16 +137,16 @@ pytest==6.2.5 \
     # via
     #   -r requirements.in
     #   pytest-django
-    #   pytest-flake8dir
+    #   pytest-flake8-path
     #   pytest-randomly
     #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
     # via -r requirements.in
-pytest-flake8dir==2.6.1 \
-    --hash=sha256:a368d1f9366b9f8084da24f324a65d312ca129d363f1a0cbdc7409376bb9e66f \
-    --hash=sha256:f37df8b9e11cdb5c6f2d8c907ce145c686e31d80b2a1f6a887534bda3288ac66
+pytest-flake8-path==1.2.0 \
+    --hash=sha256:74055e7f71d65f137e308f9d0b516f1de06997d988fab938edaf3a71f4d24d88 \
+    --hash=sha256:cc9252310fb42e8530447aeacd4adf087e24f90b2cca6daeebf04e33d2b492ab
     # via -r requirements.in
 pytest-randomly==3.10.3 \
     --hash=sha256:22154cdcff7ba44e0599596490e6b75278ca973a33812ea6a54bf14d0b042ef1 \

--- a/requirements/py38-django32.txt
+++ b/requirements/py38-django32.txt
@@ -79,7 +79,7 @@ django-testdata==1.0.3 \
 flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
-    # via pytest-flake8dir
+    # via pytest-flake8-path
 importlib-metadata==4.10.0 \
     --hash=sha256:92a8b58ce734b2a4494878e0ecf7d79ccd7a128b5fc6014c401e0b61f006f0f6 \
     --hash=sha256:b7cf7d3fef75f1e4c80a96ca660efbd51473d7e8f39b5ab9210febc7809012a4
@@ -137,16 +137,16 @@ pytest==6.2.5 \
     # via
     #   -r requirements.in
     #   pytest-django
-    #   pytest-flake8dir
+    #   pytest-flake8-path
     #   pytest-randomly
     #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
     # via -r requirements.in
-pytest-flake8dir==2.6.1 \
-    --hash=sha256:a368d1f9366b9f8084da24f324a65d312ca129d363f1a0cbdc7409376bb9e66f \
-    --hash=sha256:f37df8b9e11cdb5c6f2d8c907ce145c686e31d80b2a1f6a887534bda3288ac66
+pytest-flake8-path==1.2.0 \
+    --hash=sha256:74055e7f71d65f137e308f9d0b516f1de06997d988fab938edaf3a71f4d24d88 \
+    --hash=sha256:cc9252310fb42e8530447aeacd4adf087e24f90b2cca6daeebf04e33d2b492ab
     # via -r requirements.in
 pytest-randomly==3.10.3 \
     --hash=sha256:22154cdcff7ba44e0599596490e6b75278ca973a33812ea6a54bf14d0b042ef1 \

--- a/requirements/py38-django40.txt
+++ b/requirements/py38-django40.txt
@@ -97,7 +97,7 @@ django-testdata==1.0.3 \
 flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
-    # via pytest-flake8dir
+    # via pytest-flake8-path
 importlib-metadata==4.10.0 \
     --hash=sha256:92a8b58ce734b2a4494878e0ecf7d79ccd7a128b5fc6014c401e0b61f006f0f6 \
     --hash=sha256:b7cf7d3fef75f1e4c80a96ca660efbd51473d7e8f39b5ab9210febc7809012a4
@@ -155,16 +155,16 @@ pytest==6.2.5 \
     # via
     #   -r requirements.in
     #   pytest-django
-    #   pytest-flake8dir
+    #   pytest-flake8-path
     #   pytest-randomly
     #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
     # via -r requirements.in
-pytest-flake8dir==2.6.1 \
-    --hash=sha256:a368d1f9366b9f8084da24f324a65d312ca129d363f1a0cbdc7409376bb9e66f \
-    --hash=sha256:f37df8b9e11cdb5c6f2d8c907ce145c686e31d80b2a1f6a887534bda3288ac66
+pytest-flake8-path==1.2.0 \
+    --hash=sha256:74055e7f71d65f137e308f9d0b516f1de06997d988fab938edaf3a71f4d24d88 \
+    --hash=sha256:cc9252310fb42e8530447aeacd4adf087e24f90b2cca6daeebf04e33d2b492ab
     # via -r requirements.in
 pytest-randomly==3.10.3 \
     --hash=sha256:22154cdcff7ba44e0599596490e6b75278ca973a33812ea6a54bf14d0b042ef1 \

--- a/requirements/py39-django22.txt
+++ b/requirements/py39-django22.txt
@@ -75,7 +75,7 @@ django-testdata==1.0.3 \
 flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
-    # via pytest-flake8dir
+    # via pytest-flake8-path
 importlib-metadata==4.10.0 \
     --hash=sha256:92a8b58ce734b2a4494878e0ecf7d79ccd7a128b5fc6014c401e0b61f006f0f6 \
     --hash=sha256:b7cf7d3fef75f1e4c80a96ca660efbd51473d7e8f39b5ab9210febc7809012a4
@@ -133,16 +133,16 @@ pytest==6.2.5 \
     # via
     #   -r requirements.in
     #   pytest-django
-    #   pytest-flake8dir
+    #   pytest-flake8-path
     #   pytest-randomly
     #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
     # via -r requirements.in
-pytest-flake8dir==2.6.1 \
-    --hash=sha256:a368d1f9366b9f8084da24f324a65d312ca129d363f1a0cbdc7409376bb9e66f \
-    --hash=sha256:f37df8b9e11cdb5c6f2d8c907ce145c686e31d80b2a1f6a887534bda3288ac66
+pytest-flake8-path==1.2.0 \
+    --hash=sha256:74055e7f71d65f137e308f9d0b516f1de06997d988fab938edaf3a71f4d24d88 \
+    --hash=sha256:cc9252310fb42e8530447aeacd4adf087e24f90b2cca6daeebf04e33d2b492ab
     # via -r requirements.in
 pytest-randomly==3.10.3 \
     --hash=sha256:22154cdcff7ba44e0599596490e6b75278ca973a33812ea6a54bf14d0b042ef1 \

--- a/requirements/py39-django30.txt
+++ b/requirements/py39-django30.txt
@@ -79,7 +79,7 @@ django-testdata==1.0.3 \
 flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
-    # via pytest-flake8dir
+    # via pytest-flake8-path
 importlib-metadata==4.10.0 \
     --hash=sha256:92a8b58ce734b2a4494878e0ecf7d79ccd7a128b5fc6014c401e0b61f006f0f6 \
     --hash=sha256:b7cf7d3fef75f1e4c80a96ca660efbd51473d7e8f39b5ab9210febc7809012a4
@@ -137,16 +137,16 @@ pytest==6.2.5 \
     # via
     #   -r requirements.in
     #   pytest-django
-    #   pytest-flake8dir
+    #   pytest-flake8-path
     #   pytest-randomly
     #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
     # via -r requirements.in
-pytest-flake8dir==2.6.1 \
-    --hash=sha256:a368d1f9366b9f8084da24f324a65d312ca129d363f1a0cbdc7409376bb9e66f \
-    --hash=sha256:f37df8b9e11cdb5c6f2d8c907ce145c686e31d80b2a1f6a887534bda3288ac66
+pytest-flake8-path==1.2.0 \
+    --hash=sha256:74055e7f71d65f137e308f9d0b516f1de06997d988fab938edaf3a71f4d24d88 \
+    --hash=sha256:cc9252310fb42e8530447aeacd4adf087e24f90b2cca6daeebf04e33d2b492ab
     # via -r requirements.in
 pytest-randomly==3.10.3 \
     --hash=sha256:22154cdcff7ba44e0599596490e6b75278ca973a33812ea6a54bf14d0b042ef1 \

--- a/requirements/py39-django31.txt
+++ b/requirements/py39-django31.txt
@@ -79,7 +79,7 @@ django-testdata==1.0.3 \
 flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
-    # via pytest-flake8dir
+    # via pytest-flake8-path
 importlib-metadata==4.10.0 \
     --hash=sha256:92a8b58ce734b2a4494878e0ecf7d79ccd7a128b5fc6014c401e0b61f006f0f6 \
     --hash=sha256:b7cf7d3fef75f1e4c80a96ca660efbd51473d7e8f39b5ab9210febc7809012a4
@@ -137,16 +137,16 @@ pytest==6.2.5 \
     # via
     #   -r requirements.in
     #   pytest-django
-    #   pytest-flake8dir
+    #   pytest-flake8-path
     #   pytest-randomly
     #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
     # via -r requirements.in
-pytest-flake8dir==2.6.1 \
-    --hash=sha256:a368d1f9366b9f8084da24f324a65d312ca129d363f1a0cbdc7409376bb9e66f \
-    --hash=sha256:f37df8b9e11cdb5c6f2d8c907ce145c686e31d80b2a1f6a887534bda3288ac66
+pytest-flake8-path==1.2.0 \
+    --hash=sha256:74055e7f71d65f137e308f9d0b516f1de06997d988fab938edaf3a71f4d24d88 \
+    --hash=sha256:cc9252310fb42e8530447aeacd4adf087e24f90b2cca6daeebf04e33d2b492ab
     # via -r requirements.in
 pytest-randomly==3.10.3 \
     --hash=sha256:22154cdcff7ba44e0599596490e6b75278ca973a33812ea6a54bf14d0b042ef1 \

--- a/requirements/py39-django32.txt
+++ b/requirements/py39-django32.txt
@@ -79,7 +79,7 @@ django-testdata==1.0.3 \
 flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
-    # via pytest-flake8dir
+    # via pytest-flake8-path
 importlib-metadata==4.10.0 \
     --hash=sha256:92a8b58ce734b2a4494878e0ecf7d79ccd7a128b5fc6014c401e0b61f006f0f6 \
     --hash=sha256:b7cf7d3fef75f1e4c80a96ca660efbd51473d7e8f39b5ab9210febc7809012a4
@@ -137,16 +137,16 @@ pytest==6.2.5 \
     # via
     #   -r requirements.in
     #   pytest-django
-    #   pytest-flake8dir
+    #   pytest-flake8-path
     #   pytest-randomly
     #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
     # via -r requirements.in
-pytest-flake8dir==2.6.1 \
-    --hash=sha256:a368d1f9366b9f8084da24f324a65d312ca129d363f1a0cbdc7409376bb9e66f \
-    --hash=sha256:f37df8b9e11cdb5c6f2d8c907ce145c686e31d80b2a1f6a887534bda3288ac66
+pytest-flake8-path==1.2.0 \
+    --hash=sha256:74055e7f71d65f137e308f9d0b516f1de06997d988fab938edaf3a71f4d24d88 \
+    --hash=sha256:cc9252310fb42e8530447aeacd4adf087e24f90b2cca6daeebf04e33d2b492ab
     # via -r requirements.in
 pytest-randomly==3.10.3 \
     --hash=sha256:22154cdcff7ba44e0599596490e6b75278ca973a33812ea6a54bf14d0b042ef1 \

--- a/requirements/py39-django40.txt
+++ b/requirements/py39-django40.txt
@@ -79,7 +79,7 @@ django-testdata==1.0.3 \
 flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
-    # via pytest-flake8dir
+    # via pytest-flake8-path
 importlib-metadata==4.10.0 \
     --hash=sha256:92a8b58ce734b2a4494878e0ecf7d79ccd7a128b5fc6014c401e0b61f006f0f6 \
     --hash=sha256:b7cf7d3fef75f1e4c80a96ca660efbd51473d7e8f39b5ab9210febc7809012a4
@@ -137,16 +137,16 @@ pytest==6.2.5 \
     # via
     #   -r requirements.in
     #   pytest-django
-    #   pytest-flake8dir
+    #   pytest-flake8-path
     #   pytest-randomly
     #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
     # via -r requirements.in
-pytest-flake8dir==2.6.1 \
-    --hash=sha256:a368d1f9366b9f8084da24f324a65d312ca129d363f1a0cbdc7409376bb9e66f \
-    --hash=sha256:f37df8b9e11cdb5c6f2d8c907ce145c686e31d80b2a1f6a887534bda3288ac66
+pytest-flake8-path==1.2.0 \
+    --hash=sha256:74055e7f71d65f137e308f9d0b516f1de06997d988fab938edaf3a71f4d24d88 \
+    --hash=sha256:cc9252310fb42e8530447aeacd4adf087e24f90b2cca6daeebf04e33d2b492ab
     # via -r requirements.in
 pytest-randomly==3.10.3 \
     --hash=sha256:22154cdcff7ba44e0599596490e6b75278ca973a33812ea6a54bf14d0b042ef1 \

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -7,6 +7,6 @@ mysqlclient
 parameterized
 pytest
 pytest-django
-pytest-flake8dir
+pytest-flake8-path
 pytest-randomly
 pytest-super-check

--- a/src/django_mysql/models/query.py
+++ b/src/django_mysql/models/query.py
@@ -758,6 +758,7 @@ def pt_visual_explain(queryset: models.QuerySet, display: bool = True) -> str:
     assert mysql.stdout is not None
     mysql.stdout.close()
     explanation = visual_explain.communicate()[0].decode(encoding="utf-8")
+    mysql.wait()
     if display:
         print(explanation)
     return explanation

--- a/tests/testapp/test_cache.py
+++ b/tests/testapp/test_cache.py
@@ -1289,8 +1289,8 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
 @override_cache_settings()
 class MySQLCacheMigrationTests(MySQLCacheTableMixin, TransactionTestCase):
     @pytest.fixture(autouse=True)
-    def flake8dir(self, flake8dir):
-        self.flake8dir = flake8dir
+    def flake8_path(self, flake8_path):
+        self.flake8_path = flake8_path
 
     def test_mysql_cache_migration(self):
         out = StringIO()
@@ -1298,8 +1298,8 @@ class MySQLCacheMigrationTests(MySQLCacheTableMixin, TransactionTestCase):
         output = out.getvalue()
 
         # Lint it
-        self.flake8dir.make_example_py(output)
-        result = self.flake8dir.run_flake8()
+        (self.flake8_path / "example.py").write_text(output)
+        result = self.flake8_path.run_flake8()
         assert result.out_lines == []
 
         # Dynamic import and check


### PR DESCRIPTION
Fix these warnings exposed by Python Development Mode:

```
tests/testapp/test_models.py::VisualExplainTests::test_basic
  /opt/hostedtoolcache/Python/3.10.1/x64/lib/python3.10/subprocess.py:1067: ResourceWarning: subprocess 4321 is still running
    _warn("subprocess %s is still running" % self.pid,

tests/testapp/test_models.py::VisualExplainTests::test_subquery
  /opt/hostedtoolcache/Python/3.10.1/x64/lib/python3.10/subprocess.py:1067: ResourceWarning: subprocess 4323 is still running
    _warn("subprocess %s is still running" % self.pid,

tests/testapp/test_models.py::VisualExplainTests::test_basic_no_display
  /opt/hostedtoolcache/Python/3.10.1/x64/lib/python3.10/subprocess.py:1067: ResourceWarning: subprocess 4325 is still running
    _warn("subprocess %s is still running" % self.pid,

tests/testapp/test_cache.py::MySQLCacheMigrationTests::test_mysql_cache_migration
  /home/runner/work/django-mysql/django-mysql/tests/testapp/test_cache.py:1302: ResourceWarning: unclosed file <_io.TextIOWrapper name=10 encoding='UTF-8'>
    result = self.flake8dir.run_flake8()

tests/testapp/test_cache.py::MySQLCacheMigrationTests::test_mysql_cache_migration
  /home/runner/work/django-mysql/django-mysql/tests/testapp/test_cache.py:1302: ResourceWarning: unclosed file <_io.TextIOWrapper name=12 encoding='UTF-8'>
    result = self.flake8dir.run_flake8()
```