### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py37-plus
+    - --application-directories
+    - .:example:src
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,6 @@
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
-
 from __future__ import annotations
 
 import sys

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py37']
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 check_untyped_defs = true
 disallow_any_generics = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,3 +66,5 @@ show_missing = True
 [flake8]
 max-line-length = 88
 extend-ignore = E203
+per-file-ignores =
+    */__init__.py:F401

--- a/src/django_mysql/apps.py
+++ b/src/django_mysql/apps.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Any
+from typing import Callable
 
 from django.apps import AppConfig
 from django.conf import settings
@@ -9,7 +10,8 @@ from django.db.backends.signals import connection_created
 from django.utils.translation import gettext_lazy as _
 
 from django_mysql.checks import register_checks
-from django_mysql.rewrite_query import REWRITE_MARKER, rewrite_query
+from django_mysql.rewrite_query import REWRITE_MARKER
+from django_mysql.rewrite_query import rewrite_query
 from django_mysql.utils import mysql_connections
 
 

--- a/src/django_mysql/cache.py
+++ b/src/django_mysql/cache.py
@@ -8,14 +8,22 @@ import zlib
 from random import random
 from textwrap import dedent
 from time import time
-from typing import Any, Callable, Iterable, Tuple, cast
+from typing import Any
+from typing import Callable
+from typing import cast
+from typing import Iterable
+from typing import Tuple
 
-from django.core.cache.backends.base import DEFAULT_TIMEOUT, BaseCache, default_key_func
-from django.db import connections, router
+from django.core.cache.backends.base import BaseCache
+from django.core.cache.backends.base import default_key_func
+from django.core.cache.backends.base import DEFAULT_TIMEOUT
+from django.db import connections
+from django.db import router
 from django.utils.encoding import force_bytes
 from django.utils.module_loading import import_string
 
-from django_mysql.utils import collapse_spaces, get_list_sql
+from django_mysql.utils import collapse_spaces
+from django_mysql.utils import get_list_sql
 
 if sys.version_info >= (3, 8):
     from typing import Literal

--- a/src/django_mysql/checks.py
+++ b/src/django_mysql/checks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Iterable
+from typing import Any
+from typing import Iterable
 
 from django.core import checks
 

--- a/src/django_mysql/compat.py
+++ b/src/django_mysql/compat.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import sys
-from typing import Any, Callable, TypeVar, cast
+from typing import Any
+from typing import Callable
+from typing import cast
+from typing import TypeVar
 
 if sys.version_info >= (3, 9):
     from functools import cache

--- a/src/django_mysql/forms.py
+++ b/src/django_mysql/forms.py
@@ -8,12 +8,10 @@ from django.core.exceptions import ValidationError
 from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _
 
-from django_mysql.validators import (
-    ListMaxLengthValidator,
-    ListMinLengthValidator,
-    SetMaxLengthValidator,
-    SetMinLengthValidator,
-)
+from django_mysql.validators import ListMaxLengthValidator
+from django_mysql.validators import ListMinLengthValidator
+from django_mysql.validators import SetMaxLengthValidator
+from django_mysql.validators import SetMinLengthValidator
 
 
 class SimpleListField(forms.CharField):

--- a/src/django_mysql/locks.py
+++ b/src/django_mysql/locks.py
@@ -6,7 +6,8 @@ from types import TracebackType
 from django.db import connections
 from django.db.backends.utils import CursorWrapper
 from django.db.models import Model
-from django.db.transaction import TransactionManagementError, atomic
+from django.db.transaction import atomic
+from django.db.transaction import TransactionManagementError
 from django.db.utils import DEFAULT_DB_ALIAS
 
 from django_mysql.exceptions import TimeoutError

--- a/src/django_mysql/management/commands/cull_mysql_caches.py
+++ b/src/django_mysql/management/commands/cull_mysql_caches.py
@@ -4,8 +4,10 @@ import argparse
 from typing import Any
 
 from django.conf import settings
-from django.core.cache import InvalidCacheBackendError, caches
-from django.core.management import BaseCommand, CommandError
+from django.core.cache import caches
+from django.core.cache import InvalidCacheBackendError
+from django.core.management import BaseCommand
+from django.core.management import CommandError
 
 from django_mysql.cache import MySQLCache
 from django_mysql.utils import collapse_spaces

--- a/src/django_mysql/management/commands/dbparams.py
+++ b/src/django_mysql/management/commands/dbparams.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import argparse
 from typing import Any
 
-from django.core.management import BaseCommand, CommandError
-from django.db import DEFAULT_DB_ALIAS, connections
+from django.core.management import BaseCommand
+from django.core.management import CommandError
+from django.db import connections
+from django.db import DEFAULT_DB_ALIAS
 from django.db.utils import ConnectionDoesNotExist
 
 from django_mysql.utils import settings_to_cmd_args

--- a/src/django_mysql/management/commands/mysql_cache_migration.py
+++ b/src/django_mysql/management/commands/mysql_cache_migration.py
@@ -4,8 +4,10 @@ import argparse
 from typing import Any
 
 from django.conf import settings
-from django.core.cache import InvalidCacheBackendError, caches
-from django.core.management import BaseCommand, CommandError
+from django.core.cache import caches
+from django.core.cache import InvalidCacheBackendError
+from django.core.management import BaseCommand
+from django.core.management import CommandError
 
 from django_mysql.cache import MySQLCache
 from django_mysql.utils import collapse_spaces

--- a/src/django_mysql/models/__init__.py
+++ b/src/django_mysql/models/__init__.py
@@ -1,28 +1,30 @@
 """
 isort:skip_file
 """
+from __future__ import annotations
+
+from django_mysql.models.aggregates import BitAnd
+from django_mysql.models.aggregates import BitOr
+from django_mysql.models.aggregates import BitXor
+from django_mysql.models.aggregates import GroupConcat
 from django_mysql.models.base import Model  # noqa
-from django_mysql.models.aggregates import BitAnd, BitOr, BitXor, GroupConcat  # noqa
-from django_mysql.models.expressions import ListF, SetF  # noqa
-from django_mysql.models.query import (  # noqa
-    add_QuerySetMixin,
-    ApproximateInt,
-    SmartChunkedIterator,
-    SmartIterator,
-    pt_visual_explain,
-    QuerySet,
-    QuerySetMixin,
-)
-from django_mysql.models.fields import (  # noqa
-    Bit1BooleanField,
-    DynamicField,
-    EnumField,
-    FixedCharField,
-    ListCharField,
-    ListTextField,
-    NullBit1BooleanField,
-    SetCharField,
-    SetTextField,
-    SizedBinaryField,
-    SizedTextField,
-)
+from django_mysql.models.expressions import ListF
+from django_mysql.models.expressions import SetF
+from django_mysql.models.fields import Bit1BooleanField
+from django_mysql.models.fields import DynamicField
+from django_mysql.models.fields import EnumField
+from django_mysql.models.fields import FixedCharField
+from django_mysql.models.fields import ListCharField
+from django_mysql.models.fields import ListTextField
+from django_mysql.models.fields import NullBit1BooleanField
+from django_mysql.models.fields import SetCharField
+from django_mysql.models.fields import SetTextField
+from django_mysql.models.fields import SizedBinaryField
+from django_mysql.models.fields import SizedTextField
+from django_mysql.models.query import add_QuerySetMixin
+from django_mysql.models.query import ApproximateInt
+from django_mysql.models.query import pt_visual_explain
+from django_mysql.models.query import QuerySet
+from django_mysql.models.query import QuerySetMixin
+from django_mysql.models.query import SmartChunkedIterator
+from django_mysql.models.query import SmartIterator

--- a/src/django_mysql/models/aggregates.py
+++ b/src/django_mysql/models/aggregates.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from typing import Any
 
 from django.db.backends.base.base import BaseDatabaseWrapper
-from django.db.models import Aggregate, CharField, Expression
+from django.db.models import Aggregate
+from django.db.models import CharField
+from django.db.models import Expression
 from django.db.models.sql.compiler import SQLCompiler
 
 

--- a/src/django_mysql/models/expressions.py
+++ b/src/django_mysql/models/expressions.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from typing import Any, Iterable
+from typing import Any
+from typing import Iterable
 
 from django.db.backends.base.base import BaseDatabaseWrapper
-from django.db.models import F, Value
+from django.db.models import F
+from django.db.models import Value
 from django.db.models.expressions import BaseExpression
 from django.db.models.sql.compiler import SQLCompiler
 

--- a/src/django_mysql/models/fields/__init__.py
+++ b/src/django_mysql/models/fields/__init__.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
-from django_mysql.models.fields.bit import Bit1BooleanField, NullBit1BooleanField
+from django_mysql.models.fields.bit import Bit1BooleanField
+from django_mysql.models.fields.bit import NullBit1BooleanField
 from django_mysql.models.fields.dynamic import DynamicField
 from django_mysql.models.fields.enum import EnumField
 from django_mysql.models.fields.fixedchar import FixedCharField
-from django_mysql.models.fields.lists import ListCharField, ListTextField
-from django_mysql.models.fields.sets import SetCharField, SetTextField
-from django_mysql.models.fields.sizes import SizedBinaryField, SizedTextField
+from django_mysql.models.fields.lists import ListCharField
+from django_mysql.models.fields.lists import ListTextField
+from django_mysql.models.fields.sets import SetCharField
+from django_mysql.models.fields.sets import SetTextField
+from django_mysql.models.fields.sizes import SizedBinaryField
+from django_mysql.models.fields.sizes import SizedTextField
 
 __all__ = [
     "Bit1BooleanField",

--- a/src/django_mysql/models/fields/bit.py
+++ b/src/django_mysql/models/fields/bit.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from typing import Any
 
 from django.db.backends.base.base import BaseDatabaseWrapper
-from django.db.models import BooleanField, Expression, NullBooleanField
+from django.db.models import BooleanField
+from django.db.models import Expression
+from django.db.models import NullBooleanField
 
 
 class Bit1Mixin:

--- a/src/django_mysql/models/fields/dynamic.py
+++ b/src/django_mysql/models/fields/dynamic.py
@@ -2,21 +2,25 @@ from __future__ import annotations
 
 import datetime as dt
 import json
-from typing import Any, Callable, Dict, Iterable, Type, Union, cast
+from typing import Any
+from typing import Callable
+from typing import cast
+from typing import Dict
+from typing import Iterable
+from typing import Type
+from typing import Union
 
 from django.core import checks
 from django.db.backends.base.base import BaseDatabaseWrapper
-from django.db.models import (
-    DateField,
-    DateTimeField,
-    Expression,
-    Field,
-    FloatField,
-    IntegerField,
-    TextField,
-    TimeField,
-    Transform,
-)
+from django.db.models import DateField
+from django.db.models import DateTimeField
+from django.db.models import Expression
+from django.db.models import Field
+from django.db.models import FloatField
+from django.db.models import IntegerField
+from django.db.models import TextField
+from django.db.models import TimeField
+from django.db.models import Transform
 from django.db.models.sql.compiler import SQLCompiler
 from django.forms import Field as FormField
 from django.utils.translation import gettext_lazy as _

--- a/src/django_mysql/models/fields/enum.py
+++ b/src/django_mysql/models/fields/enum.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
+from typing import cast
 
 import django
 from django.db.backends.base.base import BaseDatabaseWrapper

--- a/src/django_mysql/models/fields/fixedchar.py
+++ b/src/django_mysql/models/fields/fixedchar.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
+from typing import cast
 
 from django.core import checks
 from django.db.backends.base.base import BaseDatabaseWrapper

--- a/src/django_mysql/models/fields/lists.py
+++ b/src/django_mysql/models/fields/lists.py
@@ -1,16 +1,25 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Iterable, cast
+from typing import Any
+from typing import Callable
+from typing import cast
+from typing import Iterable
 
 from django.core import checks
 from django.db.backends.base.base import BaseDatabaseWrapper
-from django.db.models import CharField, Field, IntegerField, Lookup, Model, TextField
+from django.db.models import CharField
+from django.db.models import Field
+from django.db.models import IntegerField
+from django.db.models import Lookup
+from django.db.models import Model
+from django.db.models import TextField
 from django.db.models.expressions import BaseExpression
 from django.forms import Field as FormField
 from django.utils.translation import gettext_lazy as _
 
 from django_mysql.forms import SimpleListField
-from django_mysql.models.lookups import SetContains, SetIContains
+from django_mysql.models.lookups import SetContains
+from django_mysql.models.lookups import SetIContains
 from django_mysql.models.transforms import SetLength
 from django_mysql.typing import DeconstructResult
 from django_mysql.validators import ListMaxLengthValidator

--- a/src/django_mysql/models/fields/sets.py
+++ b/src/django_mysql/models/fields/sets.py
@@ -1,16 +1,22 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
+from typing import cast
 
 from django.core import checks
 from django.db.backends.base.base import BaseDatabaseWrapper
-from django.db.models import CharField, Field, IntegerField, Model, TextField
+from django.db.models import CharField
+from django.db.models import Field
+from django.db.models import IntegerField
+from django.db.models import Model
+from django.db.models import TextField
 from django.db.models.expressions import BaseExpression
 from django.forms import Field as FormField
 from django.utils.translation import gettext_lazy as _
 
 from django_mysql.forms import SimpleSetField
-from django_mysql.models.lookups import SetContains, SetIContains
+from django_mysql.models.lookups import SetContains
+from django_mysql.models.lookups import SetIContains
 from django_mysql.models.transforms import SetLength
 from django_mysql.typing import DeconstructResult
 from django_mysql.validators import SetMaxLengthValidator

--- a/src/django_mysql/models/fields/sizes.py
+++ b/src/django_mysql/models/fields/sizes.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
+from typing import cast
 
 from django.core import checks
 from django.db.backends.base.base import BaseDatabaseWrapper
-from django.db.models import BinaryField, TextField
+from django.db.models import BinaryField
+from django.db.models import TextField
 
 from django_mysql.typing import DeconstructResult
 

--- a/src/django_mysql/models/functions.py
+++ b/src/django_mysql/models/functions.py
@@ -3,13 +3,20 @@ from __future__ import annotations
 import datetime as dt
 import json
 import warnings
-from typing import Any, Union
+from typing import Any
+from typing import Union
 
-from django.db import DEFAULT_DB_ALIAS, connections
+from django.db import connections
+from django.db import DEFAULT_DB_ALIAS
 from django.db.backends.base.base import BaseDatabaseWrapper
-from django.db.models import CharField, Expression
+from django.db.models import CharField
+from django.db.models import Expression
 from django.db.models import Field as DjangoField
-from django.db.models import Func, IntegerField, JSONField, TextField, Value
+from django.db.models import Func
+from django.db.models import IntegerField
+from django.db.models import JSONField
+from django.db.models import TextField
+from django.db.models import Value
 from django.db.models.sql.compiler import SQLCompiler
 
 ExpressionArgument = Union[

--- a/src/django_mysql/models/lookups.py
+++ b/src/django_mysql/models/lookups.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Iterable
+from typing import Any
+from typing import Callable
+from typing import Iterable
 
 from django.db.backends.base.base import BaseDatabaseWrapper
-from django.db.models import CharField, Lookup, Transform
+from django.db.models import CharField
+from django.db.models import Lookup
+from django.db.models import Transform
 from django.db.models.lookups import BuiltinLookup
 from django.db.models.sql.compiler import SQLCompiler
 

--- a/src/django_mysql/models/query.py
+++ b/src/django_mysql/models/query.py
@@ -7,10 +7,19 @@ import time
 from contextlib import nullcontext
 from copy import copy
 from functools import wraps
-from typing import Any, Callable, Dict, Generator, Optional, Tuple, TypeVar, Union, cast
+from typing import Any
+from typing import Callable
+from typing import cast
+from typing import Dict
+from typing import Generator
+from typing import Optional
+from typing import Tuple
+from typing import TypeVar
+from typing import Union
 
 from django.conf import settings
-from django.db import connections, models
+from django.db import connections
+from django.db import models
 from django.db.models.sql.where import ExtraWhere
 from django.db.transaction import atomic
 from django.test.utils import CaptureQueriesContext
@@ -20,12 +29,10 @@ from django.utils.translation import gettext as _
 from django_mysql.compat import cache
 from django_mysql.rewrite_query import REWRITE_MARKER
 from django_mysql.status import GlobalStatus
-from django_mysql.utils import (
-    StopWatch,
-    WeightedAverageRate,
-    format_duration,
-    settings_to_cmd_args,
-)
+from django_mysql.utils import format_duration
+from django_mysql.utils import settings_to_cmd_args
+from django_mysql.utils import StopWatch
+from django_mysql.utils import WeightedAverageRate
 
 _Q = TypeVar("_Q", bound="QuerySetMixin")
 QueryRewriteFunc = TypeVar("QueryRewriteFunc", bound=Callable[..., Any])

--- a/src/django_mysql/models/transforms.py
+++ b/src/django_mysql/models/transforms.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from typing import Any, Iterable
+from typing import Any
+from typing import Iterable
 
 from django.db.backends.base.base import BaseDatabaseWrapper
-from django.db.models import IntegerField, Transform
+from django.db.models import IntegerField
+from django.db.models import Transform
 from django.db.models.sql.compiler import SQLCompiler
 
 from django_mysql.utils import collapse_spaces

--- a/src/django_mysql/rewrite_query.py
+++ b/src/django_mysql/rewrite_query.py
@@ -3,7 +3,6 @@ Implements a function for hoisting specially constructed comments in SQL
 queries and using them to rewrite that query. This is done to support query
 hints whilst obviating patching Django's ORM in complex ways.
 """
-
 from __future__ import annotations
 
 import operator

--- a/src/django_mysql/typing.py
+++ b/src/django_mysql/typing.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, Tuple
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import Tuple
 
 DeconstructResult = Tuple[str, str, Iterable[Any], Dict[str, Any]]

--- a/src/django_mysql/utils.py
+++ b/src/django_mysql/utils.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import time
 from collections import defaultdict
 from types import TracebackType
-from typing import Any, Generator
+from typing import Any
+from typing import Generator
 
-from django.db import DEFAULT_DB_ALIAS, connections
+from django.db import connections
+from django.db import DEFAULT_DB_ALIAS
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models import Model
 

--- a/src/django_mysql/validators.py
+++ b/src/django_mysql/validators.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from django.core.validators import MaxLengthValidator, MinLengthValidator
+from django.core.validators import MaxLengthValidator
+from django.core.validators import MinLengthValidator
 from django.utils.translation import ngettext_lazy
 
 

--- a/tests/testapp/enum_default_migrations/0001_initial.py
+++ b/tests/testapp/enum_default_migrations/0001_initial.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from django.db import migrations, models
+from django.db import migrations
+from django.db import models
 
 from django_mysql.models import EnumField
 

--- a/tests/testapp/fixedchar_default_migrations/0001_initial.py
+++ b/tests/testapp/fixedchar_default_migrations/0001_initial.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from django.db import migrations, models
+from django.db import migrations
+from django.db import models
 
 from django_mysql.models import FixedCharField
 

--- a/tests/testapp/list_default_migrations/0001_initial.py
+++ b/tests/testapp/list_default_migrations/0001_initial.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from django.db import migrations, models
+from django.db import migrations
+from django.db import models
 
 from django_mysql.models import ListCharField
 

--- a/tests/testapp/list_default_migrations/0002_add_some_fields.py
+++ b/tests/testapp/list_default_migrations/0002_add_some_fields.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from django.db import migrations, models
+from django.db import migrations
+from django.db import models
 
 from django_mysql.models import ListCharField
 

--- a/tests/testapp/management/commands/test_dbparams.py
+++ b/tests/testapp/management/commands/test_dbparams.py
@@ -4,7 +4,8 @@ from io import StringIO
 from unittest import mock
 
 import pytest
-from django.core.management import CommandError, call_command
+from django.core.management import call_command
+from django.core.management import CommandError
 from django.db.utils import ConnectionHandler
 from django.test import SimpleTestCase
 

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -7,33 +7,30 @@ from typing import Any
 import django
 from django.core import checks
 from django.db import connection
-from django.db.models import (
-    CASCADE,
-    CharField,
-    DateTimeField,
-    DecimalField,
-    ForeignKey,
-    IntegerField,
-    JSONField,
-)
+from django.db.models import CASCADE
+from django.db.models import CharField
+from django.db.models import DateTimeField
+from django.db.models import DecimalField
+from django.db.models import ForeignKey
+from django.db.models import IntegerField
+from django.db.models import JSONField
 from django.db.models import Model as VanillaModel
-from django.db.models import OneToOneField, TextField
+from django.db.models import OneToOneField
+from django.db.models import TextField
 from django.utils import timezone
 
-from django_mysql.models import (
-    Bit1BooleanField,
-    DynamicField,
-    EnumField,
-    FixedCharField,
-    ListCharField,
-    ListTextField,
-    Model,
-    NullBit1BooleanField,
-    SetCharField,
-    SetTextField,
-    SizedBinaryField,
-    SizedTextField,
-)
+from django_mysql.models import Bit1BooleanField
+from django_mysql.models import DynamicField
+from django_mysql.models import EnumField
+from django_mysql.models import FixedCharField
+from django_mysql.models import ListCharField
+from django_mysql.models import ListTextField
+from django_mysql.models import Model
+from django_mysql.models import NullBit1BooleanField
+from django_mysql.models import SetCharField
+from django_mysql.models import SetTextField
+from django_mysql.models import SizedBinaryField
+from django_mysql.models import SizedTextField
 from tests.testapp.utils import conn_is_mysql
 
 

--- a/tests/testapp/set_default_migrations/0001_initial.py
+++ b/tests/testapp/set_default_migrations/0001_initial.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from django.db import migrations, models
+from django.db import migrations
+from django.db import models
 
 from django_mysql.models import SetCharField
 

--- a/tests/testapp/set_default_migrations/0002_add_some_fields.py
+++ b/tests/testapp/set_default_migrations/0002_add_some_fields.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from django.db import migrations, models
+from django.db import migrations
+from django.db import models
 
 from django_mysql.models import SetCharField
 

--- a/tests/testapp/sizedbinaryfield_migrations/0001_initial.py
+++ b/tests/testapp/sizedbinaryfield_migrations/0001_initial.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from django.db import migrations, models
+from django.db import migrations
+from django.db import models
 
 from django_mysql.models import SizedBinaryField
 

--- a/tests/testapp/sizedtextfield_migrations/0001_initial.py
+++ b/tests/testapp/sizedtextfield_migrations/0001_initial.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from django.db import migrations, models
+from django.db import migrations
+from django.db import models
 
 from django_mysql.models import SizedTextField
 

--- a/tests/testapp/test_aggregates.py
+++ b/tests/testapp/test_aggregates.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import pytest
-from django.db.models import F, TextField
+from django.db.models import F
+from django.db.models import TextField
 from django.test import TestCase
 
-from django_mysql.models import BitAnd, BitOr, BitXor, GroupConcat
+from django_mysql.models import BitAnd
+from django_mysql.models import BitOr
+from django_mysql.models import BitXor
+from django_mysql.models import GroupConcat
 from django_mysql.test.utils import override_mysql_variables
-from tests.testapp.models import Alphabet, Author
+from tests.testapp.models import Alphabet
+from tests.testapp.models import Author
 
 
 class BitAndTests(TestCase):

--- a/tests/testapp/test_bit1_field.py
+++ b/tests/testapp/test_bit1_field.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import json
 
 import django
-from django.core import checks, serializers
+from django.core import checks
+from django.core import serializers
 from django.db import models
 from django.db.models import F
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase
+from django.test import TestCase
 from django.test.utils import isolate_apps
 
 from django_mysql.models import NullBit1BooleanField

--- a/tests/testapp/test_cache.py
+++ b/tests/testapp/test_cache.py
@@ -9,18 +9,28 @@ from io import StringIO
 from typing import Any
 
 import pytest
-from django.core.cache import CacheKeyWarning, cache, caches
-from django.core.management import CommandError, call_command
-from django.db import IntegrityError, connection
+from django.core.cache import cache
+from django.core.cache import CacheKeyWarning
+from django.core.cache import caches
+from django.core.management import call_command
+from django.core.management import CommandError
+from django.db import connection
+from django.db import IntegrityError
 from django.db.migrations.state import ProjectState
 from django.http import HttpResponse
-from django.middleware.cache import FetchFromCacheMiddleware, UpdateCacheMiddleware
-from django.test import RequestFactory, TestCase, TransactionTestCase
+from django.middleware.cache import FetchFromCacheMiddleware
+from django.middleware.cache import UpdateCacheMiddleware
+from django.test import RequestFactory
+from django.test import TestCase
+from django.test import TransactionTestCase
 from django.test.utils import override_settings
 from parameterized import parameterized
 
-from django_mysql.cache import BIGINT_SIGNED_MAX, BIGINT_SIGNED_MIN, MySQLCache
-from tests.testapp.models import Poll, expensive_calculation
+from django_mysql.cache import BIGINT_SIGNED_MAX
+from django_mysql.cache import BIGINT_SIGNED_MIN
+from django_mysql.cache import MySQLCache
+from tests.testapp.models import expensive_calculation
+from tests.testapp.models import Poll
 
 
 # functions/classes for complex data type tests

--- a/tests/testapp/test_checks.py
+++ b/tests/testapp/test_checks.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django.core.management import call_command
-from django.test import TestCase, TransactionTestCase
+from django.test import TestCase
+from django.test import TransactionTestCase
 
 from django_mysql.checks import check_variables
 from django_mysql.test.utils import override_mysql_variables

--- a/tests/testapp/test_dynamicfield.py
+++ b/tests/testapp/test_dynamicfield.py
@@ -2,21 +2,26 @@ from __future__ import annotations
 
 import datetime as dt
 import json
-from unittest import SkipTest, mock
+from unittest import mock
+from unittest import SkipTest
 
 import mariadb_dyncol
 import pytest
 from django.core import serializers
 from django.core.exceptions import FieldError
-from django.db import connection, connections, models
+from django.db import connection
+from django.db import connections
+from django.db import models
 from django.db.migrations.writer import MigrationWriter
-from django.db.models import CharField, Transform
+from django.db.models import CharField
+from django.db.models import Transform
 from django.test import TestCase
 from django.test.utils import isolate_apps
 
 from django_mysql.models import DynamicField
 from django_mysql.models.fields.dynamic import KeyTransform
-from tests.testapp.models import DynamicModel, SpeclessDynamicModel
+from tests.testapp.models import DynamicModel
+from tests.testapp.models import SpeclessDynamicModel
 
 
 class DynColTestCase(TestCase):

--- a/tests/testapp/test_enumfield.py
+++ b/tests/testapp/test_enumfield.py
@@ -3,13 +3,17 @@ from __future__ import annotations
 import pytest
 from django.core.exceptions import ValidationError
 from django.core.management import call_command
-from django.db import connection, models
+from django.db import connection
+from django.db import models
 from django.db.utils import DataError
-from django.test import TestCase, TransactionTestCase, override_settings
+from django.test import override_settings
+from django.test import TestCase
+from django.test import TransactionTestCase
 from django.test.utils import isolate_apps
 
 from django_mysql.models import EnumField
-from tests.testapp.models import EnumModel, NullableEnumModel
+from tests.testapp.models import EnumModel
+from tests.testapp.models import NullableEnumModel
 
 
 class TestEnumField(TestCase):

--- a/tests/testapp/test_fixedcharfield.py
+++ b/tests/testapp/test_fixedcharfield.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 import pytest
 from django.core.management import call_command
-from django.db import connection, models
+from django.db import connection
+from django.db import models
 from django.db.utils import DataError
-from django.test import SimpleTestCase, TestCase, TransactionTestCase, override_settings
+from django.test import override_settings
+from django.test import SimpleTestCase
+from django.test import TestCase
+from django.test import TransactionTestCase
 from django.test.utils import isolate_apps
 
 from django_mysql.models import FixedCharField

--- a/tests/testapp/test_forms.py
+++ b/tests/testapp/test_forms.py
@@ -5,7 +5,8 @@ from django import forms
 from django.core import exceptions
 from django.test import SimpleTestCase
 
-from django_mysql.forms import SimpleListField, SimpleSetField
+from django_mysql.forms import SimpleListField
+from django_mysql.forms import SimpleSetField
 
 
 class TestSimpleListField(SimpleTestCase):

--- a/tests/testapp/test_functions.py
+++ b/tests/testapp/test_functions.py
@@ -5,39 +5,46 @@ from unittest import SkipTest
 
 import pytest
 from django.db import connection
-from django.db.models import F, FloatField, IntegerField, Q, Value
-from django.db.models.functions import Length, Lower, Upper
+from django.db.models import F
+from django.db.models import FloatField
+from django.db.models import IntegerField
+from django.db.models import Q
+from django.db.models import Value
+from django.db.models.functions import Length
+from django.db.models.functions import Lower
+from django.db.models.functions import Upper
 from django.test import TestCase
 
-from django_mysql.models.functions import (
-    CRC32,
-    ELT,
-    MD5,
-    SHA1,
-    SHA2,
-    AsType,
-    ColumnAdd,
-    ColumnDelete,
-    ColumnGet,
-    ConcatWS,
-    Field,
-    If,
-    JSONArrayAppend,
-    JSONExtract,
-    JSONInsert,
-    JSONKeys,
-    JSONLength,
-    JSONReplace,
-    JSONSet,
-    LastInsertId,
-    RegexpInstr,
-    RegexpReplace,
-    RegexpSubstr,
-    Sign,
-    UpdateXML,
-    XMLExtractValue,
-)
-from tests.testapp.models import Alphabet, Author, DynamicModel, JSONModel
+from django_mysql.models.functions import AsType
+from django_mysql.models.functions import ColumnAdd
+from django_mysql.models.functions import ColumnDelete
+from django_mysql.models.functions import ColumnGet
+from django_mysql.models.functions import ConcatWS
+from django_mysql.models.functions import CRC32
+from django_mysql.models.functions import ELT
+from django_mysql.models.functions import Field
+from django_mysql.models.functions import If
+from django_mysql.models.functions import JSONArrayAppend
+from django_mysql.models.functions import JSONExtract
+from django_mysql.models.functions import JSONInsert
+from django_mysql.models.functions import JSONKeys
+from django_mysql.models.functions import JSONLength
+from django_mysql.models.functions import JSONReplace
+from django_mysql.models.functions import JSONSet
+from django_mysql.models.functions import LastInsertId
+from django_mysql.models.functions import MD5
+from django_mysql.models.functions import RegexpInstr
+from django_mysql.models.functions import RegexpReplace
+from django_mysql.models.functions import RegexpSubstr
+from django_mysql.models.functions import SHA1
+from django_mysql.models.functions import SHA2
+from django_mysql.models.functions import Sign
+from django_mysql.models.functions import UpdateXML
+from django_mysql.models.functions import XMLExtractValue
+from tests.testapp.models import Alphabet
+from tests.testapp.models import Author
+from tests.testapp.models import DynamicModel
+from tests.testapp.models import JSONModel
 from tests.testapp.test_dynamicfield import DynColTestCase
 from tests.testapp.utils import print_all_queries
 

--- a/tests/testapp/test_listcharfield.py
+++ b/tests/testapp/test_listcharfield.py
@@ -5,18 +5,27 @@ import re
 
 import pytest
 from django import forms
-from django.core import exceptions, serializers
+from django.core import exceptions
+from django.core import serializers
 from django.core.management import call_command
-from django.db import connection, models
+from django.db import connection
+from django.db import models
 from django.db.migrations.writer import MigrationWriter
-from django.db.models import Q, Value
-from django.test import SimpleTestCase, TestCase, TransactionTestCase, override_settings
+from django.db.models import Q
+from django.db.models import Value
+from django.test import override_settings
+from django.test import SimpleTestCase
+from django.test import TestCase
+from django.test import TransactionTestCase
 from django.test.utils import isolate_apps
 
 from django_mysql.forms import SimpleListField
-from django_mysql.models import ListCharField, ListF
+from django_mysql.models import ListCharField
+from django_mysql.models import ListF
 from django_mysql.test.utils import override_mysql_variables
-from tests.testapp.models import CharListDefaultModel, CharListModel, IntListModel
+from tests.testapp.models import CharListDefaultModel
+from tests.testapp.models import CharListModel
+from tests.testapp.models import IntListModel
 
 
 class TestSaveLoad(TestCase):

--- a/tests/testapp/test_listtextfield.py
+++ b/tests/testapp/test_listtextfield.py
@@ -5,16 +5,19 @@ import re
 
 import pytest
 from django import forms
-from django.core import exceptions, serializers
+from django.core import exceptions
+from django.core import serializers
 from django.db import models
 from django.db.migrations.writer import MigrationWriter
 from django.db.models import Q
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase
+from django.test import TestCase
 from django.test.utils import isolate_apps
 
 from django_mysql.forms import SimpleListField
 from django_mysql.models import ListTextField
-from tests.testapp.models import BigCharListModel, BigIntListModel
+from tests.testapp.models import BigCharListModel
+from tests.testapp.models import BigIntListModel
 
 
 class TestSaveLoad(TestCase):

--- a/tests/testapp/test_locks.py
+++ b/tests/testapp/test_locks.py
@@ -5,20 +5,23 @@ from threading import Thread
 from typing import TYPE_CHECKING
 
 import pytest
-from django.db import OperationalError, connection, connections
-from django.db.transaction import TransactionManagementError, atomic
-from django.test import TestCase, TransactionTestCase
+from django.db import connection
+from django.db import connections
+from django.db import OperationalError
+from django.db.transaction import atomic
+from django.db.transaction import TransactionManagementError
+from django.test import TestCase
+from django.test import TransactionTestCase
 
 from django_mysql.exceptions import TimeoutError
-from django_mysql.locks import Lock, TableLock
+from django_mysql.locks import Lock
+from django_mysql.locks import TableLock
 from django_mysql.models import Model
-from tests.testapp.models import (
-    AgedCustomer,
-    Alphabet,
-    Customer,
-    ProxyAlphabet,
-    TitledAgedCustomer,
-)
+from tests.testapp.models import AgedCustomer
+from tests.testapp.models import Alphabet
+from tests.testapp.models import Customer
+from tests.testapp.models import ProxyAlphabet
+from tests.testapp.models import TitledAgedCustomer
 
 
 class LockTests(TestCase):

--- a/tests/testapp/test_models.py
+++ b/tests/testapp/test_models.py
@@ -3,29 +3,36 @@ from __future__ import annotations
 import pickle
 import re
 import shutil
-from unittest import SkipTest, mock
+from unittest import mock
+from unittest import SkipTest
 
 import pytest
 from django.contrib.contenttypes.models import ContentType
-from django.db import DEFAULT_DB_ALIAS, connections
-from django.db.models import Exists, OuterRef
+from django.db import connections
+from django.db import DEFAULT_DB_ALIAS
+from django.db.models import Exists
+from django.db.models import OuterRef
 from django.db.models.query import QuerySet
-from django.template import Context, Template
+from django.template import Context
+from django.template import Template
 from django.test import TestCase
-from django.test.utils import captured_stdout, override_settings
+from django.test.utils import captured_stdout
+from django.test.utils import override_settings
 
-from django_mysql.models import ApproximateInt, SmartIterator, add_QuerySetMixin
+from django_mysql.models import add_QuerySetMixin
+from django_mysql.models import ApproximateInt
+from django_mysql.models import SmartIterator
 from django_mysql.utils import index_name
-from tests.testapp.models import (
-    Author,
-    AuthorExtra,
-    AuthorMultiIndex,
-    Book,
-    NameAuthor,
-    NameAuthorExtra,
-    VanillaAuthor,
-)
-from tests.testapp.utils import CaptureLastQuery, skip_if_mysql_8_plus, used_indexes
+from tests.testapp.models import Author
+from tests.testapp.models import AuthorExtra
+from tests.testapp.models import AuthorMultiIndex
+from tests.testapp.models import Book
+from tests.testapp.models import NameAuthor
+from tests.testapp.models import NameAuthorExtra
+from tests.testapp.models import VanillaAuthor
+from tests.testapp.utils import CaptureLastQuery
+from tests.testapp.utils import skip_if_mysql_8_plus
+from tests.testapp.utils import used_indexes
 
 
 class MixinQuerysetTests(TestCase):

--- a/tests/testapp/test_operations.py
+++ b/tests/testapp/test_operations.py
@@ -3,13 +3,18 @@ from __future__ import annotations
 from unittest import SkipTest
 
 import pytest
-from django.db import connection, migrations, models, transaction
+from django.db import connection
+from django.db import migrations
+from django.db import models
+from django.db import transaction
 from django.db.migrations.operations.base import Operation
 from django.db.migrations.state import ProjectState
 from django.test import TransactionTestCase
 from django.test.utils import CaptureQueriesContext
 
-from django_mysql.operations import AlterStorageEngine, InstallPlugin, InstallSOName
+from django_mysql.operations import AlterStorageEngine
+from django_mysql.operations import InstallPlugin
+from django_mysql.operations import InstallSOName
 from django_mysql.test.utils import override_mysql_variables
 from tests.testapp.utils import conn_is_mysql
 

--- a/tests/testapp/test_setcharfield.py
+++ b/tests/testapp/test_setcharfield.py
@@ -5,18 +5,27 @@ import re
 
 import pytest
 from django import forms
-from django.core import exceptions, serializers
+from django.core import exceptions
+from django.core import serializers
 from django.core.management import call_command
-from django.db import connection, models
+from django.db import connection
+from django.db import models
 from django.db.migrations.writer import MigrationWriter
-from django.db.models import Q, Value
-from django.test import SimpleTestCase, TestCase, TransactionTestCase, override_settings
+from django.db.models import Q
+from django.db.models import Value
+from django.test import override_settings
+from django.test import SimpleTestCase
+from django.test import TestCase
+from django.test import TransactionTestCase
 from django.test.utils import isolate_apps
 
 from django_mysql.forms import SimpleSetField
-from django_mysql.models import SetCharField, SetF
+from django_mysql.models import SetCharField
+from django_mysql.models import SetF
 from django_mysql.test.utils import override_mysql_variables
-from tests.testapp.models import CharSetDefaultModel, CharSetModel, IntSetModel
+from tests.testapp.models import CharSetDefaultModel
+from tests.testapp.models import CharSetModel
+from tests.testapp.models import IntSetModel
 
 
 class TestSaveLoad(TestCase):

--- a/tests/testapp/test_settextfield.py
+++ b/tests/testapp/test_settextfield.py
@@ -4,16 +4,19 @@ import json
 
 import pytest
 from django import forms
-from django.core import exceptions, serializers
+from django.core import exceptions
+from django.core import serializers
 from django.db import models
 from django.db.migrations.writer import MigrationWriter
 from django.db.models import Q
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase
+from django.test import TestCase
 from django.test.utils import isolate_apps
 
 from django_mysql.forms import SimpleSetField
 from django_mysql.models import SetTextField
-from tests.testapp.models import BigCharSetModel, BigIntSetModel
+from tests.testapp.models import BigCharSetModel
+from tests.testapp.models import BigIntSetModel
 
 
 class TestSaveLoad(TestCase):

--- a/tests/testapp/test_size_fields.py
+++ b/tests/testapp/test_size_fields.py
@@ -2,14 +2,18 @@ from __future__ import annotations
 
 import pytest
 from django.core.management import call_command
-from django.db import connection, models
+from django.db import connection
+from django.db import models
 from django.db.migrations.writer import MigrationWriter
 from django.db.transaction import atomic
 from django.db.utils import DataError
-from django.test import TestCase, TransactionTestCase
-from django.test.utils import isolate_apps, override_settings
+from django.test import TestCase
+from django.test import TransactionTestCase
+from django.test.utils import isolate_apps
+from django.test.utils import override_settings
 
-from django_mysql.models import SizedBinaryField, SizedTextField
+from django_mysql.models import SizedBinaryField
+from django_mysql.models import SizedTextField
 from django_mysql.test.utils import override_mysql_variables
 from tests.testapp.models import SizeFieldModel
 from tests.testapp.utils import column_type

--- a/tests/testapp/test_status.py
+++ b/tests/testapp/test_status.py
@@ -4,12 +4,10 @@ import pytest
 from django.test import TestCase
 
 from django_mysql.exceptions import TimeoutError
-from django_mysql.status import (
-    GlobalStatus,
-    SessionStatus,
-    global_status,
-    session_status,
-)
+from django_mysql.status import global_status
+from django_mysql.status import GlobalStatus
+from django_mysql.status import session_status
+from django_mysql.status import SessionStatus
 
 
 class BaseStatusTests(TestCase):

--- a/tests/testapp/test_utils.py
+++ b/tests/testapp/test_utils.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import pytest
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase
+from django.test import TestCase
 
-from django_mysql.utils import WeightedAverageRate, format_duration, index_name
-from tests.testapp.models import Author, AuthorMultiIndex
+from django_mysql.utils import format_duration
+from django_mysql.utils import index_name
+from django_mysql.utils import WeightedAverageRate
+from tests.testapp.models import Author
+from tests.testapp.models import AuthorMultiIndex
 
 
 class WeightedAverageRateTests(SimpleTestCase):

--- a/tests/testapp/utils.py
+++ b/tests/testapp/utils.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import sys
 from contextlib import contextmanager
 from types import TracebackType
-from typing import Any, Generator
+from typing import Any
+from typing import Generator
 
 import pytest
-from django.db import DEFAULT_DB_ALIAS, connection, connections
+from django.db import connection
+from django.db import connections
+from django.db import DEFAULT_DB_ALIAS
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.backends.mysql.base import DatabaseWrapper as MySQLDatabaseWrapper
 from django.db.backends.utils import CursorWrapper


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
