### PR TITLE
Added support for NATURAL_SORT_KEY with MariaDB

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* Added support for NATURAL_SORT_KEY with MariaDB:10.7.0+
+
 4.10.0 (2023-06-16)
 -------------------
 

--- a/docs/database_functions.rst
+++ b/docs/database_functions.rst
@@ -135,6 +135,33 @@ String Functions
         >>> # Females, then males - but other values of gender (e.g. empty string) first
         >>> Person.objects.all().order_by(Field("gender", ["Female", "Male"]))
 
+.. class:: NaturalSortKey(expression)
+
+    .. note::
+        This works with MariaDB 10.7.0+ only. It is not supported by MySQL.
+        More information can be found in `its release notes
+        <https://mariadb.com/kb/en/mariadb-1070-release-notes/#natural-sort>`_.
+
+    Given an ``expression``, the NaturalSortKey function can be used for
+    sorting that is closer to natural sorting, providing a more intuitive
+    ordering. Strings are sorted in alphabetical order, while numbers are
+    treated in a way such that, for example, ``10`` is greater than ``2``,
+    whereas in other forms of sorting, ``2`` would be greater than ``10``,
+    just like ``z`` is greater than ``ya``.
+
+    Note that MariaDB's implementation ignores leading zeroes when performing the sort.
+
+    Docs:
+    `MariaDB <https://mariadb.com/kb/en/natural_sort_key/>`__.
+
+    Usage example:
+
+    .. code-block:: pycon
+
+        >>> # if your database contains strings ["a1", "a10", "a2"]
+        >>> Items.objects.order_by(NaturalSortKey("name"))
+        ["a1", "a2", "a10"]
+
 
 XML Functions
 -------------

--- a/src/django_mysql/models/functions.py
+++ b/src/django_mysql/models/functions.py
@@ -129,7 +129,7 @@ class NaturalSortKey(Func):
         self,
         compiler: SQLCompiler,
         connection: BaseDatabaseWrapper,
-        **extra_context,
+        **extra_context: dict[str, Any],
     ) -> tuple[str, tuple[Any, ...]]:
         if connection.vendor == "mysql" and not connection.mysql_is_mariadb:
             raise AssertionError("NATURAL_SORT_KEY is not supported by MySQL")

--- a/tests/testapp/test_functions.py
+++ b/tests/testapp/test_functions.py
@@ -6,7 +6,8 @@ import pytest
 from django.db import connection
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.backends.mysql.compiler import SQLCompiler
-from django.db.models import F, Expression
+from django.db.models import Expression
+from django.db.models import F
 from django.db.models import FloatField
 from django.db.models import IntegerField
 from django.db.models import Q


### PR DESCRIPTION
Fixes #975

This PR adds support for MariaDB's NATURAL_SORT_KEY. It has been implemented as a database function.

```Alphabet.objects.order_by(NaturalSortKey("d"))```