### PR TITLE
Use isort to sort imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,16 +52,11 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==23.1.0
-- repo: https://github.com/asottile/reorder-python-imports
-  rev: v3.12.0
+- repo: https://github.com/pycqa/isort
+  rev: 5.13.2
   hooks:
-  - id: reorder-python-imports
-    args:
-    - --py38-plus
-    - --application-directories
-    - .:example:src
-    - --add-import
-    - 'from __future__ import annotations'
+    - id: isort
+      name: isort (python)
 - repo: https://github.com/PyCQA/flake8
   rev: 7.0.0
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,13 @@ Repository = "https://github.com/adamchainz/django-mysql"
 [tool.black]
 target-version = ['py38']
 
+[tool.isort]
+add_imports = [
+    "from __future__ import annotations"
+]
+force_single_line = true
+profile = "black"
+
 [tool.pytest.ini_options]
 addopts = """\
     --strict-config

--- a/src/django_mysql/apps.py
+++ b/src/django_mysql/apps.py
@@ -34,9 +34,12 @@ class MySQLConfig(AppConfig):
         connection_created.connect(install_rewrite_hook)
 
     def add_lookups(self) -> None:
-        from django.db.models import CharField, TextField
+        from django.db.models import CharField
+        from django.db.models import TextField
 
-        from django_mysql.models.lookups import CaseSensitiveExact, Soundex, SoundsLike
+        from django_mysql.models.lookups import CaseSensitiveExact
+        from django_mysql.models.lookups import Soundex
+        from django_mysql.models.lookups import SoundsLike
 
         CharField.register_lookup(CaseSensitiveExact)
         CharField.register_lookup(SoundsLike)

--- a/src/django_mysql/cache.py
+++ b/src/django_mysql/cache.py
@@ -9,14 +9,14 @@ from textwrap import dedent
 from time import time
 from typing import Any
 from typing import Callable
-from typing import cast
 from typing import Iterable
 from typing import Literal
 from typing import Tuple
+from typing import cast
 
+from django.core.cache.backends.base import DEFAULT_TIMEOUT
 from django.core.cache.backends.base import BaseCache
 from django.core.cache.backends.base import default_key_func
-from django.core.cache.backends.base import DEFAULT_TIMEOUT
 from django.db import connections
 from django.db import router
 from django.utils.encoding import force_bytes

--- a/src/django_mysql/compat.py
+++ b/src/django_mysql/compat.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import sys
 from typing import Any
 from typing import Callable
-from typing import cast
 from typing import TypeVar
+from typing import cast
 
 if sys.version_info >= (3, 9):
     from functools import cache

--- a/src/django_mysql/locks.py
+++ b/src/django_mysql/locks.py
@@ -6,8 +6,8 @@ from types import TracebackType
 from django.db import connections
 from django.db.backends.utils import CursorWrapper
 from django.db.models import Model
-from django.db.transaction import atomic
 from django.db.transaction import TransactionManagementError
+from django.db.transaction import atomic
 from django.db.utils import DEFAULT_DB_ALIAS
 
 from django_mysql.exceptions import TimeoutError

--- a/src/django_mysql/management/commands/cull_mysql_caches.py
+++ b/src/django_mysql/management/commands/cull_mysql_caches.py
@@ -4,8 +4,8 @@ import argparse
 from typing import Any
 
 from django.conf import settings
-from django.core.cache import caches
 from django.core.cache import InvalidCacheBackendError
+from django.core.cache import caches
 from django.core.management import BaseCommand
 from django.core.management import CommandError
 

--- a/src/django_mysql/management/commands/dbparams.py
+++ b/src/django_mysql/management/commands/dbparams.py
@@ -5,8 +5,8 @@ from typing import Any
 
 from django.core.management import BaseCommand
 from django.core.management import CommandError
-from django.db import connections
 from django.db import DEFAULT_DB_ALIAS
+from django.db import connections
 from django.db.utils import ConnectionDoesNotExist
 
 from django_mysql.utils import settings_to_cmd_args

--- a/src/django_mysql/management/commands/mysql_cache_migration.py
+++ b/src/django_mysql/management/commands/mysql_cache_migration.py
@@ -4,8 +4,8 @@ import argparse
 from typing import Any
 
 from django.conf import settings
-from django.core.cache import caches
 from django.core.cache import InvalidCacheBackendError
+from django.core.cache import caches
 from django.core.management import BaseCommand
 from django.core.management import CommandError
 

--- a/src/django_mysql/models/__init__.py
+++ b/src/django_mysql/models/__init__.py
@@ -18,10 +18,10 @@ from django_mysql.models.fields import SetCharField
 from django_mysql.models.fields import SetTextField
 from django_mysql.models.fields import SizedBinaryField
 from django_mysql.models.fields import SizedTextField
-from django_mysql.models.query import add_QuerySetMixin
 from django_mysql.models.query import ApproximateInt
-from django_mysql.models.query import pt_visual_explain
 from django_mysql.models.query import QuerySet
 from django_mysql.models.query import QuerySetMixin
 from django_mysql.models.query import SmartChunkedIterator
 from django_mysql.models.query import SmartIterator
+from django_mysql.models.query import add_QuerySetMixin
+from django_mysql.models.query import pt_visual_explain

--- a/src/django_mysql/models/fields/dynamic.py
+++ b/src/django_mysql/models/fields/dynamic.py
@@ -4,11 +4,11 @@ import datetime as dt
 import json
 from typing import Any
 from typing import Callable
-from typing import cast
 from typing import Dict
 from typing import Iterable
 from typing import Type
 from typing import Union
+from typing import cast
 
 from django.core import checks
 from django.db.backends.base.base import BaseDatabaseWrapper

--- a/src/django_mysql/models/fields/lists.py
+++ b/src/django_mysql/models/fields/lists.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 from typing import Callable
-from typing import cast
 from typing import Iterable
+from typing import cast
 
 from django.core import checks
 from django.db.backends.base.base import BaseDatabaseWrapper

--- a/src/django_mysql/models/functions.py
+++ b/src/django_mysql/models/functions.py
@@ -5,8 +5,8 @@ import json
 from typing import Any
 from typing import Union
 
-from django.db import connections
 from django.db import DEFAULT_DB_ALIAS
+from django.db import connections
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models import CharField
 from django.db.models import Expression
@@ -439,7 +439,8 @@ class ColumnGet(Func):
         column_name: ExpressionArgument,
         data_type: str,
     ):
-        from django_mysql.models.fields.dynamic import DynamicField, KeyTransform
+        from django_mysql.models.fields.dynamic import DynamicField
+        from django_mysql.models.fields.dynamic import KeyTransform
 
         if not hasattr(column_name, "resolve_expression"):
             column_name = Value(column_name)

--- a/src/django_mysql/models/query.py
+++ b/src/django_mysql/models/query.py
@@ -9,7 +9,6 @@ from copy import copy
 from functools import wraps
 from typing import Any
 from typing import Callable
-from typing import cast
 from typing import Generator
 from typing import Literal
 from typing import Optional
@@ -17,6 +16,7 @@ from typing import Tuple
 from typing import TypedDict
 from typing import TypeVar
 from typing import Union
+from typing import cast
 
 from django.conf import settings
 from django.db import connections
@@ -30,10 +30,10 @@ from django.utils.translation import gettext as _
 from django_mysql.compat import cache
 from django_mysql.rewrite_query import REWRITE_MARKER
 from django_mysql.status import GlobalStatus
-from django_mysql.utils import format_duration
-from django_mysql.utils import settings_to_cmd_args
 from django_mysql.utils import StopWatch
 from django_mysql.utils import WeightedAverageRate
+from django_mysql.utils import format_duration
+from django_mysql.utils import settings_to_cmd_args
 
 _Q = TypeVar("_Q", bound="QuerySetMixin")
 QueryRewriteFunc = TypeVar("QueryRewriteFunc", bound=Callable[..., Any])

--- a/src/django_mysql/utils.py
+++ b/src/django_mysql/utils.py
@@ -6,8 +6,8 @@ from types import TracebackType
 from typing import Any
 from typing import Generator
 
-from django.db import connections
 from django.db import DEFAULT_DB_ALIAS
+from django.db import connections
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models import Model
 

--- a/tests/testapp/management/commands/test_dbparams.py
+++ b/tests/testapp/management/commands/test_dbparams.py
@@ -4,8 +4,8 @@ from io import StringIO
 from unittest import mock
 
 import pytest
-from django.core.management import call_command
 from django.core.management import CommandError
+from django.core.management import call_command
 from django.db.utils import ConnectionHandler
 from django.test import SimpleTestCase
 

--- a/tests/testapp/test_cache.py
+++ b/tests/testapp/test_cache.py
@@ -9,13 +9,13 @@ from io import StringIO
 from typing import Any
 
 import pytest
-from django.core.cache import cache
 from django.core.cache import CacheKeyWarning
+from django.core.cache import cache
 from django.core.cache import caches
-from django.core.management import call_command
 from django.core.management import CommandError
-from django.db import connection
+from django.core.management import call_command
 from django.db import IntegrityError
+from django.db import connection
 from django.db.migrations.state import ProjectState
 from django.http import HttpResponse
 from django.middleware.cache import FetchFromCacheMiddleware
@@ -29,8 +29,8 @@ from parameterized import parameterized
 from django_mysql.cache import BIGINT_SIGNED_MAX
 from django_mysql.cache import BIGINT_SIGNED_MIN
 from django_mysql.cache import MySQLCache
-from tests.testapp.models import expensive_calculation
 from tests.testapp.models import Poll
+from tests.testapp.models import expensive_calculation
 
 
 # functions/classes for complex data type tests
@@ -325,7 +325,8 @@ class MySQLCacheTests(MySQLCacheTableMixin, TestCase):
 
     def test_binary_string(self):
         # Binary strings should be cacheable
-        from zlib import compress, decompress
+        from zlib import compress
+        from zlib import decompress
 
         value = "value_to_be_compressed"
         compressed_value = compress(value.encode())

--- a/tests/testapp/test_dynamicfield.py
+++ b/tests/testapp/test_dynamicfield.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import datetime as dt
 import json
-from unittest import mock
 from unittest import SkipTest
+from unittest import mock
 
 import mariadb_dyncol
 import pytest

--- a/tests/testapp/test_enumfield.py
+++ b/tests/testapp/test_enumfield.py
@@ -6,9 +6,9 @@ from django.core.management import call_command
 from django.db import connection
 from django.db import models
 from django.db.utils import DataError
-from django.test import override_settings
 from django.test import TestCase
 from django.test import TransactionTestCase
+from django.test import override_settings
 from django.test.utils import isolate_apps
 
 from django_mysql.models import EnumField

--- a/tests/testapp/test_fixedcharfield.py
+++ b/tests/testapp/test_fixedcharfield.py
@@ -5,10 +5,10 @@ from django.core.management import call_command
 from django.db import connection
 from django.db import models
 from django.db.utils import DataError
-from django.test import override_settings
 from django.test import SimpleTestCase
 from django.test import TestCase
 from django.test import TransactionTestCase
+from django.test import override_settings
 from django.test.utils import isolate_apps
 
 from django_mysql.models import FixedCharField

--- a/tests/testapp/test_functions.py
+++ b/tests/testapp/test_functions.py
@@ -14,13 +14,13 @@ from django.db.models.functions import Lower
 from django.db.models.functions import Upper
 from django.test import TestCase
 
+from django_mysql.models.functions import CRC32
+from django_mysql.models.functions import ELT
 from django_mysql.models.functions import AsType
 from django_mysql.models.functions import ColumnAdd
 from django_mysql.models.functions import ColumnDelete
 from django_mysql.models.functions import ColumnGet
 from django_mysql.models.functions import ConcatWS
-from django_mysql.models.functions import CRC32
-from django_mysql.models.functions import ELT
 from django_mysql.models.functions import Field
 from django_mysql.models.functions import If
 from django_mysql.models.functions import JSONArrayAppend

--- a/tests/testapp/test_listcharfield.py
+++ b/tests/testapp/test_listcharfield.py
@@ -13,10 +13,10 @@ from django.db import models
 from django.db.migrations.writer import MigrationWriter
 from django.db.models import Q
 from django.db.models import Value
-from django.test import override_settings
 from django.test import SimpleTestCase
 from django.test import TestCase
 from django.test import TransactionTestCase
+from django.test import override_settings
 from django.test.utils import isolate_apps
 
 from django_mysql.forms import SimpleListField

--- a/tests/testapp/test_locks.py
+++ b/tests/testapp/test_locks.py
@@ -5,11 +5,11 @@ from threading import Thread
 from typing import TYPE_CHECKING
 
 import pytest
+from django.db import OperationalError
 from django.db import connection
 from django.db import connections
-from django.db import OperationalError
-from django.db.transaction import atomic
 from django.db.transaction import TransactionManagementError
+from django.db.transaction import atomic
 from django.test import TestCase
 from django.test import TransactionTestCase
 

--- a/tests/testapp/test_models.py
+++ b/tests/testapp/test_models.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import pickle
 import re
 import shutil
-from unittest import mock
 from unittest import SkipTest
+from unittest import mock
 
 import pytest
 from django.contrib.contenttypes.models import ContentType
-from django.db import connections
 from django.db import DEFAULT_DB_ALIAS
+from django.db import connections
 from django.db.models import Exists
 from django.db.models import OuterRef
 from django.db.models.query import QuerySet
@@ -19,9 +19,9 @@ from django.test import TestCase
 from django.test.utils import captured_stdout
 from django.test.utils import override_settings
 
-from django_mysql.models import add_QuerySetMixin
 from django_mysql.models import ApproximateInt
 from django_mysql.models import SmartIterator
+from django_mysql.models import add_QuerySetMixin
 from django_mysql.utils import index_name
 from tests.testapp.models import Author
 from tests.testapp.models import AuthorExtra

--- a/tests/testapp/test_setcharfield.py
+++ b/tests/testapp/test_setcharfield.py
@@ -15,10 +15,10 @@ from django.db.models import Q
 from django.db.models import Value
 from django.db.models.functions import Concat
 from django.db.models.functions import Upper
-from django.test import override_settings
 from django.test import SimpleTestCase
 from django.test import TestCase
 from django.test import TransactionTestCase
+from django.test import override_settings
 from django.test.utils import isolate_apps
 
 from django_mysql.forms import SimpleSetField

--- a/tests/testapp/test_status.py
+++ b/tests/testapp/test_status.py
@@ -4,10 +4,10 @@ import pytest
 from django.test import TestCase
 
 from django_mysql.exceptions import TimeoutError
-from django_mysql.status import global_status
 from django_mysql.status import GlobalStatus
-from django_mysql.status import session_status
 from django_mysql.status import SessionStatus
+from django_mysql.status import global_status
+from django_mysql.status import session_status
 
 
 class BaseStatusTests(TestCase):

--- a/tests/testapp/test_utils.py
+++ b/tests/testapp/test_utils.py
@@ -4,9 +4,9 @@ import pytest
 from django.test import SimpleTestCase
 from django.test import TestCase
 
+from django_mysql.utils import WeightedAverageRate
 from django_mysql.utils import format_duration
 from django_mysql.utils import index_name
-from django_mysql.utils import WeightedAverageRate
 from tests.testapp.models import Author
 from tests.testapp.models import AuthorMultiIndex
 

--- a/tests/testapp/utils.py
+++ b/tests/testapp/utils.py
@@ -7,9 +7,9 @@ from typing import Any
 from typing import Generator
 
 import pytest
+from django.db import DEFAULT_DB_ALIAS
 from django.db import connection
 from django.db import connections
-from django.db import DEFAULT_DB_ALIAS
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.backends.mysql.base import DatabaseWrapper as MySQLDatabaseWrapper
 from django.db.backends.utils import CursorWrapper


### PR DESCRIPTION
Switching because reorder-python-imports is incompatible with Black 24: https://github.com/asottile/reorder-python-imports/issues/366 .