### PR TITLE
Make PR pushes cancel previous actions runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,10 @@ on:
     - main
   pull_request:
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: ${{ matrix.database }} Python ${{ matrix.python-version }}


### PR DESCRIPTION
This saves time and CPU power computing stale results.

Taken from: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value
