### PR TITLE
Drop testing for MariaDB 10.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,6 @@ jobs:
         - mariadb:11.8
         - mariadb:11.4
         - mariadb:10.11
-        - mariadb:10.6
 
     services:
       database:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,8 @@ Unreleased
 
 * Drop Python 3.9 support.
 
+* Drop testing for near-EOL MariaDB 10.6.
+
 4.19.0 (2025-09-18)
 -------------------
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,7 +8,7 @@ Python 3.10 to 3.14 supported.
 
 Django 5.2 to 6.1 supported.
 
-Tested on MySQL 8.4+ and MariaDB 10.6+.
+Tested on MySQL 8.4+ and MariaDB 10.11+.
 
 Installation
 ------------


### PR DESCRIPTION
Per [endoflife.date page](https://endoflife.date/mariadb), it’s nearly EOL (2026-07-06), and Django 6.1 does not support it (tests failing since #1197 with `django.db.utils.NotSupportedError: MariaDB 10.11 or later is required (found 10.6.27).`).