### PR TITLE
Update tested database versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,12 +28,13 @@ jobs:
         - '3.13'
         - '3.14'
         database:
-        - mysql:8.0
-        - mysql:9.0
-        - mariadb:10.5
-        - mariadb:10.6
-        - mariadb:10.11
+        - mysql:9.4
+        - mysql:8.4
+        - mariadb:12.0
+        - mariadb:11.8
         - mariadb:11.4
+        - mariadb:10.11
+        - mariadb:10.6
 
     services:
       database:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,18 @@ Unreleased
 
 * Support Python 3.14.
 
+* Add testing for new database versions:
+
+  * MariaDB 12.0, 11.8
+  * MySQL 8.4 and 9.4.
+
+  Drop testing for EOL versions:
+
+  * MariaDB 10.5
+  * MySQL 8.0 and 9.0
+
+  No changes were needed.
+
 4.17.0 (2025-05-13)
 -------------------
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,7 +8,7 @@ Python 3.9 to 3.14 supported.
 
 Django 4.2 to 5.2 supported.
 
-Tested on MySQL 8.0+ and MariaDB 10.5+.
+Tested on MySQL 8.4+ and MariaDB 10.6+.
 
 Installation
 ------------


### PR DESCRIPTION
Checked on endoflife.date tables:
[MariaDB](https://endoflife.date/mariadb),
[MySQL](https://endoflife.date/mysql).