### PR TITLE
Lazily import django.test to reduce import time

### DIFF
--- a/src/django_mysql/models/query.py
+++ b/src/django_mysql/models/query.py
@@ -23,7 +23,6 @@ from django.db import connections
 from django.db import models
 from django.db.models.sql.where import ExtraWhere
 from django.db.transaction import atomic
-from django.test.utils import CaptureQueriesContext
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 
@@ -722,6 +721,9 @@ def can_approx_count(queryset: QuerySetMixin) -> bool:
 
 
 def pt_visual_explain(queryset: models.QuerySet, display: bool = True) -> str:
+    # Lazily imported to reduce startup time - most invocations of manage.py wouldn't otherwise import django.test
+    from django.test.utils import CaptureQueriesContext
+
     connection = connections[queryset.db]
     capturer = CaptureQueriesContext(connection)
     with capturer, connection.cursor() as cursor:

--- a/src/django_mysql/models/query.py
+++ b/src/django_mysql/models/query.py
@@ -721,7 +721,7 @@ def can_approx_count(queryset: QuerySetMixin) -> bool:
 
 
 def pt_visual_explain(queryset: models.QuerySet, display: bool = True) -> str:
-    # Lazily imported to reduce startup time - most invocations of manage.py wouldn't otherwise import django.test
+    # Lazy import improves start time - manage.py wouldn't normally import django.test
     from django.test.utils import CaptureQueriesContext
 
     connection = connections[queryset.db]


### PR DESCRIPTION
I was running a flamegraph on our manage.py, and noticed this import of `django.test` using 20-40ms. Seems like an easy win for startup time to make it a lazy import, because most production code wouldn't normally ever need the `django.test` module.