### PR TITLE
Update tested database versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,10 +27,11 @@ jobs:
         - '3.13'
         database:
         - mysql:8.0
+        - mysql:9.0
         - mariadb:10.5
         - mariadb:10.6
-        - mariadb:10.7
-        - mariadb:10.8
+        - mariadb:10.11
+        - mariadb:11.4
 
     services:
       database:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,11 +8,7 @@ Python 3.8 to 3.13 supported.
 
 Django 3.2 to 5.1 supported.
 
-MySQL 8.0 supported.
-
-MariaDB 10.5 to 10.8 supported.
-
-mysqclient 1.3 to 1.4 supported.
+Tested on MySQL 8.0+ and MariaDB 10.5+.
 
 Installation
 ------------


### PR DESCRIPTION
Checked on endoflife.date tables: [MariaDB](https://endoflife.date/mariadb), [MySQL](https://endoflife.date/mysql).