### PR TITLE
Add model TinyIntegerField/PositiveTinyIntegerField

### DIFF
--- a/src/django_mysql/models/__init__.py
+++ b/src/django_mysql/models/__init__.py
@@ -25,4 +25,6 @@ from django_mysql.models.fields import (  # noqa
     SetTextField,
     SizedBinaryField,
     SizedTextField,
+    TinyIntegerField,
+    PositiveTinyIntegerField,
 )

--- a/src/django_mysql/models/fields/__init__.py
+++ b/src/django_mysql/models/fields/__init__.py
@@ -7,7 +7,10 @@ from django_mysql.models.fields.fixedchar import FixedCharField
 from django_mysql.models.fields.lists import ListCharField, ListTextField
 from django_mysql.models.fields.sets import SetCharField, SetTextField
 from django_mysql.models.fields.sizes import SizedBinaryField, SizedTextField
-from django_mysql.models.fields.tinyint import TinyIntegerField, PositiveTinyIntegerField
+from django_mysql.models.fields.tinyint import (
+    PositiveTinyIntegerField,
+    TinyIntegerField,
+)
 
 __all__ = [
     "Bit1BooleanField",

--- a/src/django_mysql/models/fields/__init__.py
+++ b/src/django_mysql/models/fields/__init__.py
@@ -7,6 +7,7 @@ from django_mysql.models.fields.fixedchar import FixedCharField
 from django_mysql.models.fields.lists import ListCharField, ListTextField
 from django_mysql.models.fields.sets import SetCharField, SetTextField
 from django_mysql.models.fields.sizes import SizedBinaryField, SizedTextField
+from django_mysql.models.fields.tinyint import TinyIntegerField, PositiveTinyIntegerField
 
 __all__ = [
     "Bit1BooleanField",
@@ -20,4 +21,6 @@ __all__ = [
     "SetTextField",
     "SizedBinaryField",
     "SizedTextField",
+    "TinyIntegerField",
+    "PositiveTinyIntegerField",
 ]

--- a/src/django_mysql/models/fields/tinyint.py
+++ b/src/django_mysql/models/fields/tinyint.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from django.core import checks
+from django.db.backends.base.base import BaseDatabaseWrapper
+from django.db.models import IntegerField
+
+from django_mysql.typing import DeconstructResult
+
+
+class TinyIntegerField(IntegerField):
+    def check(self, **kwargs: Any) -> list[checks.CheckMessage]:
+        errors = super().check(**kwargs)
+
+        if isinstance(self.max_length, int) and (
+            self.max_length < -128 or self.max_length > 127
+        ):
+            errors.append(
+                checks.Error(
+                    "'max_length' must be between -128 and 127.",
+                    hint=None,
+                    obj=self,
+                    id="django_mysql.E015",
+                )
+            )
+
+        return errors
+
+    def deconstruct(self) -> DeconstructResult:
+        name, path, args, kwargs = cast(DeconstructResult, super().deconstruct())
+
+        bad_paths = (
+            "django_mysql.models.fields.tinyint.TinyIntegerField",
+            "django_mysql.models.fields.TinyIntegerField",
+        )
+        if path in bad_paths:
+            path = "django_mysql.models.TinyIntegerField"
+
+        return name, path, args, kwargs
+
+    def db_type(self, connection: BaseDatabaseWrapper) -> str:
+        return "TINYINT"
+
+
+class PositiveTinyIntegerField(IntegerField):
+    def check(self, **kwargs: Any) -> list[checks.CheckMessage]:
+        errors = super().check(**kwargs)
+
+        if isinstance(self.max_length, int) and (
+            self.max_length < 0 or self.max_length > 255
+        ):
+            errors.append(
+                checks.Error(
+                    "'max_length' must be between 0 and 255.",
+                    hint=None,
+                    obj=self,
+                    id="django_mysql.E015",
+                )
+            )
+
+        return errors
+
+    def deconstruct(self) -> DeconstructResult:
+        name, path, args, kwargs = cast(DeconstructResult, super().deconstruct())
+
+        bad_paths = (
+            "django_mysql.models.fields.tinyint.PositiveTinyIntegerField",
+            "django_mysql.models.fields.PositiveTinyIntegerField",
+        )
+        if path in bad_paths:
+            path = "django_mysql.models.PositiveTinyIntegerField"
+
+        return name, path, args, kwargs
+
+    def db_type(self, connection: BaseDatabaseWrapper) -> str:
+        return "TINYINT UNSIGNED"

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -33,8 +33,15 @@ from django_mysql.models import (
     SetTextField,
     SizedBinaryField,
     SizedTextField,
+    PositiveTinyIntegerField,
+    TinyIntegerField,
 )
 from tests.testapp.utils import conn_is_mysql
+
+
+class TinyIntModel(Model):
+    discount_amt = TinyIntegerField()
+    discount_amt_pct = PositiveTinyIntegerField()
 
 
 class EnumModel(Model):

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -29,11 +29,11 @@ from django_mysql.models import (
     ListTextField,
     Model,
     NullBit1BooleanField,
+    PositiveTinyIntegerField,
     SetCharField,
     SetTextField,
     SizedBinaryField,
     SizedTextField,
-    PositiveTinyIntegerField,
     TinyIntegerField,
 )
 from tests.testapp.utils import conn_is_mysql

--- a/tests/testapp/tinyint_default_migrations/0001_initial.py
+++ b/tests/testapp/tinyint_default_migrations/0001_initial.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from django.db import migrations, models
+
+from django_mysql.models import TinyIntegerField, PositiveTinyIntegerField
+
+
+class Migration(migrations.Migration):
+
+    dependencies: list[tuple[str, str]] = []
+
+    operations = [
+        migrations.CreateModel(
+            name="TinyIntDefaultModel",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        verbose_name="ID",
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    "col1",
+                    TinyIntegerField(),
+                ),
+                (
+                    "col2",
+                    PositiveTinyIntegerField(),
+                ),
+            ],
+            options={},
+            bases=(models.Model,),
+        )
+    ]

--- a/tests/testapp/tinyint_default_migrations/0001_initial.py
+++ b/tests/testapp/tinyint_default_migrations/0001_initial.py
@@ -23,11 +23,11 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 (
-                    "col1",
+                    "discount_amt",
                     TinyIntegerField(),
                 ),
                 (
-                    "col2",
+                    "discount_amt_pct",
                     PositiveTinyIntegerField(),
                 ),
             ],

--- a/tests/testapp/tinyint_default_migrations/0001_initial.py
+++ b/tests/testapp/tinyint_default_migrations/0001_initial.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from django.db import migrations, models
 
-from django_mysql.models import TinyIntegerField, PositiveTinyIntegerField
+from django_mysql.models import PositiveTinyIntegerField, TinyIntegerField
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
This starts adding support for the `TINYINT` field, with an unsigned version available too.

Building proper model fields (i.e., not simply subclassing `IntegerField` and overriding `db_type`) is still very foreign to me, so I appreciate any and all suggestions to help me learn how to better make these. 😃 

### TODO
- [ ] Confirm actual construction is correct
- [x] Add test model/migration
- [ ] Add/run tests
- [ ] Add documentation
- [ ] Any feedback you have

### Documentation
- https://mariadb.com/kb/en/tinyint/
- https://dev.mysql.com/doc/refman/en/integer-types.html