### PR TITLE
Fix query-rewriting for Django 6.1

### DIFF
--- a/src/django_mysql/rewrite_query.py
+++ b/src/django_mysql/rewrite_query.py
@@ -171,7 +171,7 @@ def modify_sql(
 table_spec_re_template = r"""
     \b(?P<operator>FROM|JOIN)
     \s+
-    (?P<table_name_with_alias>{table_name}(\s+[A-Z]+[0-9]+)?)
+    (?P<table_name_with_alias>{table_name}(\s+(`[^`]+`|[A-Z]+[0-9]+))?)
     \s+
 """
 


### PR DESCRIPTION
Missed in #1197. Django now always quotes table identifiers, so we need to support this syntax.