### PR TITLE
Add FixedCharField

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,9 @@ History
   Its complicated threading code leaked processes.
   Switch to calling ``pt-fingerprint`` directly with ``subprocess.run()`` instead.
 
+* Add model ``FixedCharField`` for storing fixed width strings
+  using a ``CHAR`` type.
+
 4.4.0 (2022-01-10)
 ------------------
 

--- a/docs/exposition.rst
+++ b/docs/exposition.rst
@@ -150,7 +150,7 @@ restricted to a set of choices to be stored in a space efficient manner:
 
 
 FixedCharField
----------
+--------------
 
 A field class for using MySQL's ``CHAR`` type, which allows strings to be
 stored at a fixed width:

--- a/docs/exposition.rst
+++ b/docs/exposition.rst
@@ -149,6 +149,20 @@ restricted to a set of choices to be stored in a space efficient manner:
 :ref:`Read more <enum-field>`
 
 
+FixedCharField
+---------
+
+A field class for using MySQL's ``CHAR`` type, which allows strings to be
+stored at a fixed width:
+
+.. code-block:: python
+
+    class Address(Model):
+        zip_code = FixedCharField(length=10)
+
+:ref:`Read more <fixedchar-field>`
+
+
 Resizable Text/Binary Fields
 ----------------------------
 

--- a/docs/model_fields/fixedchar_field.rst
+++ b/docs/model_fields/fixedchar_field.rst
@@ -6,14 +6,12 @@ FixedCharField
 
 .. currentmodule:: django_mysql.models
 
-Using a ``CharField`` for fixed-width strings leads to variable data
-storage since the storage amount can changed depending on the length
-of the string, whereas a fixed-width string will always use the same
-amount of storage, regardless of the string value. Fixed value columns
-can also decrease the storage size overall due to how the engine
-indexes strings. MySQL's ``CHAR`` type allows a more compact representation
-of such columns. ``FixedCharField`` allows you to use the ``CHAR`` type
-with Django.
+Django’s ``CharField`` uses the ``VARCHAR`` data type, which uses variable
+storage space depending on string length. This normally saves storage space,
+but for columns with a fixed length, it adds a small overhead.
+``FixedCharField`` uses the ``CHAR`` data type, which avoids that overhead.
+It only accepts strings with the given length, and uses a corresponding fixed
+amount of storage.
 
 Docs:
 `MySQL <https://dev.mysql.com/doc/refman/en/char.html>`_ /
@@ -34,5 +32,5 @@ Docs:
         from django_mysql.models import FixedCharField
 
 
-        class VariousCharLengths(Model):
+        class Address(Model):
             zip_code = FixedCharField(length=5)

--- a/docs/model_fields/fixedchar_field.rst
+++ b/docs/model_fields/fixedchar_field.rst
@@ -39,10 +39,10 @@ Docs:
         class VariousCharLengths(Model):
             zip_code = FixedCharField(length=5)
             default_length = FixedCharField()  # defaults to length=1
-            really_long_string = FixedCharField(length=256)  # ValueError
+            really_long_string = FixedCharField(length=256)  # raise ValueError
 
-    .. warning::
+    .. note::
 
-    MariaDB defaults to a ``CHAR(1)`` field, while MySQL has no default value.
-    ``FixedCharField`` follows the MariaDB behavior and defaults to a
-    ``CHAR(1)`` field if a length is not provided.
+        MariaDB defaults to a ``CHAR(1)`` field, while MySQL has no default value.
+        ``FixedCharField`` follows the MariaDB behavior and defaults to a
+        ``CHAR(1)`` field if a length is not provided.

--- a/docs/model_fields/fixedchar_field.rst
+++ b/docs/model_fields/fixedchar_field.rst
@@ -1,8 +1,8 @@
 .. fixedchar-field:
 
----------
+--------------
 FixedCharField
----------
+--------------
 
 .. currentmodule:: django_mysql.models
 
@@ -15,11 +15,9 @@ indexes strings. MySQL's ``CHAR`` type allows a more compact representation
 of such columns. ``FixedCharField`` allows you to use the ``CHAR`` type
 with Django.
 
-
 Docs:
 `MySQL <https://dev.mysql.com/doc/refman/en/char.html>`_ /
 `MariaDB <https://mariadb.com/kb/en/char/>`_.
-
 
 .. class:: FixedCharField(length: int, **kwargs)
 
@@ -38,4 +36,3 @@ Docs:
 
         class VariousCharLengths(Model):
             zip_code = FixedCharField(length=5)
-            really_long_string = FixedCharField(length=256)  # raise ValueError

--- a/docs/model_fields/fixedchar_field.rst
+++ b/docs/model_fields/fixedchar_field.rst
@@ -21,7 +21,7 @@ Docs:
 `MariaDB <https://mariadb.com/kb/en/char/>`_.
 
 
-.. class:: FixedCharField(length: int = 1, **kwargs)
+.. class:: FixedCharField(length: int, **kwargs)
 
     A subclass of Django's :class:`~django.db.models.Charfield` that uses a
     MySQL ``CHAR`` for storage.
@@ -33,16 +33,9 @@ Docs:
 
     .. code-block:: python
 
-        from django_mysql.models import FixedWidthField
+        from django_mysql.models import FixedCharField
 
 
         class VariousCharLengths(Model):
             zip_code = FixedCharField(length=5)
-            default_length = FixedCharField()  # defaults to length=1
             really_long_string = FixedCharField(length=256)  # raise ValueError
-
-    .. note::
-
-        MariaDB defaults to a ``CHAR(1)`` field, while MySQL has no default value.
-        ``FixedCharField`` follows the MariaDB behavior and defaults to a
-        ``CHAR(1)`` field if a length is not provided.

--- a/docs/model_fields/fixedchar_field.rst
+++ b/docs/model_fields/fixedchar_field.rst
@@ -21,7 +21,7 @@ Docs:
 `MariaDB <https://mariadb.com/kb/en/char/>`_.
 
 
-.. class:: FixedCharField(length, **kwargs)
+.. class:: FixedCharField(length: int = 1, **kwargs)
 
     A subclass of Django's :class:`~django.db.models.Charfield` that uses a
     MySQL ``CHAR`` for storage.

--- a/docs/model_fields/fixedchar_field.rst
+++ b/docs/model_fields/fixedchar_field.rst
@@ -28,14 +28,21 @@ Docs:
 
     ``length`` is a non-standard Django argument for a field class, however it
     is required for ``FixedCharField``. It must be an integer value within the
-    range of 0-255. Supplying values outside that range will throw an error. For
-    example:
+    range of 0-255. Supplying values outside that range will throw a ValueError.
+    For example:
 
     .. code-block:: python
 
         from django_mysql.models import FixedWidthField
 
 
-        class Address(Model):
-            zip_code = FixedWidthField(length=5)
+        class VariousCharLengths(Model):
+            zip_code = FixedCharField(length=5)
+            default_length = FixedCharField()  # defaults to length=1
             really_long_string = FixedCharField(length=256)  # ValueError
+
+    .. warning::
+
+    MariaDB defaults to a ``CHAR(1)`` field, while MySQL has no default value.
+    ``FixedCharField`` follows the MariaDB behavior and defaults to a
+    ``CHAR(1)`` field if a length is not provided.

--- a/docs/model_fields/fixedchar_field.rst
+++ b/docs/model_fields/fixedchar_field.rst
@@ -9,22 +9,24 @@ FixedCharField
 Django’s ``CharField`` uses the ``VARCHAR`` data type, which uses variable
 storage space depending on string length. This normally saves storage space,
 but for columns with a fixed length, it adds a small overhead.
-``FixedCharField`` uses the ``CHAR`` data type, which avoids that overhead.
-It only accepts strings with the given length, and uses a corresponding fixed
-amount of storage.
+
+The alternative ``CHAR`` data type avoids that overhead, but it has the
+surprising behaviour of removing trailing space characters, and consequently
+ignoring them in comparisons. ``FixedCharField`` provides a Django field for
+using ``CHAR``. This can help you interface with databases created by other
+systems, but it’s not recommended for general use, due to the trialing space
+behaviour.
 
 Docs:
 `MySQL <https://dev.mysql.com/doc/refman/en/char.html>`_ /
 `MariaDB <https://mariadb.com/kb/en/char/>`_.
 
-.. class:: FixedCharField(length: int, **kwargs)
+.. class:: FixedCharField(*args, max_length: int, **kwargs)
 
-    A subclass of Django's :class:`~django.db.models.Charfield` that uses a
-    MySQL ``CHAR`` for storage.
+    A subclass of Django's :class:`~django.db.models.Charfield` that uses the
+    ``CHAR`` data type. ``max_length`` is as with ``CharField``, but must be
+    within the range 0-255.
 
-    ``length`` is a non-standard Django argument for a field class, however it
-    is required for ``FixedCharField``. It must be an integer value within the
-    range of 0-255. Supplying values outside that range will throw a ValueError.
     For example:
 
     .. code-block:: python

--- a/docs/model_fields/fixedchar_field.rst
+++ b/docs/model_fields/fixedchar_field.rst
@@ -1,0 +1,41 @@
+.. fixedchar-field:
+
+---------
+FixedCharField
+---------
+
+.. currentmodule:: django_mysql.models
+
+Using a ``CharField`` for fixed-width strings leads to variable data
+storage since the storage amount can changed depending on the length
+of the string, whereas a fixed-width string will always use the same
+amount of storage, regardless of the string value. Fixed value columns
+can also decrease the storage size overall due to how the engine
+indexes strings. MySQL's ``CHAR`` type allows a more compact representation
+of such columns. ``FixedCharField`` allows you to use the ``CHAR`` type
+with Django.
+
+
+Docs:
+`MySQL <https://dev.mysql.com/doc/refman/en/char.html>`_ /
+`MariaDB <https://mariadb.com/kb/en/char/>`_.
+
+
+.. class:: FixedCharField(length, **kwargs)
+
+    A subclass of Django's :class:`~django.db.models.Charfield` that uses a
+    MySQL ``CHAR`` for storage.
+
+    ``length`` is a non-standard Django argument for a field class, however it
+    is required for ``FixedCharField``. It must be an integer value within the
+    range of 0-255. Supplying values outside that range will throw an error. For
+    example:
+
+    .. code-block:: python
+
+        from django_mysql.models import FixedWidthField
+
+
+        class Address(Model):
+            zip_code = FixedWidthField(length=5)
+            really_long_string = FixedCharField(length=256)  # ValueError

--- a/docs/model_fields/index.rst
+++ b/docs/model_fields/index.rst
@@ -17,6 +17,7 @@ to the home of Django's native fields in ``django.db.models``.
    list_fields
    set_fields
    enum_field
+   fixedchar_field
    resizable_text_binary_fields
    null_bit1_boolean_fields
 

--- a/src/django_mysql/models/__init__.py
+++ b/src/django_mysql/models/__init__.py
@@ -17,6 +17,7 @@ from django_mysql.models.fields import (  # noqa
     Bit1BooleanField,
     DynamicField,
     EnumField,
+    FixedCharField,
     ListCharField,
     ListTextField,
     NullBit1BooleanField,

--- a/src/django_mysql/models/fields/__init__.py
+++ b/src/django_mysql/models/fields/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from django_mysql.models.fields.bit import Bit1BooleanField, NullBit1BooleanField
 from django_mysql.models.fields.dynamic import DynamicField
 from django_mysql.models.fields.enum import EnumField
+from django_mysql.models.fields.fixedchar import FixedCharField
 from django_mysql.models.fields.lists import ListCharField, ListTextField
 from django_mysql.models.fields.sets import SetCharField, SetTextField
 from django_mysql.models.fields.sizes import SizedBinaryField, SizedTextField
@@ -11,6 +12,7 @@ __all__ = [
     "Bit1BooleanField",
     "DynamicField",
     "EnumField",
+    "FixedCharField",
     "ListCharField",
     "ListTextField",
     "NullBit1BooleanField",

--- a/src/django_mysql/models/fields/fixedchar.py
+++ b/src/django_mysql/models/fields/fixedchar.py
@@ -46,4 +46,4 @@ class FixedCharField(CharField):
         return name, path, args, kwargs
 
     def db_type(self, connection: BaseDatabaseWrapper) -> str:
-        return f"char({self.length})"
+        return f"CHAR({self.length})"

--- a/src/django_mysql/models/fields/fixedchar.py
+++ b/src/django_mysql/models/fields/fixedchar.py
@@ -26,7 +26,10 @@ class FixedCharField(CharField):
         if "max_length" in kwargs:
             raise TypeError('"max_length" is not a valid argument')
 
+        # However, a max_length is required by Django CharField,
+        # so we'll set it equal to the length of our CHAR field
         self.length = length
+        kwargs["max_length"] = length
         super().__init__(*args, **kwargs)
 
     def deconstruct(self) -> DeconstructResult:
@@ -40,6 +43,7 @@ class FixedCharField(CharField):
             path = "django_mysql.models.FixedCharField"
 
         kwargs["length"] = self.length
+        kwargs["max_length"] = self.length
 
         return name, path, args, kwargs
 

--- a/src/django_mysql/models/fields/fixedchar.py
+++ b/src/django_mysql/models/fields/fixedchar.py
@@ -10,26 +10,22 @@ from django_mysql.typing import DeconstructResult
 
 class FixedCharField(CharField):
     def __init__(self, *args: Any, length: int, **kwargs: Any) -> None:
-        # Ensure we have an actual integer value
         if not isinstance(length, int):
             raise TypeError(
                 'Invalid length value "{length}". '
                 "Expected integer value.".format(length=length)
             )
 
-        # CHAR fields can only be in the range of 0-255
         if length < 0 or length > 255:
             raise ValueError(
                 'Invalid length value "{length}". '
                 "Length must be in the range of 0-255.".format(length=length)
             )
 
-        # A max_length doesn't make sense in this context
         if "max_length" in kwargs:
             raise TypeError('"max_length" is not a valid argument')
 
-        # However, a max_length is required by Django CharField,
-        # so we'll set it equal to the length of our CHAR field
+        # max_length is required by CharField
         self.length = length
         kwargs["max_length"] = length
         super().__init__(*args, **kwargs)

--- a/src/django_mysql/models/fields/fixedchar.py
+++ b/src/django_mysql/models/fields/fixedchar.py
@@ -10,12 +10,6 @@ from django_mysql.typing import DeconstructResult
 
 class FixedCharField(CharField):
     def __init__(self, *args: Any, length: int, **kwargs: Any) -> None:
-        if not isinstance(length, int):
-            raise TypeError(
-                'Invalid length value "{length}". '
-                "Expected integer value.".format(length=length)
-            )
-
         if length < 0 or length > 255:
             raise ValueError(
                 'Invalid length value "{length}". '

--- a/src/django_mysql/models/fields/fixedchar.py
+++ b/src/django_mysql/models/fields/fixedchar.py
@@ -7,7 +7,7 @@ from django_mysql.typing import DeconstructResult
 
 
 class FixedCharField(CharField):
-    def __init__(self, length: int, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, length: int, **kwargs: Any) -> None:
         # Ensure we have an actual integer value
         if not isinstance(length, int):
             raise TypeError(

--- a/src/django_mysql/models/fields/fixedchar.py
+++ b/src/django_mysql/models/fields/fixedchar.py
@@ -19,10 +19,7 @@ class FixedCharField(CharField):
         if "max_length" in kwargs:
             raise TypeError('"max_length" is not a valid argument')
 
-        # max_length is required by CharField
-        self.length = length
-        kwargs["max_length"] = length
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, max_length=length, **kwargs)
 
     def deconstruct(self) -> DeconstructResult:
         name, path, args, kwargs = cast(DeconstructResult, super().deconstruct())
@@ -34,10 +31,9 @@ class FixedCharField(CharField):
         if path in bad_paths:
             path = "django_mysql.models.FixedCharField"
 
-        kwargs["length"] = self.length
-        kwargs["max_length"] = self.length
+        kwargs["length"] = kwargs.pop("max_length")
 
         return name, path, args, kwargs
 
     def db_type(self, connection: BaseDatabaseWrapper) -> str:
-        return f"CHAR({self.length})"
+        return f"CHAR({self.max_length})"

--- a/src/django_mysql/models/fields/fixedchar.py
+++ b/src/django_mysql/models/fields/fixedchar.py
@@ -6,12 +6,19 @@ from django_mysql.typing import DeconstructResult
 
 
 class FixedCharField(CharField):
-    def __init__(self, length: int, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, length: int = 1, *args: Any, **kwargs: Any) -> None:
         # Ensure we have an actual integer value
         if not isinstance(length, int):
             raise TypeError(
-                'Invalid length value "{length}".'
+                'Invalid length value "{length}". '
                 "Expected integer value.".format(length=length)
+            )
+
+        # CHAR fields can only be in the range of 0-255
+        if length < 0 or length > 255:
+            raise ValueError(
+                'Invalid length value "{length}". '
+                "Length must be in the range of 0-255.".format(length=length)
             )
 
         # A max_length doesn't make sense in this context

--- a/src/django_mysql/models/fields/fixedchar.py
+++ b/src/django_mysql/models/fields/fixedchar.py
@@ -1,4 +1,5 @@
 from typing import Any, cast
+
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models import CharField
 
@@ -43,4 +44,4 @@ class FixedCharField(CharField):
         return name, path, args, kwargs
 
     def db_type(self, connection: BaseDatabaseWrapper) -> str:
-        return "char({length})".format(length=self.length)
+        return f"char({self.length})"

--- a/src/django_mysql/models/fields/fixedchar.py
+++ b/src/django_mysql/models/fields/fixedchar.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, cast
 
 from django.db.backends.base.base import BaseDatabaseWrapper

--- a/src/django_mysql/models/fields/fixedchar.py
+++ b/src/django_mysql/models/fields/fixedchar.py
@@ -10,12 +10,6 @@ from django_mysql.typing import DeconstructResult
 
 
 class FixedCharField(CharField):
-    def __init__(self, *args: Any, length: int, **kwargs: Any) -> None:
-        if "max_length" in kwargs:
-            raise TypeError('"max_length" is not a valid argument')
-
-        super().__init__(*args, max_length=length, **kwargs)
-
     def check(self, **kwargs: Any) -> list[checks.CheckMessage]:
         errors = super().check(**kwargs)
 
@@ -24,7 +18,7 @@ class FixedCharField(CharField):
         ):
             errors.append(
                 checks.Error(
-                    "'length' must be between 0 and 255.",
+                    "'max_length' must be between 0 and 255.",
                     hint=None,
                     obj=self,
                     id="django_mysql.E015",
@@ -42,8 +36,6 @@ class FixedCharField(CharField):
         )
         if path in bad_paths:
             path = "django_mysql.models.FixedCharField"
-
-        kwargs["length"] = kwargs.pop("max_length")
 
         return name, path, args, kwargs
 

--- a/src/django_mysql/models/fields/fixedchar.py
+++ b/src/django_mysql/models/fields/fixedchar.py
@@ -7,7 +7,7 @@ from django_mysql.typing import DeconstructResult
 
 
 class FixedCharField(CharField):
-    def __init__(self, length: int = 1, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, length: int, *args: Any, **kwargs: Any) -> None:
         # Ensure we have an actual integer value
         if not isinstance(length, int):
             raise TypeError(

--- a/src/django_mysql/models/fields/fixedchar.py
+++ b/src/django_mysql/models/fields/fixedchar.py
@@ -1,0 +1,39 @@
+from typing import Any, cast
+from django.db.backends.base.base import BaseDatabaseWrapper
+from django.db.models import CharField
+
+from django_mysql.typing import DeconstructResult
+
+
+class FixedCharField(CharField):
+    def __init__(self, length: int, *args: Any, **kwargs: Any) -> None:
+        # Ensure we have an actual integer value
+        if not isinstance(length, int):
+            raise TypeError(
+                'Invalid length value "{length}".'
+                "Expected integer value.".format(length=length)
+            )
+
+        # A max_length doesn't make sense in this context
+        if "max_length" in kwargs:
+            raise TypeError('"max_length" is not a valid argument')
+
+        self.length = length
+        super().__init__(*args, **kwargs)
+
+    def deconstruct(self) -> DeconstructResult:
+        name, path, args, kwargs = cast(DeconstructResult, super().deconstruct())
+
+        bad_paths = (
+            "django_mysql.models.fields.fixedchar.FixedCharField",
+            "django_mysql.models.fields.FixedCharField",
+        )
+        if path in bad_paths:
+            path = "django_mysql.models.FixedCharField"
+
+        kwargs["length"] = self.length
+
+        return name, path, args, kwargs
+
+    def db_type(self, connection: BaseDatabaseWrapper) -> str:
+        return "char({length})".format(length=self.length)

--- a/tests/testapp/fixedchar_default_migrations/0001_initial.py
+++ b/tests/testapp/fixedchar_default_migrations/0001_initial.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import List, Tuple
-
 from django.db import migrations, models
 
 from django_mysql.models import FixedCharField

--- a/tests/testapp/fixedchar_default_migrations/0001_initial.py
+++ b/tests/testapp/fixedchar_default_migrations/0001_initial.py
@@ -1,0 +1,33 @@
+from typing import List, Tuple
+
+from django.db import migrations, models
+
+from django_mysql.models import FixedCharField
+
+
+class Migration(migrations.Migration):
+
+    dependencies: List[Tuple[str, str]] = []
+
+    operations = [
+        migrations.CreateModel(
+            name="FixedCharDefaultModel",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        verbose_name="ID",
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    "zip_code",
+                    FixedCharField(length=5),
+                ),
+            ],
+            options={},
+            bases=(models.Model,),
+        )
+    ]

--- a/tests/testapp/fixedchar_default_migrations/0001_initial.py
+++ b/tests/testapp/fixedchar_default_migrations/0001_initial.py
@@ -9,7 +9,7 @@ from django_mysql.models import FixedCharField
 
 class Migration(migrations.Migration):
 
-    dependencies: List[Tuple[str, str]] = []
+    dependencies: list[tuple[str, str]] = []
 
     operations = [
         migrations.CreateModel(

--- a/tests/testapp/fixedchar_default_migrations/0001_initial.py
+++ b/tests/testapp/fixedchar_default_migrations/0001_initial.py
@@ -24,7 +24,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "zip_code",
-                    FixedCharField(length=5),
+                    FixedCharField(max_length=5),
                 ),
             ],
             options={},

--- a/tests/testapp/fixedchar_default_migrations/0001_initial.py
+++ b/tests/testapp/fixedchar_default_migrations/0001_initial.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Tuple
 
 from django.db import migrations, models

--- a/tests/testapp/fixedchar_default_migrations/0002_change_field_length.py
+++ b/tests/testapp/fixedchar_default_migrations/0002_change_field_length.py
@@ -13,6 +13,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="FixedCharDefaultModel",
             name="zip_code",
-            field=FixedCharField(length=10),
+            field=FixedCharField(max_length=10),
         )
     ]

--- a/tests/testapp/fixedchar_default_migrations/0002_change_field_length.py
+++ b/tests/testapp/fixedchar_default_migrations/0002_change_field_length.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+from django_mysql.models import FixedCharField
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("testapp", "0001_initial")]
+
+    operations = [
+        migrations.AlterField(
+            model_name="FixedCharDefaultModel",
+            name="zip_code",
+            field=FixedCharField(length=10),
+        )
+    ]

--- a/tests/testapp/fixedchar_default_migrations/0002_change_field_length.py
+++ b/tests/testapp/fixedchar_default_migrations/0002_change_field_length.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.db import migrations
 
 from django_mysql.models import FixedCharField

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -165,7 +165,7 @@ class SpeclessDynamicModel(Model):
 
 
 class FixedCharModel(Model):
-    zip_code = FixedCharField(length=10)
+    zip_code = FixedCharField(max_length=10)
 
 
 class Author(Model):

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -23,6 +23,7 @@ from django_mysql.models import (
     Bit1BooleanField,
     DynamicField,
     EnumField,
+    FixedCharField,
     ListCharField,
     ListTextField,
     Model,
@@ -161,6 +162,10 @@ class SpeclessDynamicModel(Model):
 
     def __str__(self):  # pragma: no cover
         return ",".join(f"{key}:{value}" for key, value in self.attrs.items())
+
+
+class FixedCharModel(Model):
+    zip_code = FixedCharField(length=10)
 
 
 class Author(Model):

--- a/tests/testapp/test_fixedcharfield.py
+++ b/tests/testapp/test_fixedcharfield.py
@@ -7,14 +7,20 @@ from django_mysql.models import FixedCharField
 
 
 class TestFixedCharField(TestCase):
-    def test_missing_length(self):
-        with pytest.raises(TypeError):
-            FixedCharField()
-
     def test_invalid_length_type(self):
         with pytest.raises(TypeError) as exc_info:
             FixedCharField(length="4")
         assert "Expected integer value." in str(exc_info.value)
+
+    def test_invalid_length_too_short(self):
+        with pytest.raises(ValueError) as exc_info:
+            FixedCharField(length=-1)
+        assert "Length must be in the range" in str(exc_info.value)
+
+    def test_invalid_length_too_long(self):
+        with pytest.raises(ValueError) as exc_info:
+            FixedCharField(length=256)
+        assert "Length must be in the range" in str(exc_info.value)
 
     def test_invalid_max_length(self):
         with pytest.raises(TypeError) as exc_info:
@@ -24,10 +30,10 @@ class TestFixedCharField(TestCase):
 
 class TestDeconstruct(TestCase):
     def test_deconstruct(self):
-        field = FixedCharField(length=4)
+        field = FixedCharField()
         name, path, args, kwargs = field.deconstruct()
         assert path == "django_mysql.models.FixedCharField"
-        assert kwargs["length"] == 4
+        assert kwargs["length"] == 1
         assert "max_length" not in kwargs
         FixedCharField(*args, **kwargs)
 

--- a/tests/testapp/test_fixedcharfield.py
+++ b/tests/testapp/test_fixedcharfield.py
@@ -3,22 +3,13 @@ from __future__ import annotations
 import pytest
 from django.core.management import call_command
 from django.db import connection
-from django.test import TestCase, TransactionTestCase, override_settings
+from django.test import SimpleTestCase, TestCase, TransactionTestCase, override_settings
 
 from django_mysql.models import FixedCharField
+from tests.testapp.models import TemporaryModel
 
 
 class TestFixedCharField(TestCase):
-    def test_invalid_length_too_short(self):
-        with pytest.raises(ValueError) as exc_info:
-            FixedCharField(length=-1)
-        assert "Length must be in the range" in str(exc_info.value)
-
-    def test_invalid_length_too_long(self):
-        with pytest.raises(ValueError) as exc_info:
-            FixedCharField(length=256)
-        assert "Length must be in the range" in str(exc_info.value)
-
     def test_invalid_max_length(self):
         with pytest.raises(TypeError) as exc_info:
             FixedCharField(length=4, max_length=100)
@@ -33,6 +24,28 @@ class TestDeconstruct(TestCase):
         assert kwargs["length"] == 1
         assert "max_length" not in kwargs
         FixedCharField(*args, **kwargs)
+
+
+class TestCheck(SimpleTestCase):
+    def test_length_too_small(self):
+        class InvalidFixedCharModel1(TemporaryModel):
+            field = FixedCharField(length=-1)
+
+        errors = InvalidFixedCharModel1.check(actually_check=True)
+        assert len(errors) == 2
+        assert errors[0].id == "fields.E121"
+        assert errors[0].msg == "'max_length' must be a positive integer."
+        assert errors[1].id == "django_mysql.E015"
+        assert errors[1].msg == "'length' must be between 0 and 255."
+
+    def test_length_too_large(self):
+        class InvalidFixedCharModel2(TemporaryModel):
+            field = FixedCharField(length=256)
+
+        errors = InvalidFixedCharModel2.check(actually_check=True)
+        assert len(errors) == 1
+        assert errors[0].id == "django_mysql.E015"
+        assert errors[0].msg == "'length' must be between 0 and 255."
 
 
 class TestMigrations(TransactionTestCase):

--- a/tests/testapp/test_fixedcharfield.py
+++ b/tests/testapp/test_fixedcharfield.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from django.core.management import call_command
 from django.db import connection

--- a/tests/testapp/test_fixedcharfield.py
+++ b/tests/testapp/test_fixedcharfield.py
@@ -9,11 +9,6 @@ from django_mysql.models import FixedCharField
 
 
 class TestFixedCharField(TestCase):
-    def test_invalid_length_type(self):
-        with pytest.raises(TypeError) as exc_info:
-            FixedCharField(length="4")  # type: ignore [arg-type]
-        assert "Expected integer value." in str(exc_info.value)
-
     def test_invalid_length_too_short(self):
         with pytest.raises(ValueError) as exc_info:
             FixedCharField(length=-1)

--- a/tests/testapp/test_fixedcharfield.py
+++ b/tests/testapp/test_fixedcharfield.py
@@ -34,7 +34,7 @@ class TestDeconstruct(TestCase):
         name, path, args, kwargs = field.deconstruct()
         assert path == "django_mysql.models.FixedCharField"
         assert kwargs["length"] == 1
-        assert "max_length" not in kwargs
+        assert kwargs["max_length"] == 1
         FixedCharField(*args, **kwargs)
 
 

--- a/tests/testapp/test_fixedcharfield.py
+++ b/tests/testapp/test_fixedcharfield.py
@@ -39,6 +39,12 @@ class TestSaveLoad(TestCase):
         assert count == 1
 
 
+class SubFixedCharField(FixedCharField):
+    """
+    Used below, has a different path for deconstruct()
+    """
+
+
 class TestDeconstruct(TestCase):
     def test_deconstruct(self):
         field = FixedCharField(max_length=1)
@@ -46,6 +52,11 @@ class TestDeconstruct(TestCase):
         assert path == "django_mysql.models.FixedCharField"
         assert kwargs["max_length"] == 1
         FixedCharField(*args, **kwargs)
+
+    def test_subclass_deconstruct(self):
+        field = SubFixedCharField(max_length=1)
+        name, path, args, kwargs = field.deconstruct()
+        assert path == "tests.testapp.test_fixedcharfield.SubFixedCharField"
 
 
 class TestCheck(SimpleTestCase):

--- a/tests/testapp/test_fixedcharfield.py
+++ b/tests/testapp/test_fixedcharfield.py
@@ -1,0 +1,60 @@
+import pytest
+from django.core.management import call_command
+from django.db import connection
+from django.test import TestCase, TransactionTestCase, override_settings
+
+from django_mysql.models import FixedCharField
+
+
+class TestFixedCharField(TestCase):
+    def test_missing_length(self):
+        with pytest.raises(TypeError):
+            FixedCharField()
+
+    def test_invalid_length_type(self):
+        with pytest.raises(TypeError) as exc_info:
+            FixedCharField(length="4")
+        assert "Expected integer value." in str(exc_info.value)
+
+    def test_invalid_max_length(self):
+        with pytest.raises(TypeError) as exc_info:
+            FixedCharField(length=4, max_length=100)
+        assert '"max_length" is not a valid argument' in str(exc_info.value)
+
+
+class TestDeconstruct(TestCase):
+    def test_deconstruct(self):
+        field = FixedCharField(length=4)
+        name, path, args, kwargs = field.deconstruct()
+        assert path == "django_mysql.models.FixedCharField"
+        assert kwargs["length"] == 4
+        assert "max_length" not in kwargs
+        FixedCharField(*args, **kwargs)
+
+
+class TestMigrations(TransactionTestCase):
+    @override_settings(
+        MIGRATION_MODULES={"testapp": "tests.testapp.fixedchar_default_migrations"}
+    )
+    def test_adding_field_with_default(self):
+        table_name = "testapp_fixedchardefaultmodel"
+        table_names = connection.introspection.table_names
+        with connection.cursor() as cursor:
+            assert table_name not in table_names(cursor)
+
+        call_command(
+            "migrate", "testapp", verbosity=0, skip_checks=True, interactive=False
+        )
+        with connection.cursor() as cursor:
+            assert table_name in table_names(cursor)
+
+        call_command(
+            "migrate",
+            "testapp",
+            "zero",
+            verbosity=0,
+            skip_checks=True,
+            interactive=False,
+        )
+        with connection.cursor() as cursor:
+            assert table_name not in table_names(cursor)

--- a/tests/testapp/test_fixedcharfield.py
+++ b/tests/testapp/test_fixedcharfield.py
@@ -30,7 +30,7 @@ class TestFixedCharField(TestCase):
 
 class TestDeconstruct(TestCase):
     def test_deconstruct(self):
-        field = FixedCharField()
+        field = FixedCharField(length=1)
         name, path, args, kwargs = field.deconstruct()
         assert path == "django_mysql.models.FixedCharField"
         assert kwargs["length"] == 1

--- a/tests/testapp/test_fixedcharfield.py
+++ b/tests/testapp/test_fixedcharfield.py
@@ -10,13 +10,6 @@ from django_mysql.models import FixedCharField
 from tests.testapp.models import FixedCharModel, TemporaryModel
 
 
-class TestFixedCharField(TestCase):
-    def test_invalid_max_length(self):
-        with pytest.raises(TypeError) as exc_info:
-            FixedCharField(length=4, max_length=100)
-        assert '"max_length" is not a valid argument' in str(exc_info.value)
-
-
 class TestSaveLoad(TestCase):
     def test_success_exact(self):
         instance = FixedCharModel.objects.create(zip_code="0" * 10)
@@ -48,34 +41,33 @@ class TestSaveLoad(TestCase):
 
 class TestDeconstruct(TestCase):
     def test_deconstruct(self):
-        field = FixedCharField(length=1)
+        field = FixedCharField(max_length=1)
         name, path, args, kwargs = field.deconstruct()
         assert path == "django_mysql.models.FixedCharField"
-        assert kwargs["length"] == 1
-        assert "max_length" not in kwargs
+        assert kwargs["max_length"] == 1
         FixedCharField(*args, **kwargs)
 
 
 class TestCheck(SimpleTestCase):
     def test_length_too_small(self):
         class InvalidFixedCharModel1(TemporaryModel):
-            field = FixedCharField(length=-1)
+            field = FixedCharField(max_length=-1)
 
         errors = InvalidFixedCharModel1.check(actually_check=True)
         assert len(errors) == 2
         assert errors[0].id == "fields.E121"
         assert errors[0].msg == "'max_length' must be a positive integer."
         assert errors[1].id == "django_mysql.E015"
-        assert errors[1].msg == "'length' must be between 0 and 255."
+        assert errors[1].msg == "'max_length' must be between 0 and 255."
 
     def test_length_too_large(self):
         class InvalidFixedCharModel2(TemporaryModel):
-            field = FixedCharField(length=256)
+            field = FixedCharField(max_length=256)
 
         errors = InvalidFixedCharModel2.check(actually_check=True)
         assert len(errors) == 1
         assert errors[0].id == "django_mysql.E015"
-        assert errors[0].msg == "'length' must be between 0 and 255."
+        assert errors[0].msg == "'max_length' must be between 0 and 255."
 
 
 class TestMigrations(TransactionTestCase):

--- a/tests/testapp/test_fixedcharfield.py
+++ b/tests/testapp/test_fixedcharfield.py
@@ -31,7 +31,7 @@ class TestDeconstruct(TestCase):
         name, path, args, kwargs = field.deconstruct()
         assert path == "django_mysql.models.FixedCharField"
         assert kwargs["length"] == 1
-        assert kwargs["max_length"] == 1
+        assert "max_length" not in kwargs
         FixedCharField(*args, **kwargs)
 
 

--- a/tests/testapp/test_fixedcharfield.py
+++ b/tests/testapp/test_fixedcharfield.py
@@ -9,7 +9,7 @@ from django_mysql.models import FixedCharField
 class TestFixedCharField(TestCase):
     def test_invalid_length_type(self):
         with pytest.raises(TypeError) as exc_info:
-            FixedCharField(length="4")
+            FixedCharField(length="4")  # type: ignore [arg-type]
         assert "Expected integer value." in str(exc_info.value)
 
     def test_invalid_length_too_short(self):


### PR DESCRIPTION
Apologies if something is wrong. I had a time trying to get this project set up on my laptop. 😅

This PR adds a new model `FixedCharField`. It inherits from `django.db.models.CharField` but creates a `char` field, useful for storing fixed string length data. The length is specified through a `length` parameter and disallows passing a `max_length` as it doesn't makes sense in this context. It also checks that the length is within the 0-255 range, as required by MySQL and MariaDB. There is a minor engine implementation difference in that MariaDB defaults to a length of `1` (2) while MySQL doesn't have a default value (3). I have followed the MariaDB behavior.

I'm not at all sure the introduction paragraph is correct at all and very likely needs major correction. 😬

This was requested before in Django itself 13 years ago but was rejected as wontfix. (1).

In case you're wondering about the motivation for this PR, I'm trying to design a model for a legacy table to improve maintenance and there are instances of `char` fields that I would like to accurately map. This project is already helping out with the inclusion of the `EnumField` and I figured why not have this field to the library too. I'm sure I'm not the only one who can benefit from this.

### References
1. https://code.djangoproject.com/ticket/9349
2. https://dev.mysql.com/doc/refman/8.0/en/char.html
3. https://mariadb.com/kb/en/char/
