### PR TITLE
Fix EnumField migrations changing choices on Django 4.1

### DIFF
--- a/src/django_mysql/models/fields/enum.py
+++ b/src/django_mysql/models/fields/enum.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+import django
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models import CharField
 from django.utils.encoding import force_str
@@ -12,6 +13,9 @@ from django_mysql.typing import DeconstructResult
 
 class EnumField(CharField):
     description = _("Enumeration")
+
+    if django.VERSION >= (4, 1):
+        non_db_attrs = tuple(f for f in CharField.non_db_attrs if f != "choices")
 
     def __init__(
         self,


### PR DESCRIPTION
Fixes #901