### PR TITLE
Use @isolate_apps in tests

### DIFF
--- a/requirements/py310-django32.txt
+++ b/requirements/py310-django32.txt
@@ -135,7 +135,6 @@ pytest==6.2.5 \
     #   pytest-django
     #   pytest-flake8-path
     #   pytest-randomly
-    #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
@@ -147,10 +146,6 @@ pytest-flake8-path==1.2.0 \
 pytest-randomly==3.11.0 \
     --hash=sha256:9f013b8c1923130f3d0a286fde56e1fc52cfb3547b8eedf2765c460cee979c7f \
     --hash=sha256:a3c680d2b8150cf766311a80a1f92da64c3dd819045cda834fbf1b0ac4891610
-    # via -r requirements.in
-pytest-super-check==2.5.0 \
-    --hash=sha256:43e6339db02807d97e3d82c071e4aea7654ea3bd11aa4970134984d737d2611a \
-    --hash=sha256:f3a60920d0c656fb648d89155a04724c84b73c4cd3afc6d6134385fb59ecbb6e
     # via -r requirements.in
 pytz==2021.3 \
     --hash=sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c \

--- a/requirements/py310-django40.txt
+++ b/requirements/py310-django40.txt
@@ -135,7 +135,6 @@ pytest==6.2.5 \
     #   pytest-django
     #   pytest-flake8-path
     #   pytest-randomly
-    #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
@@ -147,10 +146,6 @@ pytest-flake8-path==1.2.0 \
 pytest-randomly==3.11.0 \
     --hash=sha256:9f013b8c1923130f3d0a286fde56e1fc52cfb3547b8eedf2765c460cee979c7f \
     --hash=sha256:a3c680d2b8150cf766311a80a1f92da64c3dd819045cda834fbf1b0ac4891610
-    # via -r requirements.in
-pytest-super-check==2.5.0 \
-    --hash=sha256:43e6339db02807d97e3d82c071e4aea7654ea3bd11aa4970134984d737d2611a \
-    --hash=sha256:f3a60920d0c656fb648d89155a04724c84b73c4cd3afc6d6134385fb59ecbb6e
     # via -r requirements.in
 sqlparse==0.4.2 \
     --hash=sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae \

--- a/requirements/py37-django22.txt
+++ b/requirements/py37-django22.txt
@@ -139,7 +139,6 @@ pytest==6.2.5 \
     #   pytest-django
     #   pytest-flake8-path
     #   pytest-randomly
-    #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
@@ -151,10 +150,6 @@ pytest-flake8-path==1.2.0 \
 pytest-randomly==3.11.0 \
     --hash=sha256:9f013b8c1923130f3d0a286fde56e1fc52cfb3547b8eedf2765c460cee979c7f \
     --hash=sha256:a3c680d2b8150cf766311a80a1f92da64c3dd819045cda834fbf1b0ac4891610
-    # via -r requirements.in
-pytest-super-check==2.5.0 \
-    --hash=sha256:43e6339db02807d97e3d82c071e4aea7654ea3bd11aa4970134984d737d2611a \
-    --hash=sha256:f3a60920d0c656fb648d89155a04724c84b73c4cd3afc6d6134385fb59ecbb6e
     # via -r requirements.in
 pytz==2021.3 \
     --hash=sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c \

--- a/requirements/py37-django30.txt
+++ b/requirements/py37-django30.txt
@@ -143,7 +143,6 @@ pytest==6.2.5 \
     #   pytest-django
     #   pytest-flake8-path
     #   pytest-randomly
-    #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
@@ -155,10 +154,6 @@ pytest-flake8-path==1.2.0 \
 pytest-randomly==3.11.0 \
     --hash=sha256:9f013b8c1923130f3d0a286fde56e1fc52cfb3547b8eedf2765c460cee979c7f \
     --hash=sha256:a3c680d2b8150cf766311a80a1f92da64c3dd819045cda834fbf1b0ac4891610
-    # via -r requirements.in
-pytest-super-check==2.5.0 \
-    --hash=sha256:43e6339db02807d97e3d82c071e4aea7654ea3bd11aa4970134984d737d2611a \
-    --hash=sha256:f3a60920d0c656fb648d89155a04724c84b73c4cd3afc6d6134385fb59ecbb6e
     # via -r requirements.in
 pytz==2021.3 \
     --hash=sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c \

--- a/requirements/py37-django31.txt
+++ b/requirements/py37-django31.txt
@@ -143,7 +143,6 @@ pytest==6.2.5 \
     #   pytest-django
     #   pytest-flake8-path
     #   pytest-randomly
-    #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
@@ -155,10 +154,6 @@ pytest-flake8-path==1.2.0 \
 pytest-randomly==3.11.0 \
     --hash=sha256:9f013b8c1923130f3d0a286fde56e1fc52cfb3547b8eedf2765c460cee979c7f \
     --hash=sha256:a3c680d2b8150cf766311a80a1f92da64c3dd819045cda834fbf1b0ac4891610
-    # via -r requirements.in
-pytest-super-check==2.5.0 \
-    --hash=sha256:43e6339db02807d97e3d82c071e4aea7654ea3bd11aa4970134984d737d2611a \
-    --hash=sha256:f3a60920d0c656fb648d89155a04724c84b73c4cd3afc6d6134385fb59ecbb6e
     # via -r requirements.in
 pytz==2021.3 \
     --hash=sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c \

--- a/requirements/py37-django32.txt
+++ b/requirements/py37-django32.txt
@@ -143,7 +143,6 @@ pytest==6.2.5 \
     #   pytest-django
     #   pytest-flake8-path
     #   pytest-randomly
-    #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
@@ -155,10 +154,6 @@ pytest-flake8-path==1.2.0 \
 pytest-randomly==3.11.0 \
     --hash=sha256:9f013b8c1923130f3d0a286fde56e1fc52cfb3547b8eedf2765c460cee979c7f \
     --hash=sha256:a3c680d2b8150cf766311a80a1f92da64c3dd819045cda834fbf1b0ac4891610
-    # via -r requirements.in
-pytest-super-check==2.5.0 \
-    --hash=sha256:43e6339db02807d97e3d82c071e4aea7654ea3bd11aa4970134984d737d2611a \
-    --hash=sha256:f3a60920d0c656fb648d89155a04724c84b73c4cd3afc6d6134385fb59ecbb6e
     # via -r requirements.in
 pytz==2021.3 \
     --hash=sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c \

--- a/requirements/py38-django22.txt
+++ b/requirements/py38-django22.txt
@@ -135,7 +135,6 @@ pytest==6.2.5 \
     #   pytest-django
     #   pytest-flake8-path
     #   pytest-randomly
-    #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
@@ -147,10 +146,6 @@ pytest-flake8-path==1.2.0 \
 pytest-randomly==3.11.0 \
     --hash=sha256:9f013b8c1923130f3d0a286fde56e1fc52cfb3547b8eedf2765c460cee979c7f \
     --hash=sha256:a3c680d2b8150cf766311a80a1f92da64c3dd819045cda834fbf1b0ac4891610
-    # via -r requirements.in
-pytest-super-check==2.5.0 \
-    --hash=sha256:43e6339db02807d97e3d82c071e4aea7654ea3bd11aa4970134984d737d2611a \
-    --hash=sha256:f3a60920d0c656fb648d89155a04724c84b73c4cd3afc6d6134385fb59ecbb6e
     # via -r requirements.in
 pytz==2021.3 \
     --hash=sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c \

--- a/requirements/py38-django30.txt
+++ b/requirements/py38-django30.txt
@@ -139,7 +139,6 @@ pytest==6.2.5 \
     #   pytest-django
     #   pytest-flake8-path
     #   pytest-randomly
-    #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
@@ -151,10 +150,6 @@ pytest-flake8-path==1.2.0 \
 pytest-randomly==3.11.0 \
     --hash=sha256:9f013b8c1923130f3d0a286fde56e1fc52cfb3547b8eedf2765c460cee979c7f \
     --hash=sha256:a3c680d2b8150cf766311a80a1f92da64c3dd819045cda834fbf1b0ac4891610
-    # via -r requirements.in
-pytest-super-check==2.5.0 \
-    --hash=sha256:43e6339db02807d97e3d82c071e4aea7654ea3bd11aa4970134984d737d2611a \
-    --hash=sha256:f3a60920d0c656fb648d89155a04724c84b73c4cd3afc6d6134385fb59ecbb6e
     # via -r requirements.in
 pytz==2021.3 \
     --hash=sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c \

--- a/requirements/py38-django31.txt
+++ b/requirements/py38-django31.txt
@@ -139,7 +139,6 @@ pytest==6.2.5 \
     #   pytest-django
     #   pytest-flake8-path
     #   pytest-randomly
-    #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
@@ -151,10 +150,6 @@ pytest-flake8-path==1.2.0 \
 pytest-randomly==3.11.0 \
     --hash=sha256:9f013b8c1923130f3d0a286fde56e1fc52cfb3547b8eedf2765c460cee979c7f \
     --hash=sha256:a3c680d2b8150cf766311a80a1f92da64c3dd819045cda834fbf1b0ac4891610
-    # via -r requirements.in
-pytest-super-check==2.5.0 \
-    --hash=sha256:43e6339db02807d97e3d82c071e4aea7654ea3bd11aa4970134984d737d2611a \
-    --hash=sha256:f3a60920d0c656fb648d89155a04724c84b73c4cd3afc6d6134385fb59ecbb6e
     # via -r requirements.in
 pytz==2021.3 \
     --hash=sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c \

--- a/requirements/py38-django32.txt
+++ b/requirements/py38-django32.txt
@@ -139,7 +139,6 @@ pytest==6.2.5 \
     #   pytest-django
     #   pytest-flake8-path
     #   pytest-randomly
-    #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
@@ -151,10 +150,6 @@ pytest-flake8-path==1.2.0 \
 pytest-randomly==3.11.0 \
     --hash=sha256:9f013b8c1923130f3d0a286fde56e1fc52cfb3547b8eedf2765c460cee979c7f \
     --hash=sha256:a3c680d2b8150cf766311a80a1f92da64c3dd819045cda834fbf1b0ac4891610
-    # via -r requirements.in
-pytest-super-check==2.5.0 \
-    --hash=sha256:43e6339db02807d97e3d82c071e4aea7654ea3bd11aa4970134984d737d2611a \
-    --hash=sha256:f3a60920d0c656fb648d89155a04724c84b73c4cd3afc6d6134385fb59ecbb6e
     # via -r requirements.in
 pytz==2021.3 \
     --hash=sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c \

--- a/requirements/py38-django40.txt
+++ b/requirements/py38-django40.txt
@@ -157,7 +157,6 @@ pytest==6.2.5 \
     #   pytest-django
     #   pytest-flake8-path
     #   pytest-randomly
-    #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
@@ -169,10 +168,6 @@ pytest-flake8-path==1.2.0 \
 pytest-randomly==3.11.0 \
     --hash=sha256:9f013b8c1923130f3d0a286fde56e1fc52cfb3547b8eedf2765c460cee979c7f \
     --hash=sha256:a3c680d2b8150cf766311a80a1f92da64c3dd819045cda834fbf1b0ac4891610
-    # via -r requirements.in
-pytest-super-check==2.5.0 \
-    --hash=sha256:43e6339db02807d97e3d82c071e4aea7654ea3bd11aa4970134984d737d2611a \
-    --hash=sha256:f3a60920d0c656fb648d89155a04724c84b73c4cd3afc6d6134385fb59ecbb6e
     # via -r requirements.in
 sqlparse==0.4.2 \
     --hash=sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae \

--- a/requirements/py39-django22.txt
+++ b/requirements/py39-django22.txt
@@ -135,7 +135,6 @@ pytest==6.2.5 \
     #   pytest-django
     #   pytest-flake8-path
     #   pytest-randomly
-    #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
@@ -147,10 +146,6 @@ pytest-flake8-path==1.2.0 \
 pytest-randomly==3.11.0 \
     --hash=sha256:9f013b8c1923130f3d0a286fde56e1fc52cfb3547b8eedf2765c460cee979c7f \
     --hash=sha256:a3c680d2b8150cf766311a80a1f92da64c3dd819045cda834fbf1b0ac4891610
-    # via -r requirements.in
-pytest-super-check==2.5.0 \
-    --hash=sha256:43e6339db02807d97e3d82c071e4aea7654ea3bd11aa4970134984d737d2611a \
-    --hash=sha256:f3a60920d0c656fb648d89155a04724c84b73c4cd3afc6d6134385fb59ecbb6e
     # via -r requirements.in
 pytz==2021.3 \
     --hash=sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c \

--- a/requirements/py39-django30.txt
+++ b/requirements/py39-django30.txt
@@ -139,7 +139,6 @@ pytest==6.2.5 \
     #   pytest-django
     #   pytest-flake8-path
     #   pytest-randomly
-    #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
@@ -151,10 +150,6 @@ pytest-flake8-path==1.2.0 \
 pytest-randomly==3.11.0 \
     --hash=sha256:9f013b8c1923130f3d0a286fde56e1fc52cfb3547b8eedf2765c460cee979c7f \
     --hash=sha256:a3c680d2b8150cf766311a80a1f92da64c3dd819045cda834fbf1b0ac4891610
-    # via -r requirements.in
-pytest-super-check==2.5.0 \
-    --hash=sha256:43e6339db02807d97e3d82c071e4aea7654ea3bd11aa4970134984d737d2611a \
-    --hash=sha256:f3a60920d0c656fb648d89155a04724c84b73c4cd3afc6d6134385fb59ecbb6e
     # via -r requirements.in
 pytz==2021.3 \
     --hash=sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c \

--- a/requirements/py39-django31.txt
+++ b/requirements/py39-django31.txt
@@ -139,7 +139,6 @@ pytest==6.2.5 \
     #   pytest-django
     #   pytest-flake8-path
     #   pytest-randomly
-    #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
@@ -151,10 +150,6 @@ pytest-flake8-path==1.2.0 \
 pytest-randomly==3.11.0 \
     --hash=sha256:9f013b8c1923130f3d0a286fde56e1fc52cfb3547b8eedf2765c460cee979c7f \
     --hash=sha256:a3c680d2b8150cf766311a80a1f92da64c3dd819045cda834fbf1b0ac4891610
-    # via -r requirements.in
-pytest-super-check==2.5.0 \
-    --hash=sha256:43e6339db02807d97e3d82c071e4aea7654ea3bd11aa4970134984d737d2611a \
-    --hash=sha256:f3a60920d0c656fb648d89155a04724c84b73c4cd3afc6d6134385fb59ecbb6e
     # via -r requirements.in
 pytz==2021.3 \
     --hash=sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c \

--- a/requirements/py39-django32.txt
+++ b/requirements/py39-django32.txt
@@ -139,7 +139,6 @@ pytest==6.2.5 \
     #   pytest-django
     #   pytest-flake8-path
     #   pytest-randomly
-    #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
@@ -151,10 +150,6 @@ pytest-flake8-path==1.2.0 \
 pytest-randomly==3.11.0 \
     --hash=sha256:9f013b8c1923130f3d0a286fde56e1fc52cfb3547b8eedf2765c460cee979c7f \
     --hash=sha256:a3c680d2b8150cf766311a80a1f92da64c3dd819045cda834fbf1b0ac4891610
-    # via -r requirements.in
-pytest-super-check==2.5.0 \
-    --hash=sha256:43e6339db02807d97e3d82c071e4aea7654ea3bd11aa4970134984d737d2611a \
-    --hash=sha256:f3a60920d0c656fb648d89155a04724c84b73c4cd3afc6d6134385fb59ecbb6e
     # via -r requirements.in
 pytz==2021.3 \
     --hash=sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c \

--- a/requirements/py39-django40.txt
+++ b/requirements/py39-django40.txt
@@ -139,7 +139,6 @@ pytest==6.2.5 \
     #   pytest-django
     #   pytest-flake8-path
     #   pytest-randomly
-    #   pytest-super-check
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
@@ -151,10 +150,6 @@ pytest-flake8-path==1.2.0 \
 pytest-randomly==3.11.0 \
     --hash=sha256:9f013b8c1923130f3d0a286fde56e1fc52cfb3547b8eedf2765c460cee979c7f \
     --hash=sha256:a3c680d2b8150cf766311a80a1f92da64c3dd819045cda834fbf1b0ac4891610
-    # via -r requirements.in
-pytest-super-check==2.5.0 \
-    --hash=sha256:43e6339db02807d97e3d82c071e4aea7654ea3bd11aa4970134984d737d2611a \
-    --hash=sha256:f3a60920d0c656fb648d89155a04724c84b73c4cd3afc6d6134385fb59ecbb6e
     # via -r requirements.in
 sqlparse==0.4.2 \
     --hash=sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae \

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -9,4 +9,3 @@ pytest
 pytest-django
 pytest-flake8-path
 pytest-randomly
-pytest-super-check

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -36,26 +36,6 @@ from django_mysql.models import (
 from django_mysql.utils import connection_is_mariadb
 
 
-class TemporaryModel(Model):
-    """
-    Used for temporary, mostly invalid models created in tests - check() is
-    disabled unless an extra parameter is provided, in case the checks get run
-    during tests, e.g. from call_command.
-    """
-
-    class Meta:
-        app_label = "testapp"
-        abstract = True
-
-    @classmethod
-    def check(cls, **kwargs):
-        actually_check = kwargs.pop("actually_check", False)
-        if actually_check:
-            return super().check(**kwargs)
-        else:
-            return []
-
-
 class EnumModel(Model):
     field = EnumField(
         choices=[

--- a/tests/testapp/test_bit1_field.py
+++ b/tests/testapp/test_bit1_field.py
@@ -4,11 +4,13 @@ import json
 
 import django
 from django.core import checks, serializers
+from django.db import models
 from django.db.models import F
 from django.test import SimpleTestCase, TestCase
+from django.test.utils import isolate_apps
 
 from django_mysql.models import NullBit1BooleanField
-from tests.testapp.models import Bit1Model, TemporaryModel
+from tests.testapp.models import Bit1Model
 
 if django.VERSION < (4, 0):
     from tests.testapp.models import NullBit1Model
@@ -180,19 +182,18 @@ if django.VERSION < (4, 0):
 
 else:
 
+    @isolate_apps("tests.testapp")
     class TestNullCheck(SimpleTestCase):
         def test_check_deprecated(self):
-            class NullBit1Model(TemporaryModel):
+            class Invalid(models.Model):
                 nb = NullBit1BooleanField()
 
-            model = NullBit1Model()
-
-            assert model.check(actually_check=True) == [
+            assert Invalid.check() == [
                 checks.Error(
                     "NullBooleanField is removed except for support in historical "
                     "migrations.",
                     hint="Use BooleanField(null=True) instead.",
-                    obj=NullBit1Model._meta.get_field("nb"),
+                    obj=Invalid._meta.get_field("nb"),
                     id="fields.E903",
                 ),
             ]


### PR DESCRIPTION
This provides a cleaner way of isolating temporary model classes. Django’s own test suite uses this extensively, and (hopefully soon) it will be documented as public API: https://code.djangoproject.com/ticket/33422